### PR TITLE
fix(responses): rewrite context-overflow errors to Anthropic wording

### DIFF
--- a/docs/m1-responses-translation.md
+++ b/docs/m1-responses-translation.md
@@ -150,6 +150,15 @@ Preserve the upstream message text where available. (Unlike the pure pass-throug
 and does not conflict with the "forward errors unmodified" rule, which governs the
 Anthropic→Anthropic path.)
 
+**Exception — context overflow.** Claude Code's automatic compact-and-retry matches the literal
+phrase `prompt is too long` (case-insensitive) and optionally parses `N tokens > M maximum` to
+size the retry, so upstream context-length errors forwarded verbatim would strand the session
+until a manual `/compact`. `map_error_value` detects them (error code
+`context_length_exceeded` or message heuristics) and rewrites the message to
+`prompt is too long: {actual} tokens > {limit} maximum`, keeping the upstream token counts when
+the message carries two (order-agnostic: the larger is the actual count), or to the bare phrase
+when it carries none.
+
 ## 9. Test targets (M1)
 
 - `insta` snapshots: request translation for (plain text, multi-turn, tool_use+tool_result

--- a/site/src/content/docs/guides/effort-and-context.md
+++ b/site/src/content/docs/guides/effort-and-context.md
@@ -48,7 +48,7 @@ export CLAUDE_CODE_MAX_CONTEXT_TOKENS=372000
 ```
 
 :::caution
-The value is **global** — one value for every non-`claude-` model in the session — and setting it larger than the real upstream window delays auto-compact past the point where the upstream rejects the request with a context-length error. Match it to the smallest real window among your mapped models.
+The value is **global** — one value for every non-`claude-` model in the session — and setting it larger than the real upstream window delays auto-compact until the upstream rejects the request with a context-length error. shunt [rewrites that error](#context-overflow-recovery) so Claude Code compacts and retries automatically, but each overflow round-trip is wasted latency — match the value to the smallest real window among your mapped models.
 :::
 
 The other client-side lever is the `[1m]` model-id suffix, which forces a 1M window — only use it when the upstream really has that window.
@@ -59,6 +59,18 @@ The other client-side lever is the `[1m]` model-id suffix, which forces a 1M win
 | Context window (denominator) | ⚠️ 200k default; set `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | ✅ exact |
 | `count_tokens` (pre-flight) | ⚠️ local tiktoken count (default) | ✅ exact (upstream) |
 | `rate_limits` (5h / weekly) | ❌ needs Anthropic headers | ✅ shown |
+
+## Context overflow recovery
+
+When a conversation outgrows the upstream model's real window, the provider rejects the request with its own wording — OpenAI's `context_length_exceeded`, `"This model's maximum context length is N tokens…"`, or a proxy's `"prompt token count of N exceeds the limit of M"`. Claude Code's automatic compact-and-retry only fires on Anthropic's phrasing, so unrewritten these errors would strand the session until a manual `/compact` ([documented gateway pitfall](https://code.claude.com/docs/en/llm-gateway-connect#troubleshoot-gateway-errors)).
+
+shunt detects context-overflow errors on `responses`-routed models and rewrites them into the Anthropic shape Claude Code matches:
+
+```json
+{"type": "error", "error": {"type": "invalid_request_error", "message": "prompt is too long: 372982 tokens > 272000 maximum"}}
+```
+
+When the upstream message carries both token counts, shunt preserves them (whatever order the upstream states them in) — Claude Code parses the `N tokens > M maximum` gap and compacts past the whole overshoot in a single retry. When the upstream gives no counts (e.g. the Responses API's plain *"Your input exceeds the context window of this model"*), shunt emits `prompt is too long` alone, which still triggers compaction. Non-overflow errors are passed through with their original message.
 
 ## Attribution block
 

--- a/site/src/content/docs/reference/endpoints.md
+++ b/site/src/content/docs/reference/endpoints.md
@@ -16,4 +16,4 @@ description: The endpoints shunt serves as a Claude Code LLM gateway.
 
 ## Gateway protocol
 
-shunt implements the official [Claude Code LLM gateway protocol](https://code.claude.com/docs/en/llm-gateway-protocol): correct header and body-field forwarding, feature pass-through, and system-prompt attribution handling. Gateway-owned errors are returned in the Anthropic error shape, and streaming responses are relayed without buffering (with optional [keepalive pings](/guides/shared-gateway/#sse-keepalive-pings)).
+shunt implements the official [Claude Code LLM gateway protocol](https://code.claude.com/docs/en/llm-gateway-protocol): correct header and body-field forwarding, feature pass-through, and system-prompt attribution handling. Gateway-owned errors are returned in the Anthropic error shape, upstream context-overflow errors are rewritten to Anthropic's `prompt is too long` wording so Claude Code's [compact-and-retry](/guides/effort-and-context/#context-overflow-recovery) fires, and streaming responses are relayed without buffering (with optional [keepalive pings](/guides/shared-gateway/#sse-keepalive-pings)).

--- a/site/src/content/docs/reference/troubleshooting.md
+++ b/site/src/content/docs/reference/troubleshooting.md
@@ -13,6 +13,7 @@ description: Common shunt errors and how to fix them.
 | `config check failed` | Run `shunt check` for the exact reason (bind address, unknown provider in a route, wrong adapter/auth). |
 | Claude Code asks you to log in | Set an Anthropic credential (`ANTHROPIC_AUTH_TOKEN` / login) that shunt can forward for unmapped models. A base URL alone is not a credential. |
 | Effort stuck at `medium` on a mapped model | Set `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1` — see [Effort & Context](/guides/effort-and-context/#reasoning-effort). |
+| Session stuck after a context-length error on a mapped model | shunt rewrites upstream overflow errors to `prompt is too long …` so Claude Code auto-compacts and retries — see [Context overflow recovery](/guides/effort-and-context/#context-overflow-recovery). If it recurs every few turns, lower `CLAUDE_CODE_MAX_CONTEXT_TOKENS` to the model's real window. |
 | Stream dies behind Cloudflare (524) | Keep [`sse_keepalive_seconds`](/guides/shared-gateway/#sse-keepalive-pings) at its default (30) instead of `0`. |
 | 401 on mapped models on a shared gateway | Missing/invalid client token — set `ANTHROPIC_CUSTOM_HEADERS="x-shunt-token: <token>"`; see [Sharing a Gateway](/guides/shared-gateway/). |
 

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -530,11 +530,13 @@ pub fn parse_sse_events(input: &str) -> Vec<ResponseEvent> {
 }
 
 pub fn map_error_value(value: &Value, status: StatusCode) -> Value {
+    let message = error_message(value);
+    let message = context_overflow_message(value, &message).unwrap_or(message);
     json!({
         "type": "error",
         "error": {
             "type": anthropic_error_type(status),
-            "message": error_message(value)
+            "message": message
         }
     })
 }
@@ -559,6 +561,58 @@ fn error_message(value: &Value) -> String {
         .and_then(Value::as_str)
         .unwrap_or("upstream request failed")
         .to_string()
+}
+
+/// Rewrite upstream context-overflow errors into Anthropic's wording.
+///
+/// Claude Code's automatic compact-and-retry only fires when the error
+/// message contains the phrase "prompt is too long" (matched
+/// case-insensitively), and it parses "N tokens > M maximum" from it to
+/// size the retry. Upstream providers phrase the same failure in their own
+/// words, which would otherwise strand the session until a manual /compact.
+fn context_overflow_message(value: &Value, message: &str) -> Option<String> {
+    let code = value
+        .pointer("/error/code")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let lower = message.to_lowercase();
+    let is_overflow = code == "context_length_exceeded"
+        || lower.contains("maximum context length")
+        || (lower.contains("context window") && lower.contains("exceed"))
+        || (lower.contains("exceeds the limit") && lower.contains("token"));
+    if !is_overflow {
+        return None;
+    }
+    // Token counts and window sizes are the only large integers in these
+    // messages (small ones come from model names like "gpt-5.2"), and the
+    // overflowing count is always the larger of the two.
+    let mut numbers: Vec<i64> = Vec::new();
+    let mut current: Option<i64> = None;
+    for ch in message.chars() {
+        if let Some(digit) = ch.to_digit(10) {
+            current = Some(
+                current
+                    .unwrap_or(0)
+                    .saturating_mul(10)
+                    .saturating_add(i64::from(digit)),
+            );
+        } else if let Some(number) = current.take() {
+            if number >= 1000 {
+                numbers.push(number);
+            }
+        }
+    }
+    if let Some(number) = current {
+        if number >= 1000 {
+            numbers.push(number);
+        }
+    }
+    match (numbers.iter().max(), numbers.iter().min()) {
+        (Some(&actual), Some(&limit)) if actual > limit => Some(format!(
+            "prompt is too long: {actual} tokens > {limit} maximum"
+        )),
+        _ => Some("prompt is too long".to_string()),
+    }
 }
 
 fn sse(event: &str, data: &Value) -> String {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -552,10 +552,12 @@ pub fn anthropic_error_type(status: StatusCode) -> &'static str {
 
 fn error_message(value: &Value) -> String {
     // OpenAI Responses errors use {"error":{"message":...}} or {"message":...};
+    // streaming `response.failed` events nest it at {"response":{"error":...}};
     // the ChatGPT Codex backend uses {"detail":...}. Surface whichever is present
     // so the client sees the real reason (e.g. "The 'X' model is not supported").
     value
         .pointer("/error/message")
+        .or_else(|| value.pointer("/response/error/message"))
         .or_else(|| value.get("message"))
         .or_else(|| value.get("detail"))
         .and_then(Value::as_str)
@@ -573,22 +575,29 @@ fn error_message(value: &Value) -> String {
 fn context_overflow_message(value: &Value, message: &str) -> Option<String> {
     let code = value
         .pointer("/error/code")
+        .or_else(|| value.pointer("/response/error/code"))
+        .or_else(|| value.get("code"))
         .and_then(Value::as_str)
         .unwrap_or_default();
     let lower = message.to_lowercase();
+    // "exceeds the limit" alone also appears in quota/rate errors ("exceeds the
+    // limit of 1000000 tokens per minute"); requiring "prompt" or "token count"
+    // pins that branch to prompt-size messages.
     let is_overflow = code == "context_length_exceeded"
         || lower.contains("maximum context length")
         || (lower.contains("context window") && lower.contains("exceed"))
-        || (lower.contains("exceeds the limit") && lower.contains("token"));
+        || (lower.contains("exceeds the limit")
+            && (lower.contains("prompt") || lower.contains("token count")));
     if !is_overflow {
         return None;
     }
     // Token counts and window sizes are the only large integers in these
     // messages (small ones come from model names like "gpt-5.2"), and the
-    // overflowing count is always the larger of the two.
+    // overflowing count is always the larger of the two. Commas and
+    // underscores are digit-group separators ("272,000"), not delimiters.
     let mut numbers: Vec<i64> = Vec::new();
     let mut current: Option<i64> = None;
-    for ch in message.chars() {
+    for ch in message.chars().filter(|ch| !matches!(ch, ',' | '_')) {
         if let Some(digit) = ch.to_digit(10) {
             current = Some(
                 current

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -364,6 +364,58 @@ fn surfaces_upstream_error_detail_and_message() {
     assert_eq!(unknown["error"]["message"], "upstream request failed");
 }
 
+#[test]
+fn rewrites_context_overflow_errors_to_anthropic_wording() {
+    // Claude Code's compact-and-retry matches "prompt is too long" and parses
+    // "N tokens > M maximum" to size the retry; each upstream phrasing must
+    // land on that shape with actual > limit regardless of the original order.
+
+    // Chat-Completions phrasing: limit appears before the actual count.
+    let chat = map_error_value(
+        &json!({"error": {
+            "code": "context_length_exceeded",
+            "message": "This model's maximum context length is 272000 tokens. However, your messages resulted in 372982 tokens. Please reduce the length of the messages."
+        }}),
+        StatusCode::BAD_REQUEST,
+    );
+    assert_eq!(chat["error"]["type"], "invalid_request_error");
+    assert_eq!(
+        chat["error"]["message"],
+        "prompt is too long: 372982 tokens > 272000 maximum"
+    );
+
+    // Gateway/proxy phrasing: actual count appears before the limit.
+    let proxied = map_error_value(
+        &json!({"error": {"message": "prompt token count of 372982 exceeds the limit of 272000 for model gpt-5.2"}}),
+        StatusCode::BAD_REQUEST,
+    );
+    assert_eq!(
+        proxied["error"]["message"],
+        "prompt is too long: 372982 tokens > 272000 maximum"
+    );
+
+    // Responses API phrasing carries no token counts; the phrase alone still
+    // triggers the client's compaction path.
+    let responses = map_error_value(
+        &json!({"error": {
+            "code": "context_length_exceeded",
+            "message": "Your input exceeds the context window of this model. Please adjust your input and try again."
+        }}),
+        StatusCode::BAD_REQUEST,
+    );
+    assert_eq!(responses["error"]["message"], "prompt is too long");
+
+    // Non-overflow errors pass through untouched.
+    let other = map_error_value(
+        &json!({"error": {"code": "invalid_api_key", "message": "Incorrect API key provided: 1234567890"}}),
+        StatusCode::UNAUTHORIZED,
+    );
+    assert_eq!(
+        other["error"]["message"],
+        "Incorrect API key provided: 1234567890"
+    );
+}
+
 fn event_names(sse: &str) -> Vec<String> {
     sse.split("\n\n")
         .filter_map(|frame| {

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -405,6 +405,26 @@ fn rewrites_context_overflow_errors_to_anthropic_wording() {
     );
     assert_eq!(responses["error"]["message"], "prompt is too long");
 
+    // Comma-formatted counts still parse (digit-group separators, not delimiters).
+    let grouped = map_error_value(
+        &json!({"error": {"message": "This model's maximum context length is 272,000 tokens. However, your messages resulted in 372,982 tokens."}}),
+        StatusCode::BAD_REQUEST,
+    );
+    assert_eq!(
+        grouped["error"]["message"],
+        "prompt is too long: 372982 tokens > 272000 maximum"
+    );
+
+    // Streaming `response.failed` events nest the error under "response".
+    let failed = map_error_value(
+        &json!({"type": "response.failed", "response": {"error": {
+            "code": "context_length_exceeded",
+            "message": "Your input exceeds the context window of this model."
+        }}}),
+        StatusCode::BAD_GATEWAY,
+    );
+    assert_eq!(failed["error"]["message"], "prompt is too long");
+
     // Non-overflow errors pass through untouched.
     let other = map_error_value(
         &json!({"error": {"code": "invalid_api_key", "message": "Incorrect API key provided: 1234567890"}}),
@@ -413,6 +433,16 @@ fn rewrites_context_overflow_errors_to_anthropic_wording() {
     assert_eq!(
         other["error"]["message"],
         "Incorrect API key provided: 1234567890"
+    );
+
+    // Quota/rate errors mention token limits too; they must NOT be rewritten.
+    let quota = map_error_value(
+        &json!({"error": {"code": "rate_limit_exceeded", "message": "Your request exceeds the limit of 1000000 tokens per minute."}}),
+        StatusCode::TOO_MANY_REQUESTS,
+    );
+    assert_eq!(
+        quota["error"]["message"],
+        "Your request exceeds the limit of 1000000 tokens per minute."
     );
 }
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -402,6 +402,12 @@ stateDiagram-v2
 | Tool use | `function_call` | `tool_use_item()` | Tool call ID test | [src/model/responses_request.rs:140-148](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses_request.rs#L140-L148) [tests/responses_translate.rs:73-96](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L73-L96) |
 | Reasoning effort | `reasoning.effort` | `effort()` | Thinking and override test | [src/model/responses_request.rs:254-280](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses_request.rs#L254-L280) [tests/responses_translate.rs:164-178](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L164-L178) |
 
+## Error Mapping
+
+Upstream errors on the `responses` path are re-shaped into the Anthropic error envelope by `map_error_value`, with the `error.type` derived from the upstream status (401 → `authentication_error`, 429 → `rate_limit_error`, 400 → `invalid_request_error`, other → `api_error`) and the upstream message preserved ([src/model/responses.rs:532-563](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses.rs#L532-L563)).
+
+Context-overflow errors are the one case where the message itself is rewritten: Claude Code's automatic compact-and-retry matches the literal phrase `prompt is too long` and parses `N tokens > M maximum` to size the retry, so upstream phrasings (`context_length_exceeded`, "maximum context length is N tokens", "prompt token count of N exceeds the limit of M") are detected and rewritten to that shape, keeping the token counts when the upstream message carries them ([src/model/responses.rs:566-616](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses.rs#L566-L616), [tests/responses_translate.rs:368-417](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L368-L417)).
+
 ## Related Pages
 
 | Page | Relationship |

--- a/wiki/src/content/docs/02-deep-dive/adapters-and-translation.md
+++ b/wiki/src/content/docs/02-deep-dive/adapters-and-translation.md
@@ -102,6 +102,25 @@ stateDiagram-v2
 | Tool use | `function_call` | `tool_use_item()` | Tool call ID test | [src/model/responses_request.rs:140-148](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses_request.rs#L140-L148) [tests/responses_translate.rs:73-96](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L73-L96) |
 | Reasoning effort | `reasoning.effort` | `effort()` | Thinking and override test | [src/model/responses_request.rs:254-280](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses_request.rs#L254-L280) [tests/responses_translate.rs:164-178](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L164-L178) |
 
+## Error Mapping
+
+Upstream errors on the `responses` path are re-shaped into the Anthropic error envelope by `map_error_value`, with the `error.type` derived from the upstream status (401 → `authentication_error`, 429 → `rate_limit_error`, 400 → `invalid_request_error`, other → `api_error`) and the upstream message preserved ([src/model/responses.rs:532-563](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses.rs#L532-L563)).
+
+Context-overflow errors are the one case where the message itself is rewritten: Claude Code's automatic compact-and-retry matches the literal phrase `prompt is too long` and parses `N tokens > M maximum` to size the retry, so upstream phrasings (`context_length_exceeded`, "maximum context length is N tokens", "prompt token count of N exceeds the limit of M") are detected and rewritten to that shape, keeping the token counts when the upstream message carries them ([src/model/responses.rs:566-616](https://github.com/chatbot-pf/shunt/blob/main/src/model/responses.rs#L566-L616), [tests/responses_translate.rs:368-417](https://github.com/chatbot-pf/shunt/blob/main/tests/responses_translate.rs#L368-L417)).
+
+```mermaid
+flowchart LR
+    Upstream[Upstream error body] --> Detect{context overflow?}
+    Detect -->|no| Preserve[original message]
+    Detect -->|yes| Rewrite["prompt is too long: N tokens > M maximum"]
+    Preserve --> Envelope[Anthropic error envelope]
+    Rewrite --> Envelope
+    classDef dark fill:#2d333b,stroke:#6d5dfc,color:#e6edf3;
+    class Upstream,Detect,Preserve,Rewrite,Envelope dark;
+    linkStyle default stroke:#8b949e;
+```
+<!-- Sources: src/model/responses.rs:532, src/model/responses.rs:573, src/adapters/responses.rs:153 -->
+
 ## Related Pages
 
 | Page | Relationship |


### PR DESCRIPTION
## Summary

Shunt now translates upstream context-overflow errors into Anthropic's `prompt is too long` wording so Claude Code's automatic compact-and-retry fires when a gateway-routed OpenAI model rejects an over-long prompt.

Claude Code's compact-and-retry matches the literal phrase `prompt is too long` (case-insensitive) and parses `N tokens > M maximum` to size the retry (verified against Claude Code source: `src/services/api/errors.ts`). Upstream OpenAI phrasings forwarded verbatim would strand the session until a manual `/compact` — a documented LLM-gateway pitfall.

## Milestone / spec

M1 — docs/m1-responses-translation.md §8 (error-mapping exception)

## Changes

- `src/model/responses.rs`: new `context_overflow_message()` — detects overflow via error code `context_length_exceeded` or message heuristics ("maximum context length", "context window"+"exceed", "exceeds the limit"+"token"); extracts token counts by scanning integers >=1000 (order-agnostic: larger = actual, smaller = limit); rewrites to `prompt is too long: N tokens > M maximum` (or the bare phrase when no counts). Wired into `map_error_value`, covering both buffered errors and streaming SSE error events. Non-overflow errors pass through unchanged.
- `tests/responses_translate.rs`: new test `rewrites_context_overflow_errors_to_anthropic_wording` covering Chat-Completions phrasing (limit-first), proxy phrasing (actual-first), no-counts Responses phrasing, and a non-overflow error passthrough.
- Docs updated across all three surfaces:
  - `docs/m1-responses-translation.md` (§8 error-mapping exception)
  - `site/` (new "Context overflow recovery" section in guides/effort-and-context.md, updated caution note, endpoints.md gateway-protocol line, troubleshooting.md row)
  - `wiki/` (new "Error Mapping" section with Mermaid diagram in 02-deep-dive/adapters-and-translation.md, mirrored into llms-full.txt)

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

- Detection heuristics in `context_overflow_message()` cover both Chat-Completions style (`error.code == context_length_exceeded`) and Responses/proxy style (message-text heuristics) — worth double-checking the integer-extraction ordering logic (larger = actual, smaller = limit) against the test fixtures in `tests/responses_translate.rs`.
- Full test suite (95 tests) passes; both Astro sites (`site/`, `wiki/`) build cleanly (15 pages each).
- No linked GitHub issue for this work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites upstream context-overflow errors to Anthropic’s “prompt is too long” so Claude Code auto-compacts on mapped OpenAI models. Preserves token counts (any order, commas ok) for precise retries; non-overflow errors pass through unchanged.

- **Bug Fixes**
  - Added `context_overflow_message()` to detect overflow (`context_length_exceeded` or heuristics, incl. nested `response.failed`), extract counts by scanning integers ≥1000 (ignores commas/underscores), order by size, and rewrite to `prompt is too long: N tokens > M maximum`; wired into `map_error_value` for buffered and SSE errors.
  - Expanded tests to cover limit-first, actual-first, no-counts, grouped numbers, streaming-nested errors, passthrough, and quota/rate-limit messages not rewritten.
  - Docs updated: “Context overflow recovery” guide, endpoint protocol note, troubleshooting entry, and spec.

<sup>Written for commit 7e827526a33d1d63ae0a64ad4673099dc801074c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

