### PR TITLE
feat(responses): round-trip reasoning and enrich request/response mapping

### DIFF
--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -37,10 +37,18 @@ async fn forward(
     route: Route,
     body: Vec<u8>,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
-    let client_wants_stream = serde_json::from_slice::<Value>(&body)
-        .ok()
+    let request_json = serde_json::from_slice::<Value>(&body).ok();
+    let client_wants_stream = request_json
+        .as_ref()
         .and_then(|value| value.get("stream").and_then(Value::as_bool))
         .unwrap_or(false);
+    // Gates reasoning round-tripping (see model/responses.rs): surface thinking
+    // blocks only when the client asked for extended thinking, since that is what
+    // makes Claude Code echo them back on the next turn.
+    let thinking_enabled = request_json
+        .as_ref()
+        .and_then(|value| value.pointer("/thinking/type").and_then(Value::as_str))
+        == Some("enabled");
     let upstream_body =
         translate_request(&body, &route).map_err(|error| own_error(error.to_string()))?;
     tracing::debug!(
@@ -60,16 +68,26 @@ async fn forward(
         return Err(mapped_upstream_error(status, upstream, &route.provider).await);
     }
     if client_wants_stream {
-        Ok((StatusCode::OK, stream_response(upstream, route.model)))
+        Ok((
+            StatusCode::OK,
+            stream_response(upstream, route.model, thinking_enabled),
+        ))
     } else {
-        Ok((StatusCode::OK, json_response(upstream, route.model).await?))
+        Ok((
+            StatusCode::OK,
+            json_response(upstream, route.model, thinking_enabled).await?,
+        ))
     }
 }
 
-fn stream_response(upstream: reqwest::Response, model: String) -> axum::response::Response {
+fn stream_response(
+    upstream: reqwest::Response,
+    model: String,
+    thinking_enabled: bool,
+) -> axum::response::Response {
     let bytes = upstream.bytes_stream();
     let parser = SseParser::default();
-    let machine = AnthropicSseMachine::new(model);
+    let machine = AnthropicSseMachine::new(model, thinking_enabled);
     let output = stream::unfold((bytes, parser, machine, false), |state| async move {
         let (mut bytes, mut parser, mut machine, mut finished) = state;
         if finished {
@@ -114,12 +132,13 @@ fn stream_response(upstream: reqwest::Response, model: String) -> axum::response
 async fn json_response(
     upstream: reqwest::Response,
     model: String,
+    thinking_enabled: bool,
 ) -> Result<axum::response::Response, AdapterError> {
     let body = upstream
         .text()
         .await
         .map_err(|error| own_error(error.to_string()))?;
-    let mut machine = AnthropicSseMachine::new(model);
+    let mut machine = AnthropicSseMachine::new(model, thinking_enabled);
     for event in parse_sse_events(&body) {
         let _ = machine.apply(event);
     }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -275,10 +275,15 @@ impl AnthropicSseMachine {
             out.extend(self.open_reasoning());
         }
         if !encrypted.is_empty() {
+            // Prefer the id captured at output_item.added; fall back to the id on
+            // this done event so the round-trip keeps a real reasoning-item id even
+            // if the added event was missed or carried none.
             let id = self
                 .reasoning
                 .as_ref()
                 .map(|reasoning| reasoning.id.clone())
+                .filter(|id| !id.is_empty())
+                .or_else(|| item.get("id").and_then(Value::as_str).map(str::to_string))
                 .unwrap_or_default();
             let signature = encode_reasoning_signature(&id, encrypted);
             if let Some(reasoning) = &mut self.reasoning {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
 use serde_json::{json, Value};
 
-pub use crate::model::responses_request::translate_request;
+pub use crate::model::responses_request::{encode_reasoning_signature, translate_request};
 
 #[derive(Debug, Clone)]
 pub struct ResponseEvent {
@@ -19,6 +19,7 @@ struct OpenBlock {
 enum BlockKind {
     Text,
     Tool,
+    Reasoning,
 }
 
 #[derive(Debug, Clone)]
@@ -30,12 +31,14 @@ pub struct AnthropicSseMachine {
     index: usize,
     open: Option<OpenBlock>,
     saw_tool: bool,
+    thinking_enabled: bool,
     input_tokens: u64,
     cache_read_tokens: u64,
     output_tokens: u64,
     content: Vec<Value>,
     text_buffer: String,
     tool_buffer: Option<ToolBuffer>,
+    reasoning: Option<ReasoningBuffer>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,8 +48,19 @@ struct ToolBuffer {
     json: String,
 }
 
+/// Accumulates a Responses `reasoning` output item so it can be surfaced as an
+/// Anthropic thinking block. `signature` packs the item's id + encrypted_content
+/// (set at `output_item.done`) so the next turn can round-trip it (see
+/// [`encode_reasoning_signature`]).
+#[derive(Debug, Clone)]
+struct ReasoningBuffer {
+    id: String,
+    summary: String,
+    signature: Option<String>,
+}
+
 impl AnthropicSseMachine {
-    pub fn new(model: impl Into<String>) -> Self {
+    pub fn new(model: impl Into<String>, thinking_enabled: bool) -> Self {
         Self {
             id: "msg_responses".to_string(),
             model: model.into(),
@@ -55,12 +69,14 @@ impl AnthropicSseMachine {
             index: 0,
             open: None,
             saw_tool: false,
+            thinking_enabled,
             input_tokens: 0,
             cache_read_tokens: 0,
             output_tokens: 0,
             content: Vec::new(),
             text_buffer: String::new(),
             tool_buffer: None,
+            reasoning: None,
         }
     }
 
@@ -76,10 +92,10 @@ impl AnthropicSseMachine {
             "response.output_text.done" | "response.content_part.done" => {
                 self.close_current(BlockKind::Text)
             }
+            "response.reasoning_summary_text.delta" => self.reasoning_delta(&event.data),
             "response.function_call_arguments.delta" => self.arguments_delta(&event.data),
-            "response.function_call_arguments.done" | "response.output_item.done" => {
-                self.close_current(BlockKind::Tool)
-            }
+            "response.function_call_arguments.done" => self.close_current(BlockKind::Tool),
+            "response.output_item.done" => self.output_item_done(&event.data),
             "response.completed" | "response.done" => self.complete(&event.data),
             "error" | "response.failed" => {
                 self.stopped = true;
@@ -153,8 +169,132 @@ impl AnthropicSseMachine {
         match item.get("type").and_then(Value::as_str) {
             Some("message") => self.open_text(),
             Some("function_call") => self.open_tool(item),
+            Some("reasoning") => self.reasoning_added(item),
             _ => Vec::new(),
         }
+    }
+
+    /// `response.output_item.done` closes whichever item just finished. Reasoning
+    /// items need special handling (stamp the round-trip signature); function_call
+    /// and message items just close.
+    fn output_item_done(&mut self, data: &Value) -> Vec<String> {
+        let item = data.get("item").unwrap_or(data);
+        if item.get("type").and_then(Value::as_str) == Some("reasoning") {
+            return self.reasoning_done(item);
+        }
+        self.close_any()
+    }
+
+    /// Record the reasoning item's id; defer opening the thinking block until the
+    /// first summary delta (or `output_item.done` when there is encrypted content),
+    /// so a reasoning item with neither summary nor encrypted content emits nothing.
+    fn reasoning_added(&mut self, item: &Value) -> Vec<String> {
+        if !self.thinking_enabled {
+            return Vec::new();
+        }
+        let id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        self.reasoning = Some(ReasoningBuffer {
+            id,
+            summary: String::new(),
+            signature: None,
+        });
+        Vec::new()
+    }
+
+    fn open_reasoning(&mut self) -> Vec<String> {
+        let mut out = self.close_any();
+        if self.reasoning.is_none() {
+            self.reasoning = Some(ReasoningBuffer {
+                id: String::new(),
+                summary: String::new(),
+                signature: None,
+            });
+        }
+        self.open = Some(OpenBlock {
+            index: self.index,
+            kind: BlockKind::Reasoning,
+        });
+        out.push(sse(
+            "content_block_start",
+            &json!({
+                "type": "content_block_start",
+                "index": self.index,
+                "content_block": {"type": "thinking", "thinking": ""}
+            }),
+        ));
+        out
+    }
+
+    fn reasoning_delta(&mut self, data: &Value) -> Vec<String> {
+        if !self.thinking_enabled {
+            return Vec::new();
+        }
+        let delta = data.get("delta").and_then(Value::as_str).unwrap_or("");
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        if self.open.as_ref().map(|block| block.kind) != Some(BlockKind::Reasoning) {
+            out.extend(self.open_reasoning());
+        }
+        if let Some(reasoning) = &mut self.reasoning {
+            reasoning.summary.push_str(delta);
+        }
+        out.push(sse(
+            "content_block_delta",
+            &json!({
+                "type": "content_block_delta",
+                "index": self.open_index(),
+                "delta": {"type": "thinking_delta", "thinking": delta}
+            }),
+        ));
+        out
+    }
+
+    fn reasoning_done(&mut self, item: &Value) -> Vec<String> {
+        if !self.thinking_enabled {
+            return Vec::new();
+        }
+        let encrypted = item
+            .get("encrypted_content")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let is_open = self.open.as_ref().map(|block| block.kind) == Some(BlockKind::Reasoning);
+        // Nothing to show (no summary streamed) and nothing to round-trip.
+        if !is_open && encrypted.is_empty() {
+            self.reasoning = None;
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        if !is_open {
+            // Open an empty thinking block purely to carry the round-trip signature.
+            out.extend(self.open_reasoning());
+        }
+        if !encrypted.is_empty() {
+            let id = self
+                .reasoning
+                .as_ref()
+                .map(|reasoning| reasoning.id.clone())
+                .unwrap_or_default();
+            let signature = encode_reasoning_signature(&id, encrypted);
+            if let Some(reasoning) = &mut self.reasoning {
+                reasoning.signature = Some(signature.clone());
+            }
+            out.push(sse(
+                "content_block_delta",
+                &json!({
+                    "type": "content_block_delta",
+                    "index": self.open_index(),
+                    "delta": {"type": "signature_delta", "signature": signature}
+                }),
+            ));
+        }
+        out.extend(self.close_any());
+        out
     }
 
     fn open_text(&mut self) -> Vec<String> {
@@ -265,6 +405,15 @@ impl AnthropicSseMachine {
                         "name": tool.name,
                         "input": input
                     }));
+                }
+            }
+            BlockKind::Reasoning => {
+                if let Some(reasoning) = self.reasoning.take() {
+                    let mut block = json!({"type": "thinking", "thinking": reasoning.summary});
+                    if let Some(signature) = reasoning.signature {
+                        block["signature"] = json!(signature);
+                    }
+                    self.content.push(block);
                 }
             }
         }

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde_json::{json, Map, Value};
 
 use crate::routing::Route;
@@ -24,9 +25,78 @@ pub fn translate_request(body: &[u8], route: &Route) -> Result<Value, serde_json
         json!({"effort": effort(&request, route), "summary": "auto"}),
     );
     out.insert("text".to_string(), json!({"verbosity": "medium"}));
+    // With store:false the Responses backend forgets each turn's reasoning, so ask
+    // for the encrypted reasoning blob and echo it back next turn (see input_items).
+    // Only when the client enabled extended thinking, which is what lets Claude Code
+    // round-trip the thinking blocks that carry the blob (see model/responses.rs).
+    if thinking_enabled(&request) {
+        out.insert(
+            "include".to_string(),
+            json!(["reasoning.encrypted_content"]),
+        );
+    }
+    if let Some(cache_key) = prompt_cache_key(&request) {
+        out.insert("prompt_cache_key".to_string(), json!(cache_key));
+    }
+    // Anthropic `max_tokens` caps output; the Responses equivalent is
+    // `max_output_tokens`. Forward it so the client's cap is respected instead of
+    // falling back to the model default.
+    if let Some(max_tokens) = request.get("max_tokens").and_then(Value::as_u64) {
+        out.insert("max_output_tokens".to_string(), json!(max_tokens));
+    }
     out.insert("store".to_string(), json!(false));
     out.insert("stream".to_string(), json!(true));
     Ok(Value::Object(out))
+}
+
+/// A stable per-conversation key so the Responses backend routes every turn of a
+/// session to the same prompt cache (codex uses its thread_id here). Claude Code
+/// packs `{device_id, account_uuid, session_id}` as a JSON string in
+/// `metadata.user_id`; `session_id` is the per-conversation id. Falls back to a
+/// hash of the raw user_id, or nothing when the client sends no metadata.
+fn prompt_cache_key(request: &Value) -> Option<String> {
+    let user_id = request
+        .pointer("/metadata/user_id")
+        .and_then(Value::as_str)
+        .filter(|user_id| !user_id.is_empty())?;
+    if let Ok(parsed) = serde_json::from_str::<Value>(user_id) {
+        if let Some(session) = parsed
+            .get("session_id")
+            .and_then(Value::as_str)
+            .filter(|session| !session.is_empty())
+        {
+            return Some(format!("shunt-{session}"));
+        }
+    }
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(user_id, &mut hasher);
+    Some(format!("shunt-{:016x}", std::hash::Hasher::finish(&hasher)))
+}
+
+/// Whether the client requested extended thinking. Gates reasoning round-tripping:
+/// Claude Code only echoes assistant thinking blocks back when thinking is enabled.
+fn thinking_enabled(request: &Value) -> bool {
+    request.pointer("/thinking/type").and_then(Value::as_str) == Some("enabled")
+}
+
+/// Pack a Responses reasoning item's id + encrypted_content into the opaque
+/// `signature` of an Anthropic thinking block. Claude Code round-trips signatures
+/// verbatim, so the next turn can [`decode_reasoning_signature`] it back into a
+/// Responses `reasoning` input item — preserving chain-of-thought under store:false.
+pub fn encode_reasoning_signature(id: &str, encrypted_content: &str) -> String {
+    let payload = json!({"id": id, "enc": encrypted_content});
+    URL_SAFE_NO_PAD.encode(payload.to_string())
+}
+
+/// Inverse of [`encode_reasoning_signature`]. Returns `None` for signatures shunt
+/// did not produce (e.g. a genuine Anthropic thinking signature), which are dropped
+/// rather than forwarded — the Responses backend rejects reasoning it never issued.
+fn decode_reasoning_signature(signature: &str) -> Option<(String, String)> {
+    let bytes = URL_SAFE_NO_PAD.decode(signature).ok()?;
+    let value: Value = serde_json::from_slice(&bytes).ok()?;
+    let id = value.get("id").and_then(Value::as_str)?.to_string();
+    let enc = value.get("enc").and_then(Value::as_str)?.to_string();
+    Some((id, enc))
 }
 
 fn instructions(request: &Value) -> Option<String> {
@@ -63,8 +133,13 @@ fn input_items(request: &Value) -> Vec<Value> {
             match block.get("type").and_then(Value::as_str) {
                 Some("text") => text_part(role, &block, &mut pending),
                 Some("image") => image_part(&block, &mut pending),
+                Some("document") => document_part(&block, &mut pending),
                 Some("tool_use") => tool_use_item(&mut out, role, &mut pending, &block),
                 Some("tool_result") => tool_result_item(&mut out, role, &mut pending, &block),
+                Some("thinking") => reasoning_item(&mut out, role, &mut pending, &block),
+                Some("redacted_thinking") => {
+                    redacted_reasoning_item(&mut out, role, &mut pending, &block)
+                }
                 _ => {}
             }
         }
@@ -125,17 +200,47 @@ fn text_part(role: &str, block: &Value, pending: &mut Vec<Value>) {
 }
 
 fn image_part(block: &Value, pending: &mut Vec<Value>) {
-    if let Some(source) = block.get("source") {
-        let media_type = source
-            .get("media_type")
-            .and_then(Value::as_str)
-            .unwrap_or("image/png");
-        let data = source.get("data").and_then(Value::as_str).unwrap_or("");
-        pending.push(json!({
-            "type": "input_image",
-            "image_url": format!("data:{media_type};base64,{data}")
-        }));
+    if let Some(item) = image_content_item(block) {
+        pending.push(item);
     }
+}
+
+fn document_part(block: &Value, pending: &mut Vec<Value>) {
+    if let Some(item) = file_content_item(block) {
+        pending.push(item);
+    }
+}
+
+/// Anthropic `image` block -> Responses `input_image` (base64 data URL).
+fn image_content_item(block: &Value) -> Option<Value> {
+    let source = block.get("source")?;
+    let media_type = source
+        .get("media_type")
+        .and_then(Value::as_str)
+        .unwrap_or("image/png");
+    let data = source.get("data").and_then(Value::as_str).unwrap_or("");
+    Some(json!({
+        "type": "input_image",
+        "image_url": format!("data:{media_type};base64,{data}")
+    }))
+}
+
+/// Anthropic `document` block (e.g. a PDF) -> Responses `input_file`.
+fn file_content_item(block: &Value) -> Option<Value> {
+    let source = block.get("source")?;
+    let media_type = source
+        .get("media_type")
+        .and_then(Value::as_str)
+        .unwrap_or("application/pdf");
+    let data = source.get("data").and_then(Value::as_str).unwrap_or("");
+    let mut item = json!({
+        "type": "input_file",
+        "file_data": format!("data:{media_type};base64,{data}")
+    });
+    if let Some(filename) = block.get("title").and_then(Value::as_str) {
+        item["filename"] = json!(filename);
+    }
+    Some(item)
 }
 
 fn tool_use_item(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>, block: &Value) {
@@ -157,6 +262,57 @@ fn tool_result_item(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>, 
     }));
 }
 
+/// An assistant `thinking` block carries a Responses reasoning item's state in its
+/// signature (stamped by shunt on the way out). Decode it back into a `reasoning`
+/// input item so the backend keeps its chain-of-thought under store:false. Blocks
+/// whose signature shunt did not produce are dropped — never forwarded.
+fn reasoning_item(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>, block: &Value) {
+    let Some(signature) = block.get("signature").and_then(Value::as_str) else {
+        return;
+    };
+    let Some((id, encrypted_content)) = decode_reasoning_signature(signature) else {
+        return;
+    };
+    flush_message(out, role, pending);
+    let summary = block.get("thinking").and_then(Value::as_str).unwrap_or("");
+    out.push(reasoning_input_item(&id, &encrypted_content, summary));
+}
+
+/// A `redacted_thinking` block is the opaque fallback vehicle for the same reasoning
+/// state, carried in `data` instead of a signature.
+fn redacted_reasoning_item(
+    out: &mut Vec<Value>,
+    role: &str,
+    pending: &mut Vec<Value>,
+    block: &Value,
+) {
+    let Some(data) = block.get("data").and_then(Value::as_str) else {
+        return;
+    };
+    let Some((id, encrypted_content)) = decode_reasoning_signature(data) else {
+        return;
+    };
+    flush_message(out, role, pending);
+    out.push(reasoning_input_item(&id, &encrypted_content, ""));
+}
+
+fn reasoning_input_item(id: &str, encrypted_content: &str, summary: &str) -> Value {
+    let summary = if summary.is_empty() {
+        json!([])
+    } else {
+        json!([{"type": "summary_text", "text": summary}])
+    };
+    let mut item = json!({
+        "type": "reasoning",
+        "summary": summary,
+        "encrypted_content": encrypted_content,
+    });
+    if !id.is_empty() {
+        item["id"] = json!(id);
+    }
+    item
+}
+
 fn content_blocks(content: Option<&Value>) -> Vec<Value> {
     match content {
         Some(Value::String(text)) => vec![json!({"type": "text", "text": text})],
@@ -173,26 +329,49 @@ fn flush_message(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>) {
     pending.clear();
 }
 
-fn tool_result_output(block: &Value) -> String {
+/// The `output` of a `function_call_output`. Text-only results collapse to a plain
+/// string (what most tools return); results carrying an image or document are sent
+/// as the Responses content-item array (text/image/file) so they are not dropped.
+fn tool_result_output(block: &Value) -> Value {
+    let is_error = block.get("is_error").and_then(Value::as_bool) == Some(true);
     match block.get("content") {
-        Some(Value::String(text)) => text.clone(),
+        Some(Value::String(text)) => json!(text),
         Some(Value::Array(blocks)) => {
+            let has_rich = blocks.iter().any(|inner| {
+                matches!(
+                    inner.get("type").and_then(Value::as_str),
+                    Some("image") | Some("document")
+                )
+            });
+            if has_rich {
+                let items = blocks
+                    .iter()
+                    .filter_map(|inner| match inner.get("type").and_then(Value::as_str) {
+                        Some("text") => inner
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .map(|text| json!({"type": "input_text", "text": text})),
+                        Some("image") => image_content_item(inner),
+                        Some("document") => file_content_item(inner),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                return Value::Array(items);
+            }
             let text = blocks
                 .iter()
-                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
-                .filter_map(|block| block.get("text").and_then(Value::as_str))
+                .filter(|inner| inner.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|inner| inner.get("text").and_then(Value::as_str))
                 .collect::<Vec<_>>()
                 .join("\n");
-            if text.is_empty() && block.get("is_error").and_then(Value::as_bool) == Some(true) {
-                "Tool execution failed".to_string()
+            if text.is_empty() && is_error {
+                json!("Tool execution failed")
             } else {
-                text
+                json!(text)
             }
         }
-        _ if block.get("is_error").and_then(Value::as_bool) == Some(true) => {
-            "Tool execution failed".to_string()
-        }
-        _ => String::new(),
+        _ if is_error => json!("Tool execution failed"),
+        _ => json!(""),
     }
 }
 

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -211,36 +211,60 @@ fn document_part(block: &Value, pending: &mut Vec<Value>) {
     }
 }
 
-/// Anthropic `image` block -> Responses `input_image` (base64 data URL).
+/// Anthropic `image` block -> Responses `input_image`. `image_url` accepts both
+/// a passthrough URL and a base64 `data:` URI, so both source shapes map to it.
 fn image_content_item(block: &Value) -> Option<Value> {
-    let source = block.get("source")?;
-    let media_type = source
-        .get("media_type")
-        .and_then(Value::as_str)
-        .unwrap_or("image/png");
-    let data = source.get("data").and_then(Value::as_str).unwrap_or("");
-    Some(json!({
-        "type": "input_image",
-        "image_url": format!("data:{media_type};base64,{data}")
-    }))
+    let image_url = source_url(block.get("source")?, "image/png")?;
+    Some(json!({"type": "input_image", "image_url": image_url}))
 }
 
-/// Anthropic `document` block (e.g. a PDF) -> Responses `input_file`.
+/// Anthropic `document` block (e.g. a PDF) -> Responses `input_file`. Unlike
+/// images, `input_file` splits by key: `file_url` for a URL source, `file_data`
+/// for base64. Source shapes shunt can't represent are dropped (return None)
+/// rather than forwarded as an empty, invalid `data:` URI.
 fn file_content_item(block: &Value) -> Option<Value> {
     let source = block.get("source")?;
-    let media_type = source
-        .get("media_type")
-        .and_then(Value::as_str)
-        .unwrap_or("application/pdf");
-    let data = source.get("data").and_then(Value::as_str).unwrap_or("");
-    let mut item = json!({
-        "type": "input_file",
-        "file_data": format!("data:{media_type};base64,{data}")
-    });
+    let mut item = match source.get("type").and_then(Value::as_str) {
+        Some("url") => {
+            let url = source.get("url").and_then(Value::as_str)?;
+            json!({"type": "input_file", "file_url": url})
+        }
+        Some("base64") | None => {
+            let data = source.get("data").and_then(Value::as_str)?;
+            let media_type = source
+                .get("media_type")
+                .and_then(Value::as_str)
+                .unwrap_or("application/pdf");
+            json!({"type": "input_file", "file_data": format!("data:{media_type};base64,{data}")})
+        }
+        _ => return None,
+    };
     if let Some(filename) = block.get("title").and_then(Value::as_str) {
         item["filename"] = json!(filename);
     }
     Some(item)
+}
+
+/// Resolve an Anthropic block `source` to a URL string: a passthrough `url`
+/// source, or a base64 `data:` URI. Returns None for a base64 source missing its
+/// data, or any source shape shunt can't represent — the caller drops the block
+/// rather than emitting a malformed empty `data:` URI.
+fn source_url(source: &Value, default_media_type: &str) -> Option<String> {
+    match source.get("type").and_then(Value::as_str) {
+        Some("url") => source
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        Some("base64") | None => {
+            let data = source.get("data").and_then(Value::as_str)?;
+            let media_type = source
+                .get("media_type")
+                .and_then(Value::as_str)
+                .unwrap_or(default_media_type);
+            Some(format!("data:{media_type};base64,{data}"))
+        }
+        _ => None,
+    }
 }
 
 fn tool_use_item(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>, block: &Value) {
@@ -344,7 +368,7 @@ fn tool_result_output(block: &Value) -> Value {
                 )
             });
             if has_rich {
-                let items = blocks
+                let mut items = blocks
                     .iter()
                     .filter_map(|inner| match inner.get("type").and_then(Value::as_str) {
                         Some("text") => inner
@@ -356,6 +380,22 @@ fn tool_result_output(block: &Value) -> Value {
                         _ => None,
                     })
                     .collect::<Vec<_>>();
+                // Preserve the failure signal the text-only branch conveys: a
+                // failed result with no text would otherwise reach the model as
+                // media alone, with no indication it errored.
+                let has_text = items.iter().any(|item| {
+                    item.get("type").and_then(Value::as_str) == Some("input_text")
+                        && item
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .is_some_and(|text| !text.is_empty())
+                });
+                if is_error && !has_text {
+                    items.insert(
+                        0,
+                        json!({"type": "input_text", "text": "Tool execution failed"}),
+                    );
+                }
                 return Value::Array(items);
             }
             let text = blocks

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -44,6 +44,7 @@ fn translates_plain_text_request() {
             }],
             "reasoning": {"effort": "medium", "summary": "auto"},
             "text": {"verbosity": "medium"},
+            "max_output_tokens": 1000,
             "store": false,
             "stream": true
         })
@@ -203,7 +204,7 @@ fn streaming_state_machine_emits_incremental_anthropic_events() {
         "data: {\"response\":{\"usage\":{\"input_tokens\":1200,\"input_tokens_details\":{\"cached_tokens\":800},\"output_tokens\":9}}}\n\n",
         "data: [DONE]\n\n"
     );
-    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex");
+    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex", false);
     let emitted = parse_sse_events(fixture)
         .into_iter()
         .flat_map(|event| machine.apply(event))
@@ -292,4 +293,210 @@ fn event_names(sse: &str) -> Vec<String> {
                 .find_map(|line| line.strip_prefix("event: ").map(ToOwned::to_owned))
         })
         .collect()
+}
+
+#[test]
+fn includes_encrypted_reasoning_only_when_thinking_enabled() {
+    let with_thinking = translate(json!({
+        "thinking": {"type": "enabled"},
+        "messages": [{"role": "user", "content": "hi"}]
+    }));
+    assert_eq!(
+        with_thinking["include"],
+        json!(["reasoning.encrypted_content"])
+    );
+
+    let without = translate(json!({
+        "messages": [{"role": "user", "content": "hi"}]
+    }));
+    assert!(without.get("include").is_none());
+}
+
+/// End-to-end: a reasoning item streams out as a thinking block whose signature
+/// carries the encrypted state, and feeding that block back yields a Responses
+/// `reasoning` input item — preserving chain-of-thought under store:false.
+#[test]
+fn streams_reasoning_as_thinking_block_and_round_trips() {
+    let fixture = concat!(
+        "event: response.created\n",
+        "data: {\"response\":{\"id\":\"resp_1\"}}\n\n",
+        "event: response.output_item.added\n",
+        "data: {\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}\n\n",
+        "event: response.reasoning_summary_text.delta\n",
+        "data: {\"delta\":\"Let me\"}\n\n",
+        "event: response.reasoning_summary_text.delta\n",
+        "data: {\"delta\":\" think\"}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"ENC123\"}}\n\n",
+        "event: response.output_item.added\n",
+        "data: {\"item\":{\"type\":\"message\"}}\n\n",
+        "event: response.output_text.delta\n",
+        "data: {\"delta\":\"Hi\"}\n\n",
+        "event: response.output_text.done\n",
+        "data: {}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":2}}}\n\n",
+        "data: [DONE]\n\n"
+    );
+
+    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex", true);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+    let mut finished = machine.finish().join("");
+    finished.insert_str(0, &emitted);
+    let emitted = finished;
+
+    // A thinking block leads the message, streams summary text, then a signature.
+    let names = event_names(&emitted);
+    assert_eq!(names.first().map(String::as_str), Some("message_start"));
+    assert!(emitted.contains("\"type\":\"thinking\""));
+    assert!(emitted.contains("\"thinking_delta\""));
+    assert!(emitted.contains("\"signature_delta\""));
+
+    let expected_signature = shunt::model::responses::encode_reasoning_signature("rs_1", "ENC123");
+    assert!(emitted.contains(&expected_signature));
+
+    // Feed the thinking block back: it must become a reasoning input item.
+    let out = translate(json!({
+        "thinking": {"type": "enabled"},
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "Let me think", "signature": expected_signature},
+                {"type": "text", "text": "Hi"}
+            ]}
+        ]
+    }));
+    let input = out["input"].as_array().unwrap();
+    let reasoning = input
+        .iter()
+        .find(|item| item["type"] == "reasoning")
+        .expect("reasoning input item present");
+    assert_eq!(reasoning["id"], "rs_1");
+    assert_eq!(reasoning["encrypted_content"], "ENC123");
+    // Reasoning must precede the assistant message it reasoned about.
+    let reasoning_pos = input.iter().position(|i| i["type"] == "reasoning").unwrap();
+    let message_pos = input
+        .iter()
+        .position(|i| i["type"] == "message" && i["role"] == "assistant")
+        .unwrap();
+    assert!(reasoning_pos < message_pos);
+}
+
+#[test]
+fn drops_foreign_thinking_signature() {
+    // A signature shunt did not produce (e.g. a genuine Anthropic one) is dropped,
+    // never forwarded as a bogus reasoning item the backend would reject.
+    let out = translate(json!({
+        "thinking": {"type": "enabled"},
+        "messages": [
+            {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "x", "signature": "not-a-shunt-signature"},
+                {"type": "text", "text": "Hi"}
+            ]}
+        ]
+    }));
+    let input = out["input"].as_array().unwrap();
+    assert!(input.iter().all(|item| item["type"] != "reasoning"));
+}
+
+#[test]
+fn ignores_reasoning_when_thinking_disabled() {
+    let fixture = concat!(
+        "event: response.output_item.added\n",
+        "data: {\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\"}}\n\n",
+        "event: response.reasoning_summary_text.delta\n",
+        "data: {\"delta\":\"secret\"}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"item\":{\"type\":\"reasoning\",\"id\":\"rs_1\",\"encrypted_content\":\"ENC\"}}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+    );
+    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex", false);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+    assert!(!emitted.contains("thinking"));
+    assert!(!emitted.contains("signature"));
+}
+
+#[test]
+fn derives_prompt_cache_key_from_session_id() {
+    // Claude Code packs a JSON blob into metadata.user_id; session_id is the
+    // stable per-conversation key the Responses cache should be routed by.
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {"user_id": "{\"device_id\":\"d1\",\"session_id\":\"sess_abc\"}"}
+    }));
+    assert_eq!(out["prompt_cache_key"], "shunt-sess_abc");
+
+    // No metadata -> no key sent.
+    let bare = translate(json!({"messages": [{"role": "user", "content": "hi"}]}));
+    assert!(bare.get("prompt_cache_key").is_none());
+
+    // A non-JSON user_id still yields a stable (hashed) key.
+    let hashed = translate(json!({
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {"user_id": "plain-user"}
+    }));
+    let key = hashed["prompt_cache_key"].as_str().unwrap();
+    assert!(key.starts_with("shunt-"));
+    // Determinism: same input -> same key.
+    let again = translate(json!({
+        "messages": [{"role": "user", "content": "different"}],
+        "metadata": {"user_id": "plain-user"}
+    }));
+    assert_eq!(hashed["prompt_cache_key"], again["prompt_cache_key"]);
+}
+
+#[test]
+fn tool_result_with_image_becomes_content_array() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+                {"type": "text", "text": "see screenshot"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "IMG"}}
+            ]}
+        ]}]
+    }));
+    let output = &out["input"][0]["output"];
+    assert_eq!(
+        *output,
+        json!([
+            {"type": "input_text", "text": "see screenshot"},
+            {"type": "input_image", "image_url": "data:image/png;base64,IMG"}
+        ])
+    );
+}
+
+#[test]
+fn text_only_tool_result_stays_a_string() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+                {"type": "text", "text": "ok"}
+            ]}
+        ]}]
+    }));
+    assert_eq!(out["input"][0]["output"], json!("ok"));
+}
+
+#[test]
+fn document_block_becomes_input_file() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": "read this"},
+            {"type": "document", "title": "spec.pdf", "source": {"type": "base64", "media_type": "application/pdf", "data": "PDF"}}
+        ]}]
+    }));
+    assert_eq!(
+        out["input"][0]["content"],
+        json!([
+            {"type": "input_text", "text": "read this"},
+            {"type": "input_file", "file_data": "data:application/pdf;base64,PDF", "filename": "spec.pdf"}
+        ])
+    );
 }

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -500,3 +500,107 @@ fn document_block_becomes_input_file() {
         ])
     );
 }
+
+#[test]
+fn url_sourced_document_uses_file_url_not_empty_data() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "document", "source": {"type": "url", "url": "https://example.com/spec.pdf"}}
+        ]}]
+    }));
+    assert_eq!(
+        out["input"][0]["content"][0],
+        json!({"type": "input_file", "file_url": "https://example.com/spec.pdf"})
+    );
+}
+
+#[test]
+fn url_sourced_image_passes_url_through() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "image", "source": {"type": "url", "url": "https://example.com/x.png"}}
+        ]}]
+    }));
+    assert_eq!(
+        out["input"][0]["content"][0],
+        json!({"type": "input_image", "image_url": "https://example.com/x.png"})
+    );
+}
+
+#[test]
+fn unrepresentable_document_source_is_dropped_not_emptied() {
+    // A source shunt can't represent must not become an empty "data:...;base64," URI.
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": "read"},
+            {"type": "document", "source": {"type": "file", "file_id": "file_123"}}
+        ]}]
+    }));
+    // Only the text survives; the unrepresentable document is dropped.
+    assert_eq!(
+        out["input"][0]["content"],
+        json!([{"type": "input_text", "text": "read"}])
+    );
+}
+
+#[test]
+fn errored_tool_result_with_image_keeps_failure_signal() {
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "is_error": true, "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "IMG"}}
+            ]}
+        ]}]
+    }));
+    assert_eq!(
+        out["input"][0]["output"],
+        json!([
+            {"type": "input_text", "text": "Tool execution failed"},
+            {"type": "input_image", "image_url": "data:image/png;base64,IMG"}
+        ])
+    );
+}
+
+#[test]
+fn errored_tool_result_with_text_and_image_keeps_text_only() {
+    // When the tool provided its own error text, don't inject a duplicate marker.
+    let out = translate(json!({
+        "messages": [{"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "is_error": true, "content": [
+                {"type": "text", "text": "boom: file missing"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "IMG"}}
+            ]}
+        ]}]
+    }));
+    assert_eq!(
+        out["input"][0]["output"],
+        json!([
+            {"type": "input_text", "text": "boom: file missing"},
+            {"type": "input_image", "image_url": "data:image/png;base64,IMG"}
+        ])
+    );
+}
+
+#[test]
+fn reasoning_id_falls_back_to_done_event_when_added_missing() {
+    // No output_item.added for the reasoning item (so the buffer id is empty);
+    // the id must be recovered from the output_item.done event's item.
+    let fixture = concat!(
+        "event: response.reasoning_summary_text.delta\n",
+        "data: {\"delta\":\"think\"}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"item\":{\"type\":\"reasoning\",\"id\":\"rs_done\",\"encrypted_content\":\"ENC\"}}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+    );
+    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex", true);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+    let expected = shunt::model::responses::encode_reasoning_signature("rs_done", "ENC");
+    assert!(
+        emitted.contains(&expected),
+        "signature should encode the id from the done event"
+    );
+}


### PR DESCRIPTION
## Summary

Extends shunt's OpenAI Responses adapter (the openai/codex path that translates Anthropic Messages <-> OpenAI Responses) with four related improvements. All are gated/scoped so non-thinking, non-OpenAI traffic is unchanged.

1. **Reasoning round-trip (store:false)** — surfaces OpenAI reasoning as Anthropic `thinking` blocks and preserves chain-of-thought across tool-call turns. Packs the Responses reasoning item's `{id, encrypted_content}` into the thinking block's `signature` (base64url), which Claude Code round-trips verbatim; the next turn decodes it back into a Responses `reasoning` input item. Requests add `include:["reasoning.encrypted_content"]`. All gated on the client having extended thinking enabled (`thinking.type == "enabled"`). Signatures shunt did not mint (e.g. genuine Anthropic ones) are dropped, never forwarded.
2. **prompt_cache_key** — derives a stable per-conversation key from Claude Code's `metadata.user_id.session_id` (falls back to a hash) so the Responses backend routes each turn to the same prompt cache.
3. **max_tokens -> max_output_tokens** — forwards the client's output cap instead of falling back to the model default.
4. **tool_result images + document blocks** — tool results carrying images (and PDF `document` blocks) now map to the Responses content-item array (`input_text`/`input_image`/`input_file`) instead of being dropped to text-only.

## Milestone / spec

M1 — docs/m1-responses-translation.md (Responses translation adapter)

## Changes

- `src/model/responses_request.rs` — request translation (include, prompt_cache_key, max_output_tokens, reasoning echo decode, image/document/rich tool_result)
- `src/model/responses.rs` — SSE machine: reasoning -> thinking block + signature
- `src/adapters/responses.rs` — thread thinking_enabled through
- `tests/responses_translate.rs` — 11 new tests

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — full suite green, 54 tests total (11 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it
- [ ] Any new GitHub Action is pinned to a full commit SHA (n/a — no workflow changes)

## Notes for reviewers

- Reasoning round-trip is the highest-risk piece: verify the signature packing/decoding (`src/model/responses.rs`, `src/model/responses_request.rs`) handles malformed/foreign signatures safely (dropped, never forwarded) and that the whole reasoning path stays fully gated on `thinking.type == "enabled"`.
- Verified end-to-end through the running gateway against a mock Responses upstream: reasoning round-trip, prompt_cache_key, max_output_tokens, tool_result image, document, and the thinking-disabled / foreign-signature negative paths were all exercised manually in addition to the automated test suite.

## Test Plan

- [x] Full test suite (54 tests) passes
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] Manual end-to-end verification against a mock Responses upstream: reasoning round-trip, prompt_cache_key routing, max_output_tokens forwarding, tool_result image mapping, document mapping, thinking-disabled negative path, foreign-signature negative path
