### PR TITLE
feat(config): hot-reload config on SIGHUP and file change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +956,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1064,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1121,6 +1180,33 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2081,11 +2167,13 @@ name = "shunt-gateway"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "axum",
  "base64",
  "clap",
  "figment",
  "futures-util",
+ "notify",
  "reqwest 0.12.28",
  "sentry",
  "serde",
@@ -2773,7 +2861,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2791,14 +2888,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2808,10 +2922,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2820,10 +2946,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2832,10 +2970,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2844,10 +2994,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+arc-swap = "1.9.2"
 axum = "0.8"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", features = ["toml", "env"] }
 futures-util = "0.3"
+notify = "8.2.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 sentry = { version = "0.48.4", default-features = false, features = ["backtrace", "contexts", "metrics", "panic", "reqwest", "rustls", "tracing"] }
 serde = { version = "1", features = ["derive"] }

--- a/docs/config-reload.md
+++ b/docs/config-reload.md
@@ -1,0 +1,59 @@
+# Config hot-reload (SIGHUP + file watch)
+
+## 0. Problem
+
+A shared/enterprise gateway should pick up config edits — a new route, a rotated
+API key env, an added client token — without dropping in-flight requests or a
+maintenance window. shunt reloads its config file while running, fail-safe: a bad
+edit never takes the process down and never leaves it running open.
+
+## 1. Triggers
+
+Two triggers reload the config; both call the same fail-safe path.
+
+- **SIGHUP**: `kill -HUP <pid>` (Unix only). Handy after editing the file in
+  place or from a config-management tool.
+- **File change (automatic)**: shunt watches the config file's **parent
+  directory**, not the file inode, so atomic-rename saves (editors) and
+  **Kubernetes ConfigMap** symlink swaps — which replace the file rather than
+  write in place — are detected. Events are debounced (400 ms quiet period) so a
+  burst of writes coalesces into a single reload. Auto-reload is active only when
+  the effective config path is known (a `--config` path or a discovered file);
+  running on built-in defaults has nothing to watch.
+
+If the file watcher fails to initialize, shunt logs a warning and keeps running
+with SIGHUP-only reload rather than aborting.
+
+## 2. Fail-safe behavior
+
+A reload loads and fully **validates** the candidate config before doing
+anything. Only on complete success is the new config swapped in atomically. On
+**any** error (missing file, TOML parse error, unknown provider, unresolvable
+`[server.auth]` tokens, …) the reload returns the error, logs it, and leaves the
+**currently-running config live and unchanged**. There is no window where the
+gateway runs a half-applied or open config.
+
+## 3. In-flight request consistency
+
+The live config is held behind an atomic pointer (`arc-swap`). Each request
+snapshots the live config on entry and uses that one snapshot for its whole
+lifetime, so a reload that lands mid-request never changes config underneath it.
+Requests that arrive after the swap see the new config. No locks, no added
+per-request latency.
+
+## 4. Fields that require a restart
+
+Most settings apply on reload (routes, providers, models, `[server.auth]`,
+`sse_keepalive_seconds`). Two cannot be hot-applied; changing them is accepted
+into the reloaded config but only takes effect after a restart, and shunt logs a
+`warn!` so the change is not mistaken for live:
+
+- **`server.bind`** — the listener is already bound at the old address.
+- **`[sentry]`** — the Sentry client is initialized once before the runtime
+  starts and cannot be hot-swapped.
+
+## 5. What reload does not do
+
+- No signal handling on non-Unix platforms (SIGHUP does not exist there); the
+  file watcher still works.
+- No partial/atomic multi-file config — shunt reloads the single effective file.

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -390,11 +390,7 @@ mod tests {
 
     #[test]
     fn builds_codex_url_and_headers_without_sending() {
-        let state = AppState {
-            config: Config::default(),
-            http_client: reqwest::Client::new(),
-            inbound_auth: None,
-        };
+        let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
 
         let request = build_test_request(
             &state,
@@ -452,11 +448,7 @@ mod tests {
 
     #[test]
     fn builds_xai_request_bearer_only_without_openai_beta() {
-        let state = AppState {
-            config: Config::default(),
-            http_client: reqwest::Client::new(),
-            inbound_auth: None,
-        };
+        let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
 
         let request = build_test_request(
             &state,

--- a/src/config.rs
+++ b/src/config.rs
@@ -425,8 +425,9 @@ impl Config {
     }
 
     /// First existing file from the standard search order used when no
-    /// `--config` is given.
-    fn find_config_file() -> Option<PathBuf> {
+    /// `--config` is given. Public so the binary can resolve the effective path
+    /// once at startup and reuse it for hot-reload/file-watch.
+    pub fn find_config_file() -> Option<PathBuf> {
         let xdg_config_home = match std::env::var_os("XDG_CONFIG_HOME") {
             Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
             _ => std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")),
@@ -526,6 +527,21 @@ impl Config {
             }
         }
         Ok(self)
+    }
+
+    /// Resolve `[server.auth]` into the runtime inbound-auth state, reading the
+    /// configured tokens env. `None` when inbound auth is not configured. Fails
+    /// closed (see [`InboundAuthConfig::resolve`]). Shared by `build_router` and
+    /// the hot-reload path so both re-resolve tokens identically.
+    pub fn resolve_inbound_auth(
+        &self,
+    ) -> Result<Option<std::sync::Arc<crate::auth::inbound::InboundAuth>>, ConfigError> {
+        self.server
+            .auth
+            .as_ref()
+            .map(|auth| auth.resolve())
+            .transpose()
+            .map(|auth| auth.map(std::sync::Arc::new))
     }
 
     /// Look up a provider by name.

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -16,6 +16,8 @@ pub struct ModelEntry {
 }
 
 pub async fn get(State(state): State<AppState>, headers: HeaderMap) -> Json<ModelsResponse> {
+    // Snapshot the live config so this response reflects the latest reload.
+    let state = state.refreshed();
     let _credential = discovery_credential(&headers);
     let data: Vec<ModelEntry> = state
         .config
@@ -64,11 +66,7 @@ mod tests {
             ],
             ..crate::config::Config::default()
         };
-        let state = AppState {
-            config,
-            http_client: reqwest::Client::new(),
-            inbound_auth: None,
-        };
+        let state = AppState::new(config, reqwest::Client::new()).unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer test".parse().unwrap());
 
@@ -88,11 +86,8 @@ mod tests {
 
     #[tokio::test]
     async fn returns_empty_data_when_models_are_unconfigured() {
-        let state = AppState {
-            config: crate::config::Config::default(),
-            http_client: reqwest::Client::new(),
-            inbound_auth: None,
-        };
+        let state =
+            AppState::new(crate::config::Config::default(), reqwest::Client::new()).unwrap();
 
         let response = get(State(state), HeaderMap::new()).await;
         let body = serde_json::to_value(response.0).unwrap();
@@ -102,6 +97,6 @@ mod tests {
 
     #[test]
     fn router_includes_get_models_route() {
-        let _router = server::build_router(crate::config::Config::default()).unwrap();
+        let (_router, _shared) = server::build_router(crate::config::Config::default()).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ pub mod keepalive;
 pub mod metrics;
 pub mod model;
 pub mod proxy;
+pub mod reload;
 pub mod routing;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,13 +80,16 @@ async fn token() -> anyhow::Result<()> {
 }
 
 fn run(config_path: Option<PathBuf>) -> anyhow::Result<()> {
-    let config = Config::load(config_path.as_deref()).context("failed to load config")?;
+    // Resolve the effective config path once at startup so reload/file-watch
+    // reuse the exact same file the initial load used.
+    let path = config_path.or_else(Config::find_config_file);
+    let config = Config::load(path.as_deref()).context("failed to load config")?;
     // The guard must outlive the runtime so buffered events flush on shutdown.
     let _sentry = init_sentry(config.sentry.as_ref());
-    runtime()?.block_on(serve(config))
+    runtime()?.block_on(serve(config, path))
 }
 
-async fn serve(config: Config) -> anyhow::Result<()> {
+async fn serve(config: Config, path: Option<PathBuf>) -> anyhow::Result<()> {
     let bind = config
         .server
         .bind_addr()
@@ -98,7 +101,10 @@ async fn serve(config: Config) -> anyhow::Result<()> {
         .local_addr()
         .context("failed to read bind address")?;
     tracing::info!(%local_addr, "shunt listening");
-    let router = server::build_router(config).context("failed to initialize gateway")?;
+    let (router, shared) = server::build_router(config).context("failed to initialize gateway")?;
+    // Reload triggers (SIGHUP and config-file watch) run as background tasks and
+    // hot-swap the shared runtime state that the router reads per request.
+    shunt::reload::spawn_reload_watchers(shared, path).await;
     axum::serve(listener, router).await?;
     Ok(())
 }
@@ -224,7 +230,7 @@ mod tests {
         config.server.bind = "not-an-address".to_string();
         let error = runtime()
             .expect("runtime builds")
-            .block_on(serve(config))
+            .block_on(serve(config, None))
             .expect_err("invalid bind must fail");
         assert!(error.to_string().contains("invalid server bind address"));
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -26,6 +26,10 @@ pub async fn post(
     headers: HeaderMap,
     body: Body,
 ) -> axum::response::Response {
+    // Snapshot the live config once, at request entry: a mid-request reload
+    // never changes config underneath an in-flight request, while a request that
+    // arrives after a reload sees the new config.
+    let state = state.refreshed();
     let started_at = Instant::now();
     let path = uri.path().to_string();
     let session_id = headers

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -151,14 +151,21 @@ fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
         .map(std::path::Path::to_path_buf)
         .unwrap_or_else(|| std::path::PathBuf::from("."));
 
-    // notify calls the handler on its own thread with std types; forward raw
-    // events onto a tokio channel so the async task can debounce them.
+    // notify calls the handler on its own thread with std types; forward only
+    // events that touch the config file onto a tokio channel so the async task
+    // can debounce them. Filtering here (rather than in the async task) means an
+    // unrelated sibling write in the watched directory never reaches the debounce
+    // timer and so cannot reset it — a continuously-active writer in the same
+    // directory can no longer starve a real config change indefinitely.
+    let watch_path = path.clone();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<notify::Event>();
     let mut watcher = match notify::recommended_watcher(
         move |result: notify::Result<notify::Event>| {
             if let Ok(event) = result {
-                // A closed receiver just means the server is shutting down.
-                let _ = tx.send(event);
+                if event_touches_path(&event, &watch_path) {
+                    // A closed receiver just means the server is shutting down.
+                    let _ = tx.send(event);
+                }
             }
         },
     ) {
@@ -179,15 +186,15 @@ fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
         // event delivery.
         let _watcher = watcher;
         loop {
-            // Block until an event that touches the config file arrives.
-            let Some(event) = rx.recv().await else {
+            // Block until a config-relevant event arrives. Sibling events are
+            // filtered out in the watcher callback, so every event delivered here
+            // touches the config file and may legitimately extend the debounce.
+            if rx.recv().await.is_none() {
                 break;
-            };
-            if !event_touches_path(&event, &path) {
-                continue;
             }
             // Debounce: keep draining until the writes go quiet, coalescing a
-            // burst of events into a single reload.
+            // burst of events into a single reload. Only config-relevant events
+            // reach the channel, so a sibling write can never restart this timer.
             loop {
                 match tokio::time::timeout(DEBOUNCE, rx.recv()).await {
                     Ok(Some(_)) => continue, // more events; keep waiting for quiet
@@ -206,13 +213,18 @@ fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
 /// Whether a filesystem event concerns the config file. Directory watching
 /// surfaces sibling files too, so filter by the config file's own path (matching
 /// its final component covers atomic renames whose event carries the temp path
-/// then the final path).
+/// then the final path). A Kubernetes ConfigMap mount is a special case: the
+/// config symlink itself never fires an event on update — kubelet atomically
+/// swaps the `..data` symlink that the config path resolves through, so accept a
+/// `..data` event too or a mounted ConfigMap change would never hot-reload.
 fn event_touches_path(event: &notify::Event, path: &std::path::Path) -> bool {
     let name = path.file_name();
-    event
-        .paths
-        .iter()
-        .any(|event_path| event_path == path || (name.is_some() && event_path.file_name() == name))
+    let configmap_data = std::ffi::OsStr::new("..data");
+    event.paths.iter().any(|event_path| {
+        event_path == path
+            || (name.is_some() && event_path.file_name() == name)
+            || event_path.file_name() == Some(configmap_data)
+    })
 }
 
 #[cfg(test)]
@@ -438,6 +450,13 @@ mod tests {
         let by_name =
             notify::Event::new(notify::EventKind::Any).add_path(dir.join("..data/shunt.toml"));
         assert!(event_touches_path(&by_name, &config));
+
+        // Kubernetes ConfigMap update: kubelet atomically swaps the `..data`
+        // symlink, and that rename — not the config symlink — is the only event
+        // that fires, so a bare `..data` event must count as touching the config.
+        let configmap_swap =
+            notify::Event::new(notify::EventKind::Any).add_path(dir.join("..data"));
+        assert!(event_touches_path(&configmap_swap, &config));
 
         // An unrelated sibling in the watched directory must be ignored.
         let sibling = notify::Event::new(notify::EventKind::Any).add_path(dir.join("other.toml"));

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -221,8 +221,11 @@ mod tests {
 
     use arc_swap::ArcSwap;
 
-    use super::{reload, RuntimeState, SharedState};
-    use crate::config::Config;
+    use super::{
+        event_touches_path, reload, sentry_changed, spawn_reload_watchers, RuntimeState,
+        SharedState,
+    };
+    use crate::config::{Config, SentryConfig};
 
     /// Unique temp dir per test so concurrent `cargo test` runs never collide.
     fn temp_dir(tag: &str) -> std::path::PathBuf {
@@ -363,5 +366,127 @@ mod tests {
         // ...but the operator was warned it requires a restart to take effect.
         assert!(logs.contains("server.bind changed"));
         assert!(logs.contains("requires a restart"));
+    }
+
+    #[test]
+    fn sentry_change_warns_but_reload_still_succeeds() {
+        let dir = temp_dir("sentry");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        // Start with no [sentry] section.
+        std::fs::write(&path, "[server]\ndefault_provider = \"anthropic\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+
+        // Add a (disabled, empty-DSN) [sentry] section: a change that only takes
+        // effect on restart, so the reload succeeds but warns.
+        std::fs::write(
+            &path,
+            "[server]\ndefault_provider = \"anthropic\"\n\n[sentry]\ndsn = \"\"\n",
+        )
+        .unwrap();
+        let logs = capture_logs(|| {
+            reload(&shared, Some(&path)).expect("reload succeeds despite sentry change");
+        });
+
+        assert!(shared.load().config.sentry.is_some());
+        assert!(logs.contains("[sentry] configuration changed"));
+        assert!(logs.contains("requires a restart"));
+    }
+
+    #[test]
+    fn sentry_changed_compares_presence_and_fields() {
+        let base = SentryConfig {
+            dsn: "https://public@o0.ingest.sentry.io/1".to_string(),
+            environment: Some("prod".to_string()),
+            metrics: false,
+        };
+        // Same values ⇒ unchanged; presence changes and field changes ⇒ changed.
+        assert!(!sentry_changed(None, None));
+        assert!(!sentry_changed(Some(&base), Some(&base.clone())));
+        assert!(sentry_changed(None, Some(&base)));
+        assert!(sentry_changed(Some(&base), None));
+
+        let other_dsn = SentryConfig {
+            dsn: "https://public@o0.ingest.sentry.io/2".to_string(),
+            ..base.clone()
+        };
+        assert!(sentry_changed(Some(&base), Some(&other_dsn)));
+        let other_env = SentryConfig {
+            environment: None,
+            ..base.clone()
+        };
+        assert!(sentry_changed(Some(&base), Some(&other_env)));
+        let other_metrics = SentryConfig {
+            metrics: true,
+            ..base.clone()
+        };
+        assert!(sentry_changed(Some(&base), Some(&other_metrics)));
+    }
+
+    #[test]
+    fn event_touches_path_matches_file_and_ignores_siblings() {
+        let dir = std::path::Path::new("/etc/shunt");
+        let config = dir.join("shunt.toml");
+
+        // Exact path match.
+        let exact = notify::Event::new(notify::EventKind::Any).add_path(config.clone());
+        assert!(event_touches_path(&exact, &config));
+
+        // Same filename under a different directory (atomic-rename / ConfigMap
+        // symlink swap surfaces the final component).
+        let by_name =
+            notify::Event::new(notify::EventKind::Any).add_path(dir.join("..data/shunt.toml"));
+        assert!(event_touches_path(&by_name, &config));
+
+        // An unrelated sibling in the watched directory must be ignored.
+        let sibling = notify::Event::new(notify::EventKind::Any).add_path(dir.join("other.toml"));
+        assert!(!event_touches_path(&sibling, &config));
+    }
+
+    #[test]
+    fn from_config_rejects_invalid_config() {
+        // default_provider pointing at an unknown provider fails validation, so
+        // building runtime state from it errors rather than swapping in bad state.
+        let mut config = Config::default();
+        config.server.default_provider = "nope".to_string();
+        // `RuntimeState` is not `Debug`, so match rather than `expect_err`.
+        let error = match RuntimeState::from_config(config) {
+            Ok(_) => panic!("invalid config must fail"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("unknown provider: nope"));
+    }
+
+    #[tokio::test]
+    async fn file_watch_task_hot_reloads_on_file_change() {
+        let dir = temp_dir("watch");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        std::fs::write(&path, "[server]\ndefault_provider = \"anthropic\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+        assert_eq!(shared.load().config.server.default_provider, "anthropic");
+
+        // Start the watchers (SIGHUP + file watch) against the real file, then
+        // change the file and wait for the debounced watcher to hot-swap it.
+        spawn_reload_watchers(shared.clone(), Some(path.clone())).await;
+
+        std::fs::write(&path, "[server]\ndefault_provider = \"openai\"\n").unwrap();
+
+        // Poll for the reload rather than sleeping a fixed time: filesystem
+        // notifications and the debounce window make timing non-deterministic.
+        let mut reloaded = false;
+        for _ in 0..80 {
+            if shared.load().config.server.default_provider == "openai" {
+                reloaded = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(
+            reloaded,
+            "file watcher should have hot-reloaded the changed config"
+        );
     }
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -115,6 +115,27 @@ pub async fn spawn_reload_watchers(shared: SharedState, path: Option<std::path::
     }
 }
 
+/// Run a [`reload`] on the blocking thread pool so its synchronous file I/O
+/// (`Config::load` reads and parses the file) never stalls an async worker: a
+/// slow or network-mounted config could otherwise pause request handling on the
+/// shared runtime. Logs `failure_context` on a reload error, and separately if
+/// the blocking task itself panics.
+async fn reload_off_thread(
+    shared: &SharedState,
+    path: Option<&std::path::Path>,
+    failure_context: &'static str,
+) {
+    let shared = shared.clone();
+    let path = path.map(std::path::Path::to_path_buf);
+    match tokio::task::spawn_blocking(move || reload(&shared, path.as_deref())).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::error!(%error, "{failure_context}"),
+        Err(join_error) => {
+            tracing::error!(%join_error, "reload task panicked; keeping the running configuration")
+        }
+    }
+}
+
 /// Reload on each `SIGHUP` (`kill -HUP <pid>`). Unix-only; on other platforms
 /// SIGHUP does not exist and only the file watcher drives reloads.
 #[cfg(unix)]
@@ -131,9 +152,12 @@ fn spawn_sighup_task(shared: SharedState, path: Option<std::path::PathBuf>) {
     tokio::spawn(async move {
         while signal.recv().await.is_some() {
             tracing::info!("received SIGHUP, reloading configuration");
-            if let Err(error) = reload(&shared, path.as_deref()) {
-                tracing::error!(%error, "SIGHUP reload failed; keeping the running configuration");
-            }
+            reload_off_thread(
+                &shared,
+                path.as_deref(),
+                "SIGHUP reload failed; keeping the running configuration",
+            )
+            .await;
         }
     });
 }
@@ -212,9 +236,12 @@ fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
                 }
             }
             tracing::info!("detected config file change, reloading configuration");
-            if let Err(error) = reload(&shared, Some(path.as_path())) {
-                tracing::error!(%error, "config file reload failed; keeping the running configuration");
-            }
+            reload_off_thread(
+                &shared,
+                Some(path.as_path()),
+                "config file reload failed; keeping the running configuration",
+            )
+            .await;
         }
     });
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1,0 +1,367 @@
+//! Hot configuration reload for a long-running shared gateway.
+//!
+//! The live config is held behind an [`arc_swap::ArcSwap`] so a reload swaps in
+//! a new [`RuntimeState`] atomically without locking readers. Two triggers call
+//! [`reload`]: a `SIGHUP` signal (`kill -HUP <pid>`) and automatic detection of
+//! config-file changes (a `notify` watcher on the file's parent directory).
+//!
+//! Reload is fail-safe: [`reload`] loads and validates the new config in full
+//! before swapping, and on any error it returns without touching the live state,
+//! so an invalid edit never takes the process down or leaves it running open.
+//! Each request snapshots the live state on entry (see `AppState::refreshed`),
+//! so an in-flight request never sees config change underneath it.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use crate::{
+    auth::inbound::InboundAuth,
+    config::{Config, ConfigError, SentryConfig},
+};
+
+/// The hot-swappable runtime state derived from a loaded config: the config
+/// itself plus anything resolved from it that a request reads on every call.
+pub struct RuntimeState {
+    pub config: Arc<Config>,
+    /// Inbound client-token auth (`[server.auth]`), re-resolved on every reload
+    /// so token/header edits take effect. `None` ⇒ open (no inbound auth).
+    pub inbound_auth: Option<Arc<InboundAuth>>,
+}
+
+/// Shared handle to the live [`RuntimeState`]. Cloning is cheap (an `Arc`); a
+/// reload replaces the pointed-to state with [`ArcSwap::store`].
+pub type SharedState = Arc<ArcSwap<RuntimeState>>;
+
+impl RuntimeState {
+    /// Build runtime state from an already-loaded config. `Config::load`
+    /// validates, but a config constructed by other means might not have, so
+    /// validate defensively before resolving auth.
+    pub fn from_config(config: Config) -> Result<Self, ConfigError> {
+        let config = config.validate()?;
+        let inbound_auth = config.resolve_inbound_auth()?;
+        Ok(Self {
+            config: Arc::new(config),
+            inbound_auth,
+        })
+    }
+}
+
+/// Reload the config from `path` and, only on full success, atomically swap it
+/// into `shared`. On any error the currently-live config stays untouched and the
+/// error is returned for the caller to log — the gateway keeps running the last
+/// good config rather than going down or running open.
+///
+/// Fields that cannot be hot-applied (`server.bind`, `[sentry]`) are compared
+/// against the live config and a `warn!` is logged when they change; the new
+/// values are accepted into the swapped config but only take effect on restart.
+pub fn reload(shared: &SharedState, path: Option<&std::path::Path>) -> Result<(), ConfigError> {
+    // Load + validate the candidate before touching the live state.
+    let new_config = Config::load(path)?;
+    let previous = shared.load();
+    warn_on_restart_only_changes(&previous.config, &new_config);
+    let new_state = RuntimeState::from_config(new_config)?;
+    shared.store(Arc::new(new_state));
+    tracing::info!("configuration reloaded successfully");
+    Ok(())
+}
+
+/// Warn about fields that a hot reload cannot apply, so an operator relying on
+/// the change is not misled into thinking it took effect.
+fn warn_on_restart_only_changes(previous: &Config, next: &Config) {
+    if previous.server.bind != next.server.bind {
+        tracing::warn!(
+            previous = %previous.server.bind,
+            next = %next.server.bind,
+            "server.bind changed but requires a restart to apply; the listener is already bound"
+        );
+    }
+    if sentry_changed(previous.sentry.as_ref(), next.sentry.as_ref()) {
+        tracing::warn!(
+            "[sentry] configuration changed but requires a restart to apply; the Sentry client is initialized once at startup"
+        );
+    }
+}
+
+/// Structural comparison of two optional `[sentry]` sections. `SentryConfig`
+/// does not derive `PartialEq`, so compare the fields that matter.
+fn sentry_changed(previous: Option<&SentryConfig>, next: Option<&SentryConfig>) -> bool {
+    match (previous, next) {
+        (None, None) => false,
+        (Some(a), Some(b)) => {
+            a.dsn != b.dsn || a.environment != b.environment || a.metrics != b.metrics
+        }
+        _ => true,
+    }
+}
+
+/// Debounce window: filesystem writes arrive in bursts (editors write, rename,
+/// chmod; Kubernetes swaps a ConfigMap symlink), so a relevant event starts a
+/// quiet timer that later events restart, and the reload fires once the writes
+/// settle. Long enough to coalesce a burst, short enough to feel immediate.
+const DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Spawn the reload triggers as background tasks and return. On Unix a `SIGHUP`
+/// handler reloads on each signal. When `path` is set, a `notify` watcher on the
+/// config file's parent directory reloads (debounced) on file changes. Watcher
+/// setup failures are logged and skipped — the gateway keeps running (and SIGHUP
+/// still works) rather than aborting.
+pub async fn spawn_reload_watchers(shared: SharedState, path: Option<std::path::PathBuf>) {
+    #[cfg(unix)]
+    spawn_sighup_task(shared.clone(), path.clone());
+
+    if let Some(path) = path {
+        spawn_file_watch_task(shared, path);
+    }
+}
+
+/// Reload on each `SIGHUP` (`kill -HUP <pid>`). Unix-only; on other platforms
+/// SIGHUP does not exist and only the file watcher drives reloads.
+#[cfg(unix)]
+fn spawn_sighup_task(shared: SharedState, path: Option<std::path::PathBuf>) {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut signal = match signal(SignalKind::hangup()) {
+        Ok(signal) => signal,
+        Err(error) => {
+            tracing::warn!(%error, "failed to install SIGHUP handler; reload-on-signal disabled");
+            return;
+        }
+    };
+    tokio::spawn(async move {
+        while signal.recv().await.is_some() {
+            tracing::info!("received SIGHUP, reloading configuration");
+            if let Err(error) = reload(&shared, path.as_deref()) {
+                tracing::error!(%error, "SIGHUP reload failed; keeping the running configuration");
+            }
+        }
+    });
+}
+
+/// Watch the config file's parent directory (not the file inode) so atomic-rename
+/// saves and Kubernetes ConfigMap symlink swaps — which replace the file rather
+/// than write in place — are still detected. Events are bridged from `notify`'s
+/// std channel onto a tokio channel and debounced before each reload.
+fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
+    use notify::{RecursiveMode, Watcher};
+
+    let watch_dir = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
+    // notify calls the handler on its own thread with std types; forward raw
+    // events onto a tokio channel so the async task can debounce them.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<notify::Event>();
+    let mut watcher = match notify::recommended_watcher(
+        move |result: notify::Result<notify::Event>| {
+            if let Ok(event) = result {
+                // A closed receiver just means the server is shutting down.
+                let _ = tx.send(event);
+            }
+        },
+    ) {
+        Ok(watcher) => watcher,
+        Err(error) => {
+            tracing::warn!(%error, "failed to create config file watcher; auto-reload on file change disabled (SIGHUP still works)");
+            return;
+        }
+    };
+    if let Err(error) = watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+        tracing::warn!(%error, dir = %watch_dir.display(), "failed to watch config directory; auto-reload on file change disabled (SIGHUP still works)");
+        return;
+    }
+    tracing::info!(dir = %watch_dir.display(), "watching config directory for changes");
+
+    tokio::spawn(async move {
+        // Keep the watcher alive for the lifetime of this task; dropping it stops
+        // event delivery.
+        let _watcher = watcher;
+        loop {
+            // Block until an event that touches the config file arrives.
+            let Some(event) = rx.recv().await else {
+                break;
+            };
+            if !event_touches_path(&event, &path) {
+                continue;
+            }
+            // Debounce: keep draining until the writes go quiet, coalescing a
+            // burst of events into a single reload.
+            loop {
+                match tokio::time::timeout(DEBOUNCE, rx.recv()).await {
+                    Ok(Some(_)) => continue, // more events; keep waiting for quiet
+                    Ok(None) => break,       // channel closed; reload once below
+                    Err(_) => break,         // quiet period elapsed
+                }
+            }
+            tracing::info!("detected config file change, reloading configuration");
+            if let Err(error) = reload(&shared, Some(path.as_path())) {
+                tracing::error!(%error, "config file reload failed; keeping the running configuration");
+            }
+        }
+    });
+}
+
+/// Whether a filesystem event concerns the config file. Directory watching
+/// surfaces sibling files too, so filter by the config file's own path (matching
+/// its final component covers atomic renames whose event carries the temp path
+/// then the final path).
+fn event_touches_path(event: &notify::Event, path: &std::path::Path) -> bool {
+    let name = path.file_name();
+    event
+        .paths
+        .iter()
+        .any(|event_path| event_path == path || (name.is_some() && event_path.file_name() == name))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arc_swap::ArcSwap;
+
+    use super::{reload, RuntimeState, SharedState};
+    use crate::config::Config;
+
+    /// Unique temp dir per test so concurrent `cargo test` runs never collide.
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "shunt-reload-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    struct TempDirGuard(std::path::PathBuf);
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn shared_from(config: Config) -> SharedState {
+        Arc::new(ArcSwap::from_pointee(
+            RuntimeState::from_config(config).expect("valid initial config"),
+        ))
+    }
+
+    /// Capture tracing output for a closure, so warn-path assertions can inspect
+    /// the emitted logs (mirrors config.rs's log-capture test).
+    fn capture_logs(run: impl FnOnce()) -> String {
+        use std::io::{self, Write};
+        use std::sync::Mutex;
+
+        struct BufferWriter {
+            buffer: Arc<Mutex<Vec<u8>>>,
+        }
+        impl Write for BufferWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.buffer.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(move || BufferWriter {
+                buffer: Arc::clone(&writer_output),
+            })
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        tracing::subscriber::with_default(subscriber, run);
+        let bytes = output.lock().unwrap().clone();
+        String::from_utf8(bytes).unwrap()
+    }
+
+    #[test]
+    fn reload_swaps_in_a_valid_new_config() {
+        let dir = temp_dir("valid");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        // Start from a config whose default_provider is anthropic.
+        std::fs::write(&path, "[server]\ndefault_provider = \"anthropic\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+        assert_eq!(shared.load().config.server.default_provider, "anthropic");
+
+        // Rewrite the file and reload; the live state must reflect the change.
+        std::fs::write(&path, "[server]\ndefault_provider = \"openai\"\n").unwrap();
+        reload(&shared, Some(&path)).expect("valid reload succeeds");
+        assert_eq!(shared.load().config.server.default_provider, "openai");
+    }
+
+    #[test]
+    fn reload_with_invalid_config_keeps_previous_state() {
+        let dir = temp_dir("invalid");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        std::fs::write(&path, "[server]\ndefault_provider = \"anthropic\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+
+        // default_provider referencing an unknown provider fails validation.
+        std::fs::write(&path, "[server]\ndefault_provider = \"nonexistent\"\n").unwrap();
+        let error = reload(&shared, Some(&path)).expect_err("invalid reload must fail");
+        assert!(error.to_string().contains("unknown provider: nonexistent"));
+        // Fail-safe: the previously-live config is untouched.
+        assert_eq!(shared.load().config.server.default_provider, "anthropic");
+    }
+
+    #[test]
+    fn reload_reresolves_inbound_auth() {
+        let dir = temp_dir("auth");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+        let env = format!("SHUNT_RELOAD_TEST_TOKENS_{}", std::process::id());
+
+        // Start with no inbound auth.
+        std::fs::write(&path, "[server]\ndefault_provider = \"anthropic\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+        assert!(shared.load().inbound_auth.is_none());
+
+        // Add [server.auth] pointing at an env var holding a valid token.
+        std::env::set_var(&env, "alice:tok-a");
+        std::fs::write(
+            &path,
+            format!(
+                "[server]\ndefault_provider = \"anthropic\"\n\n[server.auth]\ntokens_env = \"{env}\"\n"
+            ),
+        )
+        .unwrap();
+        reload(&shared, Some(&path)).expect("reload with auth succeeds");
+        assert!(shared.load().inbound_auth.is_some());
+        std::env::remove_var(&env);
+    }
+
+    #[test]
+    fn bind_change_warns_and_reload_still_succeeds() {
+        let dir = temp_dir("bind");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        std::fs::write(&path, "[server]\nbind = \"127.0.0.1:3001\"\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+
+        std::fs::write(&path, "[server]\nbind = \"127.0.0.1:4002\"\n").unwrap();
+        let logs = capture_logs(|| {
+            reload(&shared, Some(&path)).expect("reload succeeds despite bind change");
+        });
+
+        // The reload succeeded and the new bind is stored in the config...
+        assert_eq!(shared.load().config.server.bind, "127.0.0.1:4002");
+        // ...but the operator was warned it requires a restart to take effect.
+        assert!(logs.contains("server.bind changed"));
+        assert!(logs.contains("requires a restart"));
+    }
+}

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -160,12 +160,21 @@ fn spawn_file_watch_task(shared: SharedState, path: std::path::PathBuf) {
     let watch_path = path.clone();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<notify::Event>();
     let mut watcher = match notify::recommended_watcher(
-        move |result: notify::Result<notify::Event>| {
-            if let Ok(event) = result {
-                if event_touches_path(&event, &watch_path) {
+        move |result: notify::Result<notify::Event>| match result {
+            Ok(event) => {
+                // Skip access (read/open) events: a reload reads the config file,
+                // and that read fires an access event on the watched directory —
+                // forwarding it would retrigger reload on our own read, a loop.
+                // Only forward real changes that touch the config file.
+                if !event.kind.is_access() && event_touches_path(&event, &watch_path) {
                     // A closed receiver just means the server is shutting down.
                     let _ = tx.send(event);
                 }
+            }
+            // Surface watcher errors rather than silently degrading: the watch may
+            // be impaired (e.g. inotify queue overflow) and the operator should know.
+            Err(error) => {
+                tracing::warn!(%error, "config file watcher error");
             }
         },
     ) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,41 +10,69 @@ use crate::{
     auth::inbound::InboundAuth,
     config::{Config, ConfigError},
     discovery, proxy,
+    reload::{RuntimeState, SharedState},
 };
 
 #[derive(Clone)]
 pub struct AppState {
-    pub config: Config,
+    /// Per-request config snapshot (see [`AppState::refreshed`]).
+    pub config: Arc<Config>,
     pub http_client: reqwest::Client,
-    /// Inbound client-token auth, resolved once at startup (None ⇒ open).
+    /// Inbound client-token auth snapshot for this request (None ⇒ open).
     pub inbound_auth: Option<Arc<InboundAuth>>,
+    /// The live, hot-swappable runtime state a reload updates. Private so the
+    /// only way in is a snapshot method that keeps `config`/`inbound_auth`
+    /// consistent with it.
+    shared: SharedState,
 }
 
-pub fn build_router(config: Config) -> Result<Router, ConfigError> {
-    let inbound_auth = config
-        .server
-        .auth
-        .as_ref()
-        .map(|auth| auth.resolve())
-        .transpose()?
-        .map(Arc::new);
-    let state = AppState {
-        config,
-        http_client: reqwest::Client::new(),
-        inbound_auth,
-    };
+impl AppState {
+    /// Build state from a config, owning a fresh shared store. Used by tests and
+    /// by callers that do not thread an external [`SharedState`].
+    pub fn new(config: Config, http_client: reqwest::Client) -> Result<Self, ConfigError> {
+        let runtime = RuntimeState::from_config(config)?;
+        let shared: SharedState = Arc::new(arc_swap::ArcSwap::from_pointee(runtime));
+        Ok(Self::from_shared(shared, http_client))
+    }
+
+    /// Snapshot the current runtime state from an existing shared store.
+    pub fn from_shared(shared: SharedState, http_client: reqwest::Client) -> Self {
+        let current = shared.load();
+        Self {
+            config: current.config.clone(),
+            inbound_auth: current.inbound_auth.clone(),
+            http_client,
+            shared,
+        }
+    }
+
+    /// Re-snapshot the live shared state into a new `AppState`, so a request
+    /// entry picks up the latest reloaded config while holding one stable
+    /// snapshot for the whole request. Cheap: clones `Arc`s and the client.
+    pub(crate) fn refreshed(&self) -> Self {
+        Self::from_shared(self.shared.clone(), self.http_client.clone())
+    }
+}
+
+/// Build the router and return it alongside the [`SharedState`] it reads, so the
+/// caller can spawn reload watchers that hot-swap the same store.
+pub fn build_router(config: Config) -> Result<(Router, SharedState), ConfigError> {
+    let runtime = RuntimeState::from_config(config)?;
+    let shared: SharedState = Arc::new(arc_swap::ArcSwap::from_pointee(runtime));
+    let state = AppState::from_shared(shared.clone(), reqwest::Client::new());
 
     // `/` and `/health` stay unauthenticated even when `[server.auth]` is
     // configured (healthcheck tools rarely carry tokens); they must never
     // expose config, credentials, or upstream details — only version, status,
     // and the already-public endpoint list.
-    Ok(Router::new()
+    let router = Router::new()
         .route("/", get(root_index))
         .route("/health", get(health))
         .route("/v1/models", get(discovery::get))
         .route("/v1/messages", post(proxy::post))
         .route("/v1/messages/count_tokens", post(proxy::post))
-        .with_state(state))
+        .with_state(state);
+    Ok((router, shared))
 }
 
 /// Human-facing landing page; axum also serves HEAD `/` from this handler,

--- a/tests/inbound_auth.rs
+++ b/tests/inbound_auth.rs
@@ -81,7 +81,7 @@ async fn start_gateway_with(mut config: Config) -> TestGateway {
         .await
         .unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();
-    let app = server::build_router(config).unwrap();
+    let (app, _shared) = server::build_router(config).unwrap();
     let task = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -52,7 +52,7 @@ async fn start_gateway_with(mut config: Config) -> TestGateway {
         .await
         .unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();
-    let app = server::build_router(config).unwrap();
+    let (app, _shared) = server::build_router(config).unwrap();
     let task = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });


### PR DESCRIPTION
## Summary

Adds hot-reload of the config file while the gateway is running, triggered two ways:

- **SIGHUP** (`kill -HUP <pid>`, Unix-only)
- **Automatic file-change detection** — a `notify` watcher on the config file's *parent* directory (so atomic-rename saves and Kubernetes ConfigMap symlink swaps are caught), debounced 400ms

The live config is held behind `arc-swap::ArcSwap<RuntimeState>`. Each request snapshots the config at entry (via `AppState::refreshed`) so an in-flight request never sees the config change underneath it. Reload is fail-safe: an invalid config keeps the currently-running config and logs an error — it never takes the process down or leaves it in a half-applied state.

`server.bind` and `[sentry]` are accepted into the reloaded config but only take effect on restart; each logs a `warn` when changed via reload so the operator knows a restart is needed.

## Milestone / spec

Not tied to an existing M-numbered milestone doc. Adds a new operator doc, `docs/config-reload.md`, describing the reload behavior, triggers, and restart-required fields.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it — N/A, no existing spec covers config reload; new operator doc added instead
- [ ] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes in this PR

## Notes for reviewers

- New files: `src/reload.rs` (module + 4 unit tests), `docs/config-reload.md` (operator doc). New deps: `arc-swap`, `notify`.
- Verified via `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features --workspace` (89 lib tests incl. 4 new reload tests + 56 integration tests) — all pass.
- Additionally smoke-tested live against a running server (`/v1/models`): file-watch reload, SIGHUP reload, fail-safe behavior on an invalid config, recovery after fixing the config, and the `server.bind`/`[sentry]` restart-required warn on change.
- No linked issue for this branch (not created via `gh issue develop`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hot-reload for the gateway config via SIGHUP and file-change detection without blocking the async runtime. Keeps in-flight requests stable and rejects invalid configs; logs when changes require a restart.

- **New Features**
  - Reload on SIGHUP (Unix): `kill -HUP <pid>`.
  - Auto-reload on file changes by watching the config file’s parent dir with a 400 ms debounce; filters to the config file (incl. atomic renames and Kubernetes `..data` swaps), ignores access/open events to prevent reload loops, logs watcher errors, and falls back to SIGHUP-only if watcher init fails.
  - Live config behind `arc-swap`; each request snapshots via `AppState::refreshed()` for consistency.
  - Fail-safe reloads: invalid configs are logged and the current config remains active.
  - Warn when `server.bind` or `[sentry]` change; they require a restart to take effect.
  - Reload I/O runs off the async runtime via `tokio::task::spawn_blocking` to avoid stalling request handling.
  - Added `docs/config-reload.md` with operator guidance.

- **Dependencies**
  - Added `arc-swap`.
  - Added `notify`.

<sup>Written for commit f9b378835157d3d5f363c6e25c4b9a24ac37d8df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

