### PR TITLE
feat: add GET /health healthcheck and GET / landing endpoints

### DIFF
--- a/.claude/agent-memory/review-review-security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-security-reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [Unauth endpoints invariant](project_unauth-endpoints-invariant.md) — GET / and GET /health bypass auth by design; must expose only status + crate version.

--- a/.claude/agent-memory/review-review-security-reviewer/project_unauth-endpoints-invariant.md
+++ b/.claude/agent-memory/review-review-security-reviewer/project_unauth-endpoints-invariant.md
@@ -1,0 +1,12 @@
+---
+name: unauth-endpoints-invariant
+description: shunt's GET / and GET /health are intentionally unauthenticated; invariant is they expose only status + crate version
+metadata:
+  type: project
+---
+
+`src/server.rs` `build_router` mounts `GET /` (`root_index`) and `GET /health` (`health`) BEFORE the protected `/v1/*` routes. Inbound `[server.auth]` is enforced inside the proxy/discovery handlers, not middleware, so `/` and `/health` bypass auth BY DESIGN.
+
+**Why:** healthcheck/liveness tools usually cannot attach tokens.
+
+**How to apply:** the documented invariant (docs/running.md) is these routes must expose nothing beyond status and crate version. When reviewing changes here, verify both handlers stay fully static — they build responses only from string literals + `env!("CARGO_PKG_VERSION")` (compile-time constant), with zero request input, config, or secrets interpolated. Flag only if a change starts leaking config/credentials/upstream details or reflects request input. The auth exemption itself is not a finding.

--- a/docs/running.md
+++ b/docs/running.md
@@ -182,9 +182,14 @@ e.g. `RUST_LOG=shunt=debug cargo run -- run`.
 | Method | Path                          | Purpose                                             |
 | :----- | :---------------------------- | :-------------------------------------------------- |
 | `HEAD` | `/`                           | Liveness probe                                      |
+| `GET`  | `/`                           | Human-readable landing (version + endpoint list)    |
+| `GET`  | `/health`                     | Healthcheck — `{"status":"ok","version":"x.y.z"}`   |
 | `GET`  | `/v1/models`                  | Model discovery (returns your `[[models]]` entries) |
 | `POST` | `/v1/messages`                | Inference — routed per the request's `model` id     |
 | `POST` | `/v1/messages/count_tokens`   | Token counting (see below)                          |
+
+`GET /` and `GET /health` stay open even when `[server.auth]` is enabled (healthcheck tools
+usually cannot attach tokens) and expose nothing beyond status and version.
 
 **`count_tokens`:** for an **Anthropic-routed** model shunt passes the request through to the
 upstream's `count_tokens` endpoint (exact counts). For a **`responses`-routed** model (codex/OpenAI)
@@ -498,7 +503,8 @@ export SHUNT_CLIENT_TOKENS="minsu:$(openssl rand -hex 32),alice:$(openssl rand -
 
 Startup **fails closed** if `[server.auth]` is present but the env var is unset or
 malformed. Requests to mapped models without a valid token get a 401
-`authentication_error`; `GET /v1/models`, `HEAD /`, and passthrough models stay open.
+`authentication_error`; `GET /v1/models`, `GET|HEAD /`, `GET /health`, and passthrough
+models stay open.
 The token header is always stripped before forwarding, matching is constant-time, and
 token values are never logged (client *names* are, per request).
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -189,7 +189,8 @@ e.g. `RUST_LOG=shunt=debug cargo run -- run`.
 | `POST` | `/v1/messages/count_tokens`   | Token counting (see below)                          |
 
 `GET /` and `GET /health` stay open even when `[server.auth]` is enabled (healthcheck tools
-usually cannot attach tokens) and expose nothing beyond status and version.
+usually cannot attach tokens) and expose nothing sensitive — only status, version, and the
+already-public endpoint list.
 
 **`count_tokens`:** for an **Anthropic-routed** model shunt passes the request through to the
 upstream's `count_tokens` endpoint (exact counts). For a **`responses`-routed** model (codex/OpenAI)

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,8 +36,8 @@ pub fn build_router(config: Config) -> Result<Router, ConfigError> {
 
     // `/` and `/health` stay unauthenticated even when `[server.auth]` is
     // configured (healthcheck tools rarely carry tokens); they must never
-    // expose config, credentials, or upstream details — version and status
-    // only.
+    // expose config, credentials, or upstream details — only version, status,
+    // and the already-public endpoint list.
     Ok(Router::new()
         .route("/", get(root_index))
         .route("/health", get(health))

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use axum::{
-    routing::{get, head, post},
-    Router,
+    routing::{get, post},
+    Json, Router,
 };
+use serde::Serialize;
 
 use crate::{
     auth::inbound::InboundAuth,
@@ -33,12 +34,40 @@ pub fn build_router(config: Config) -> Result<Router, ConfigError> {
         inbound_auth,
     };
 
+    // `/` and `/health` stay unauthenticated even when `[server.auth]` is
+    // configured (healthcheck tools rarely carry tokens); they must never
+    // expose config, credentials, or upstream details — version and status
+    // only.
     Ok(Router::new()
-        .route("/", head(root_probe))
+        .route("/", get(root_index))
+        .route("/health", get(health))
         .route("/v1/models", get(discovery::get))
         .route("/v1/messages", post(proxy::post))
         .route("/v1/messages/count_tokens", post(proxy::post))
         .with_state(state))
 }
 
-async fn root_probe() {}
+/// Human-facing landing page; axum also serves HEAD `/` from this handler,
+/// which keeps the pre-existing liveness probe working.
+async fn root_index() -> String {
+    format!(
+        "shunt v{} — Anthropic Messages proxy. Endpoints: /v1/models, /v1/messages, /v1/messages/count_tokens, /health\n",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    version: &'static str,
+}
+
+/// Machine-facing liveness endpoint: the process is up and config loaded
+/// (the router cannot exist otherwise). Deliberately does not check upstream
+/// connectivity — that is decided per request and would only cause flapping.
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}

--- a/tests/inbound_auth.rs
+++ b/tests/inbound_auth.rs
@@ -234,6 +234,38 @@ async fn passthrough_route_needs_no_token_and_still_strips_the_header() {
 }
 
 #[tokio::test]
+async fn health_and_root_stay_open_when_inbound_auth_is_configured() {
+    if !can_bind_loopback() {
+        return;
+    }
+    std::env::set_var("SHUNT_TEST_M4_KEY_F", "upstream-key");
+    std::env::set_var("SHUNT_TEST_M4_TOKENS_F", "alice:tok-a");
+    let upstream = MockServer::start().await;
+    let config = with_inbound_auth(
+        test_config(&upstream.uri(), "SHUNT_TEST_M4_KEY_F"),
+        "SHUNT_TEST_M4_TOKENS_F",
+    );
+    let gateway = start_gateway_with(config).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/health", gateway.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_eq!(body["status"], "ok");
+
+    let response = client
+        .get(format!("{}/", gateway.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn without_auth_config_mapped_route_stays_open() {
     if !can_bind_loopback() {
         return;

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -96,6 +96,49 @@ async fn head_root_returns_ok() {
 }
 
 #[tokio::test]
+async fn get_root_returns_landing_text_with_version_and_endpoints() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/", gateway.base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.text().await.unwrap();
+    assert!(body.contains(&format!("shunt v{}", env!("CARGO_PKG_VERSION"))));
+    assert!(body.contains("/v1/messages"));
+    assert!(body.contains("/health"));
+}
+
+#[tokio::test]
+async fn get_health_returns_ok_status_and_version() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/health", gateway.base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_eq!(
+        body,
+        serde_json::json!({"status": "ok", "version": env!("CARGO_PKG_VERSION")})
+    );
+}
+
+#[tokio::test]
 async fn messages_forwards_anthropic_headers_verbatim_and_preserves_query() {
     if !can_bind_loopback() {
         return;


### PR DESCRIPTION
## Summary

Adds a `GET /health` healthcheck endpoint and a human-readable `GET /` landing endpoint to the proxy server.

- `src/server.rs` replaces the HEAD-only `/` route with `get(root_index)` (axum serves `HEAD` from the `GET` handler automatically, so the existing liveness-probe behavior — `HEAD /` returns an empty `200` — is preserved unchanged).
- Adds a new `GET /health` route returning JSON `{"status":"ok","version":"<CARGO_PKG_VERSION>"}`.
- `GET /` now returns a one-line human-readable landing text listing the version and available endpoints.
- Both `/` and `/health` remain unauthenticated even when `[server.auth]` is configured, because inbound auth is enforced inside the proxy handler itself, not as router-level middleware — and both endpoints deliberately expose only status + version, never config/token/upstream details.

## Milestone / spec

<!-- No specific milestone/spec doc in docs/ covers this; it's an operational addition (healthcheck + landing page) on top of the existing proxy. -->

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it
- [ ] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

- `tests/passthrough.rs`: two new integration tests using a real axum server + reqwest — `get_root_returns_landing_text_with_version_and_endpoints` and `get_health_returns_ok_status_and_version`.
- `tests/inbound_auth.rs`: one new test — `health_and_root_stay_open_when_inbound_auth_is_configured` — verifying both endpoints stay open when `[server.auth]` is set.
- `docs/running.md`: the "Endpoints served" table gains rows for `GET /` and `GET /health`, plus a short auth-exemption note; the `[server.auth]` section's list of endpoints that stay open when auth is configured was updated to include them.
- Verified locally: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features --workspace` all pass, including the new integration tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GET `/health` and GET `/` endpoints for a simple healthcheck and a human-readable landing page. Preserves HEAD `/` liveness and exposes only status, version, and the public endpoint list.

- **New Features**
  - `GET /health` returns `{"status":"ok","version":"<CARGO_PKG_VERSION>"}`; no upstream checks to avoid flapping.
  - `GET /` returns a one-line landing text with the version and endpoint list; `HEAD /` still works via `axum`.
  - Both endpoints are unauthenticated even when `[server.auth]` is enabled.
  - Docs updated to note the public endpoint list exposure; integration tests added (`reqwest` + real server).

<sup>Written for commit f238af262582b56ca129ffb3eaa9737bd7850697. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

