### PR TITLE
feat(config): standard config-file fallback chain and strict --config

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -43,7 +43,11 @@ You can also run straight from the source tree with `cargo run -- <args>` (examp
 shunt loads configuration from, in increasing precedence:
 
 1. Built-in defaults (all providers preconfigured — see `src/config.rs`).
-2. A **TOML file**, `./shunt.toml` by default (override with `--config <path>`).
+2. A **TOML file**. With `--config <path>` that exact file is used (a missing
+   file is an error). Otherwise shunt takes the first file found in:
+   `./shunt.toml` → `$XDG_CONFIG_HOME/shunt/shunt.toml` (defaulting to
+   `~/.config/shunt/shunt.toml`) → `$(brew --prefix)/etc/shunt.toml`. Boot
+   logs report which file was loaded, or that defaults are in use.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys
    (e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`).
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -46,7 +46,8 @@ shunt loads configuration from, in increasing precedence:
 2. A **TOML file**. With `--config <path>` that exact file is used (a missing
    file is an error). Otherwise shunt takes the first file found in:
    `./shunt.toml` → `$XDG_CONFIG_HOME/shunt/shunt.toml` (defaulting to
-   `~/.config/shunt/shunt.toml`) → `$(brew --prefix)/etc/shunt.toml`. Boot
+   `~/.config/shunt/shunt.toml`) → `$HOMEBREW_PREFIX/etc/shunt.toml`
+   (defaulting to the `/opt/homebrew` and `/usr/local` prefixes). Boot
    logs report which file was loaded, or that defaults are in use.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys
    (e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, net::SocketAddr, path::Path};
+use std::{
+    collections::BTreeMap,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 
 use figment::{
     providers::{Env, Format, Serialized, Toml},
@@ -193,6 +197,8 @@ pub struct RoutePrefixConfig {
 pub enum ConfigError {
     #[error("failed to load configuration: {0}")]
     Figment(#[from] Box<figment::Error>),
+    #[error("config file not found: {}", .0.display())]
+    MissingConfigFile(PathBuf),
     #[error("server.bind must be a socket address: {0}")]
     BindAddress(#[from] std::net::AddrParseError),
     #[error("providers.{provider}.base_url must be a valid absolute URL: {message}")]
@@ -276,15 +282,67 @@ impl Default for Config {
     }
 }
 
+/// Standard config search order: `./shunt.toml`, then
+/// `$XDG_CONFIG_HOME/shunt/shunt.toml` (defaulting to `~/.config`), then
+/// `<homebrew prefix>/etc/shunt.toml` (`$HOMEBREW_PREFIX`, or the stock
+/// `/opt/homebrew` and `/usr/local` prefixes when unset).
+fn config_file_candidates(
+    xdg_config_home: Option<PathBuf>,
+    homebrew_prefix: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut candidates = vec![PathBuf::from("./shunt.toml")];
+    if let Some(dir) = xdg_config_home {
+        candidates.push(dir.join("shunt").join("shunt.toml"));
+    }
+    let brew_prefixes = match homebrew_prefix {
+        Some(prefix) => vec![prefix],
+        None => vec![PathBuf::from("/opt/homebrew"), PathBuf::from("/usr/local")],
+    };
+    for prefix in brew_prefixes {
+        candidates.push(prefix.join("etc").join("shunt.toml"));
+    }
+    candidates
+}
+
 impl Config {
     pub fn load(path: Option<&Path>) -> Result<Self, ConfigError> {
-        let path = path.unwrap_or_else(|| Path::new("./shunt.toml"));
-        let config: Self = Figment::from(Serialized::defaults(Self::default()))
-            .merge(Toml::file(path))
+        // An explicit --config that doesn't exist is an error; a typo'd path
+        // must not silently fall back to defaults.
+        let path = match path {
+            Some(path) if !path.is_file() => {
+                return Err(ConfigError::MissingConfigFile(path.to_path_buf()));
+            }
+            Some(path) => Some(path.to_path_buf()),
+            None => Self::find_config_file(),
+        };
+        let mut figment = Figment::from(Serialized::defaults(Self::default()));
+        if let Some(path) = &path {
+            figment = figment.merge(Toml::file(path));
+        }
+        let config: Self = figment
             .merge(Env::prefixed("SHUNT_").split("__"))
             .extract()
             .map_err(Box::new)?;
+        match &path {
+            Some(path) => tracing::info!(path = %path.display(), "loaded config"),
+            None => tracing::info!("no config file found, using defaults"),
+        }
         config.validate()
+    }
+
+    /// First existing file from the standard search order used when no
+    /// `--config` is given.
+    fn find_config_file() -> Option<PathBuf> {
+        let xdg_config_home = match std::env::var_os("XDG_CONFIG_HOME") {
+            Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+            _ => std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")),
+        };
+        let homebrew_prefix = std::env::var_os("HOMEBREW_PREFIX")
+            .filter(|prefix| !prefix.is_empty())
+            .map(PathBuf::from);
+        config_file_candidates(xdg_config_home, homebrew_prefix)
+            .into_iter()
+            .find(|path| path.is_file())
     }
 
     pub fn validate(self) -> Result<Self, ConfigError> {
@@ -390,7 +448,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use super::{AuthMode, Config, ModelConfig, ProviderKind};
+    use super::{config_file_candidates, AuthMode, Config, ConfigError, ModelConfig, ProviderKind};
 
     struct BufferWriter {
         buffer: Arc<Mutex<Vec<u8>>>,
@@ -451,6 +509,51 @@ mod tests {
             AuthMode::ChatgptOauth
         );
         assert!(config.provider("kimi").is_none());
+    }
+
+    #[test]
+    fn load_errors_when_explicit_config_path_is_missing() {
+        let path = std::path::Path::new("./no-such-shunt-config.toml");
+        let error = Config::load(Some(path)).unwrap_err();
+        assert!(matches!(error, ConfigError::MissingConfigFile(_)));
+        assert!(error.to_string().contains("no-such-shunt-config.toml"));
+    }
+
+    #[test]
+    fn config_file_candidates_follow_search_order() {
+        let candidates = config_file_candidates(
+            Some(std::path::PathBuf::from("/home/u/.config")),
+            Some(std::path::PathBuf::from("/opt/homebrew")),
+        );
+        let candidates: Vec<_> = candidates
+            .iter()
+            .map(|path| path.to_str().unwrap())
+            .collect();
+        assert_eq!(
+            candidates,
+            [
+                "./shunt.toml",
+                "/home/u/.config/shunt/shunt.toml",
+                "/opt/homebrew/etc/shunt.toml",
+            ]
+        );
+    }
+
+    #[test]
+    fn config_file_candidates_try_stock_brew_prefixes_when_env_is_unset() {
+        let candidates = config_file_candidates(None, None);
+        let candidates: Vec<_> = candidates
+            .iter()
+            .map(|path| path.to_str().unwrap())
+            .collect();
+        assert_eq!(
+            candidates,
+            [
+                "./shunt.toml",
+                "/opt/homebrew/etc/shunt.toml",
+                "/usr/local/etc/shunt.toml",
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,6 +199,8 @@ pub enum ConfigError {
     Figment(#[from] Box<figment::Error>),
     #[error("config file not found: {}", .0.display())]
     MissingConfigFile(PathBuf),
+    #[error("failed to read config file {}: {message}", .path.display())]
+    ReadConfigFile { path: PathBuf, message: String },
     #[error("server.bind must be a socket address: {0}")]
     BindAddress(#[from] std::net::AddrParseError),
     #[error("providers.{provider}.base_url must be a valid absolute URL: {message}")]
@@ -306,28 +308,40 @@ fn config_file_candidates(
 
 impl Config {
     pub fn load(path: Option<&Path>) -> Result<Self, ConfigError> {
-        // An explicit --config that doesn't exist is an error; a typo'd path
-        // must not silently fall back to defaults.
         let path = match path {
-            Some(path) if !path.is_file() => {
-                return Err(ConfigError::MissingConfigFile(path.to_path_buf()));
-            }
             Some(path) => Some(path.to_path_buf()),
             None => Self::find_config_file(),
         };
         let mut figment = Figment::from(Serialized::defaults(Self::default()));
         if let Some(path) = &path {
-            figment = figment.merge(Toml::file(path));
+            // Read the file ourselves instead of `Toml::file`, which silently
+            // yields an empty provider for a missing file — a typo'd --config
+            // or a file deleted after discovery must error, not fall back to
+            // defaults while the boot log claims the file was loaded.
+            let raw = std::fs::read_to_string(path).map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    ConfigError::MissingConfigFile(path.clone())
+                } else {
+                    ConfigError::ReadConfigFile {
+                        path: path.clone(),
+                        message: error.to_string(),
+                    }
+                }
+            })?;
+            figment = figment.merge(Toml::string(&raw));
         }
         let config: Self = figment
             .merge(Env::prefixed("SHUNT_").split("__"))
             .extract()
             .map_err(Box::new)?;
+        let config = config.validate()?;
+        // Logged only after validation so a rejected config never boots with a
+        // misleading "loaded config" line.
         match &path {
             Some(path) => tracing::info!(path = %path.display(), "loaded config"),
             None => tracing::info!("no config file found, using defaults"),
         }
-        config.validate()
+        Ok(config)
     }
 
     /// First existing file from the standard search order used when no


### PR DESCRIPTION
## Summary

`Config::load(None)` now searches a standard fallback chain instead of
only ever reading `./shunt.toml`, and an explicit `--config <path>` that
doesn't exist is now a hard error instead of a silent fallback to defaults.

- Search order (no `--config`): `./shunt.toml` -> `$XDG_CONFIG_HOME/shunt/shunt.toml`
  (default `~/.config/shunt/shunt.toml`) -> `<homebrew prefix>/etc/shunt.toml`
  (`$HOMEBREW_PREFIX`, else `/opt/homebrew` and `/usr/local`).
- Explicit `--config <path>` pointing at a missing file now returns
  `ConfigError::MissingConfigFile` instead of silently using defaults.
- Boot logs one line via `tracing`: `loaded config path=<path>` or
  `no config file found, using defaults`.
- Env vars (`SHUNT_*`) still merge on top in all cases.

## Milestone / spec

<!-- Not tied to a milestone doc; standard config discovery hardening. -->

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (`docs/running.md` section 3 updated)
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a, no CI changes)

## Notes for reviewers

- Three new unit tests: missing explicit path errors; candidate search order
  with and without `HOMEBREW_PREFIX`.
- Verified locally beyond the automated tests: live smoke tests of both
  boot-log paths (found vs. not-found) and the missing-file error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a standard config file search order and make `--config` strict to prevent silent defaults. Also harden boot logging to avoid misleading messages.

- **New Features**
  - Search order (no `--config`): `./shunt.toml` → `$XDG_CONFIG_HOME/shunt/shunt.toml` (default `~/.config/shunt/shunt.toml`) → `<homebrew prefix>/etc/shunt.toml` (`$HOMEBREW_PREFIX`, else `/opt/homebrew` or `/usr/local`).
  - Boot logs after validation: `loaded config path=<path>` or `no config file found, using defaults`.
  - Env vars `SHUNT_*` still merge on top.

- **Migration**
  - `--config <path>` must exist and be readable; missing files return `MissingConfigFile`, other I/O errors return `ReadConfigFile`. No silent fallback to defaults.

<sup>Written for commit 0052d5e7907c783ae75ddc6b3e3b06f1d9b59f89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

