### PR TITLE
fix(codex): send codex client identity headers to unlock version-gated models

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -433,6 +433,15 @@ Then pick it from `/model` in Claude Code. That id is what shunt routes on, so i
 > may only be entitled to the earlier ones. Use `upstream_model` in a route, or pass an entitled
 > slug via `ANTHROPIC_CUSTOM_MODEL_OPTION`. See [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) §0.
 
+> **Client-version gating:** some slugs additionally carry a `minimal_client_version` (e.g.
+> `gpt-5.6-luna` requires ≥ 0.144.0) and the backend answers **`Model not found <slug>`** — not
+> an entitlement error — when the request's client identity is missing or too old. The gate keys
+> on the `originator` + `version` headers ([openai/codex#31967](https://github.com/openai/codex/issues/31967)).
+> shunt therefore sends the Codex CLI identity headers (`originator: codex_cli_rs`,
+> `version`, and a matching `user-agent`) on ChatGPT OAuth requests, **pinned to
+> openai/codex rust-v0.144.1**. If a future slug demands a newer client, bump the pinned
+> version in `src/adapters/responses.rs` (`CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`).
+
 Per-context selection also works via Claude Code's own knobs — a subagent's `model:`
 frontmatter, or `CLAUDE_CODE_SUBAGENT_MODEL` for all subagents — so you can divert only one
 agent while the main session stays on Claude.

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -227,6 +227,21 @@ fn own_error(message: String) -> AdapterError {
     }
 }
 
+/// Codex CLI client identity, mirrored from openai/codex rust-v0.144.1.
+///
+/// The ChatGPT backend routes newer model slugs (e.g. gpt-5.6-luna, which has
+/// `minimal_client_version: 0.144.0`) by client identity and answers
+/// "Model not found" — not an entitlement error — when the identity is
+/// missing or too old. Per openai/codex#31967 the gate keys on the
+/// `originator` + `version` header combination; the `user-agent` is sent for
+/// fidelity with Codex, which builds it as
+/// `{originator}/{version} ({os} {os_version}; {arch}) {terminal}`
+/// (codex-rs/login/src/auth/default_client.rs) and sends the bare CLI
+/// version in a `version` header (codex-rs/model-provider-info/src/lib.rs).
+/// Bump both together when a new slug requires a newer client version.
+const CODEX_USER_AGENT: &str = "codex_cli_rs/0.144.1";
+const CODEX_CLIENT_VERSION: &str = "0.144.1";
+
 fn request_builder(
     state: &AppState,
     route: &Route,
@@ -254,7 +269,9 @@ fn request_builder(
             request = request
                 .bearer_auth(access_token)
                 .header("chatgpt-account-id", account_id)
-                .header("originator", "codex_cli_rs");
+                .header("originator", "codex_cli_rs")
+                .header("user-agent", CODEX_USER_AGENT)
+                .header("version", CODEX_CLIENT_VERSION);
         }
         // xAI subscription OAuth: bearer only, no account-id/originator headers.
         Credential::XaiOauth { access_token } => {
@@ -402,6 +419,14 @@ mod tests {
         );
         assert_eq!(request.headers().get("originator").unwrap(), "codex_cli_rs");
         assert_eq!(
+            request.headers().get("user-agent").unwrap(),
+            super::CODEX_USER_AGENT
+        );
+        assert_eq!(
+            request.headers().get("version").unwrap(),
+            super::CODEX_CLIENT_VERSION
+        );
+        assert_eq!(
             request.headers().get("OpenAI-Beta").unwrap(),
             "responses=experimental"
         );
@@ -450,6 +475,8 @@ mod tests {
         // No ChatGPT/Codex headers and no OpenAI-Beta for the xai flavor.
         assert!(request.headers().get("chatgpt-account-id").is_none());
         assert!(request.headers().get("originator").is_none());
+        assert!(request.headers().get("user-agent").is_none());
+        assert!(request.headers().get("version").is_none());
         assert!(request.headers().get("OpenAI-Beta").is_none());
     }
 


### PR DESCRIPTION
## Summary

Requests for `gpt-5.6-luna` through shunt failed with upstream `Model not found gpt-5.6-luna` while `gpt-5.6-sol`/`-terra` worked. This is not an entitlement error: the ChatGPT Codex backend gates slugs carrying a `minimal_client_version` (luna requires ≥ 0.144.0) on the **`originator` + `version` header combination** — see [openai/codex#31967](https://github.com/openai/codex/issues/31967). shunt sent `originator: codex_cli_rs` but no client version, so the backend resolved luna to an unavailable engine and reported it as missing.

This change sends the Codex CLI client identity on ChatGPT OAuth requests, **pinned to openai/codex rust-v0.144.1**:

- `version: 0.144.1` (the load-bearing gate header)
- `user-agent: codex_cli_rs/0.144.1` (prefix of Codex's UA format, for fidelity)

Other codex 0.144.1 headers on this endpoint (`session-id`, `x-codex-window-id`, `Accept: text/event-stream`, …) are session/tracing state and not involved in the gate, so they are intentionally not added. Docs (`docs/running.md` §5.4) gain a note explaining the gating and where to bump the pinned version.

## Milestone / spec

M2 — docs/m2-chatgpt-oauth.md (ChatGPT OAuth request headers); docs/running.md §5.4 updated.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a)

## Notes for reviewers

- Verified end-to-end against the live backend: with this patch `gpt-5.6-luna` returns 200 through shunt (previously `Model not found`), and `gpt-5.6-sol` still works (no regression). Direct backend probes confirmed the same request fails without the version identity and succeeds with it.
- The identity headers are added only in the `Credential::ChatGptOAuth` arm; the xAI test asserts they do not leak onto xAI requests.
- Version pin is a deliberate static constant (`CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`) — bumping it is a one-line change when a future slug demands a newer client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Codex client identity headers on ChatGPT OAuth requests to unlock version‑gated models like gpt‑5.6‑luna. Fixes "Model not found" by adding `version: 0.144.1` and `user-agent: codex_cli_rs/0.144.1` alongside `originator`.

- **Bug Fixes**
  - Scope: applied only for `ChatGptOAuth`; xAI flows unchanged.
  - Pin: rust‑v0.144.1; bump `CODEX_USER_AGENT`/`CODEX_CLIENT_VERSION` in `src/adapters/responses.rs` when needed.
  - Docs/tests: added gating note in `docs/running.md`; tests assert header presence/absence.

<sup>Written for commit 20f91927590ad7d7f4f206f6375621bb62749438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

