### PR TITLE
feat: strip [1m] context hint + document codex-path context accounting

### DIFF
--- a/.claude/agent-memory/github-pr-manager/MEMORY.md
+++ b/.claude/agent-memory/github-pr-manager/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [shunt PR template and quirks](reference_shunt-pr-template-and-quirks.md) — pleaseai/shunt's `.github/PULL_REQUEST_TEMPLATE.md` checklist + `gh please pr create` silent-success quirk (verify via plain `gh pr list`) + not a Graphite repo.

--- a/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
+++ b/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
@@ -1,0 +1,24 @@
+---
+name: shunt-pr-template-and-quirks
+description: pleaseai/shunt PR template location and a gh-please pr create display quirk (silent stdout on success)
+metadata:
+  type: reference
+---
+
+`pleaseai/shunt` has a single repo PR template at `.github/PULL_REQUEST_TEMPLATE.md`
+(Summary / Milestone-spec / Checklist / Notes for reviewers — no generic
+"Changes"/"Test Plan" sections, but a "Changes" subsection fits naturally
+under Summary). Checklist enforces `cargo build`/`test`/`clippy -D warnings`/
+`fmt --check`, 500-line source file cap, English-only, frozen `docs/` spec
+sync, and SHA-pinned GitHub Actions — run these locally before filling the
+checklist rather than checking boxes blind.
+
+`gh please pr create --repo <owner>/<repo> --draft ...` printed **no stdout at
+all** on a successful create (both title and body args accepted, empty
+output). Don't treat empty output as failure — verify with
+`gh pr list --head <branch> --repo <owner>/<repo>` (plain `gh`, not `gh
+please pr list`, which errored with exit 1 / a stray `--json` flag artifact
+in this environment) before assuming the create failed and retrying.
+
+pleaseai/shunt is not a Graphite repo (`detect-stack-tool.sh` prints nothing) —
+plain `gh please pr create` / `gh pr create` is the right tool, no `gt submit`.

--- a/.claude/agents/gpt-5.6-luna.md
+++ b/.claude/agents/gpt-5.6-luna.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-luna
+description: General-purpose agent that runs on GPT-5.6-Luna (routed through the shunt gateway to the ChatGPT/Codex subscription). Use when you want a task handled by GPT-5.6-Luna instead of the default Claude model.
+model: gpt-5.6-luna
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Luna.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.

--- a/.claude/agents/gpt-5.6-sol.md
+++ b/.claude/agents/gpt-5.6-sol.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-sol
+description: General-purpose agent that runs on GPT-5.6-Sol (routed through the shunt gateway to the ChatGPT/Codex subscription). Use when you want a task handled by GPT-5.6-Sol instead of the default Claude model.
+model: gpt-5.6-sol
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Sol.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.

--- a/.claude/agents/gpt-5.6-terra.md
+++ b/.claude/agents/gpt-5.6-terra.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-terra
+description: General-purpose agent that runs on GPT-5.6-Terra (routed through the shunt gateway to the ChatGPT/Codex subscription). Use when you want a task handled by GPT-5.6-Terra instead of the default Claude model.
+model: gpt-5.6-terra
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Terra.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.

--- a/docs/running.md
+++ b/docs/running.md
@@ -424,6 +424,23 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION="gpt-5.6-sol"
 Then pick it from `/model` in Claude Code. That id is what shunt routes on, so it must match a
 `[[routes]]`/`[[route_prefixes]]` rule in your config.
 
+**The two picker-exposure methods split cleanly on the `claude-`/`anthropic-` prefix — they don't
+overlap.** Discovery honors *only* `claude-`/`anthropic-` ids; `ANTHROPIC_CUSTOM_MODEL_OPTION` and
+the `CLAUDE_CODE_MAX_CONTEXT_TOKENS` window override apply *only* to ids that do **not** start with
+that prefix. The consequence: a `claude-…-via-codex` discovery alias is convenient (auto-listed,
+one-tap selectable) but its context window is **stuck at the 200k default** — the override can't
+reach a `claude-`-prefixed id (§5.8).
+
+| What | `claude-`/`anthropic-` id (discovery alias) | non-`claude-` id (e.g. `gpt-5.6-sol`) |
+| :-- | :-- | :-- |
+| `/v1/models` discovery → `/model` picker | ✅ auto-listed ("From gateway"), many models | ❌ dropped by Claude Code |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION` | ❌ not honored | ✅ adds to picker (**one id only**) |
+| `CLAUDE_CODE_MAX_CONTEXT_TOKENS` window | ❌ ignored → 200k default | ✅ applies → set the real window (e.g. 372k) |
+
+So choose by priority: the **discovery alias** for picker convenience across several models (accept
+the conservative 200k denominator), or a **non-`claude-` id via `ANTHROPIC_CUSTOM_MODEL_OPTION`** for
+an accurate window, one model at a time. (Subagents are a separate path — see below.)
+
 > **Model slugs:** the ChatGPT-account Codex backend **rejects** `gpt-*-codex` slugs (e.g.
 > `gpt-5.2-codex`) — it only accepts the account's live-entitled slugs. The authoritative catalog
 > of Codex slugs (and the reasoning levels each accepts) is openai/codex's
@@ -442,9 +459,20 @@ Then pick it from `/model` in Claude Code. That id is what shunt routes on, so i
 > openai/codex rust-v0.144.1**. If a future slug demands a newer client, bump the pinned
 > version in `src/adapters/responses.rs` (`CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`).
 
-Per-context selection also works via Claude Code's own knobs — a subagent's `model:`
-frontmatter, or `CLAUDE_CODE_SUBAGENT_MODEL` for all subagents — so you can divert only one
-agent while the main session stays on Claude.
+Per-context selection also works via Claude Code's own knobs — divert one agent to a mapped model
+while the main session stays on Claude:
+
+- **A named subagent's `model:` frontmatter** (`.claude/agents/<name>.md`) is the only way to put a
+  subagent on a `gpt-*` id: that field accepts any string, whereas the Agent/Task tool's `model`
+  parameter is restricted to the built-in aliases (`opus`/`sonnet`/`haiku`/`fable`) and cannot take
+  a gateway id. Spawn the agent by its type **without** a `model` override — the tool parameter
+  outranks frontmatter (resolution order: `CLAUDE_CODE_SUBAGENT_MODEL` > tool `model` > frontmatter
+  > `inherit`), so passing one would shadow the mapped model.
+- **`CLAUDE_CODE_SUBAGENT_MODEL`** forces every subagent onto one model (global).
+
+The context window follows the model automatically: `CLAUDE_CODE_MAX_CONTEXT_TOKENS` (§5.8) is keyed
+on the id, so one global value sizes the mapped subagent (e.g. 372k) while the Claude main keeps its
+own — no per-subagent env is needed, and the same overflow/compact behavior (§5.8) applies.
 
 ### 5.5 (Optional) Model discovery
 
@@ -559,14 +587,28 @@ export CLAUDE_CODE_MAX_CONTEXT_TOKENS=372000
 
 Caveats: it is **global** — one value for every non-`claude-` model in the session, so it can't be
 set per-model when routing models with different window sizes — and setting it **larger than the
-real upstream window delays auto-compact past the point where the upstream rejects the request**
-with a context-length error, so match it to the smallest real window among your mapped models.
-Claude passthrough models (`claude-*` ids) ignore it and keep their exact built-in sizes. (With
-`DISABLE_COMPACT` also set, the value applies unconditionally — `claude-*` ids included.)
+real upstream window** means auto-compact won't trigger in time, so requests overflow the real
+limit. On the streaming path Claude Code actually uses, the ChatGPT/Codex backend surfaces a
+`prompt is too long` error mid-stream, which shunt's context-overflow rewrite normalizes
+(`context_overflow_message`, `src/model/responses.rs`) and Claude Code auto-compacts + retries on —
+so the session recovers, but every overflow round-trip
+is wasted latency. Match it to the **smallest real window** among your mapped models to avoid the
+churn. (Live-verified for `gpt-5.6-sol`: 365k tokens answers normally, 372k+ overflows — the
+boundary is its `models.json` `context_window` of 372000; `gpt-5.5` is 272000. A *non*-streaming
+request instead degrades to an empty `200` with `input_tokens: 0`, but the main loop always
+streams.) Claude passthrough models
+(`claude-*` ids) ignore it and keep their exact built-in sizes. (With `DISABLE_COMPACT` also set,
+the value applies unconditionally — `claude-*` ids included.) This same `claude-` gate is why a
+**discovery alias** (which must begin with `claude-`, §5.4) can't take this override — its window
+stays pinned at the 200k default: safe (auto-compact fires early) but not raisable to the model's
+real size without `DISABLE_COMPACT`. Use a non-`claude-` id when you need the accurate window.
 
 The other client-side lever is the `[1m]` model-id suffix, which forces a **1M** window — useful
 for a genuinely 1M-context model, but misleading (under-reporting) for a smaller one, so avoid it
-unless the upstream really has that window.
+unless the upstream really has that window. shunt strips a trailing `[1m]` from the model id before
+route matching and before forwarding upstream (`routing.rs`), so `gpt-5.6-sol[1m]` (or a
+`claude-…-via-codex[1m]` discovery alias) still routes correctly and the provider never sees the
+suffix — the hint stays purely client-side.
 
 | Field | Mapped (`responses`) model | Claude passthrough |
 | :-- | :-- | :-- |

--- a/site/src/content/docs/guides/connect-claude-code.md
+++ b/site/src/content/docs/guides/connect-claude-code.md
@@ -83,9 +83,19 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION="gpt-5.6-sol"
 
 Then pick it from `/model` in Claude Code. That id is what shunt routes on, so it must match a `[[routes]]`/`[[route_prefixes]]` rule in your config.
 
+The two picker-exposure methods split cleanly on the `claude-`/`anthropic-` prefix — they don't overlap. Discovery honors *only* `claude-`/`anthropic-` ids; `ANTHROPIC_CUSTOM_MODEL_OPTION` and the `CLAUDE_CODE_MAX_CONTEXT_TOKENS` window override apply *only* to ids that do **not** start with that prefix:
+
+| What | `claude-`/`anthropic-` id (discovery alias) | non-`claude-` id (e.g. `gpt-5.6-sol`) |
+| :-- | :-- | :-- |
+| [`/v1/models` discovery](/guides/model-discovery/) → `/model` picker | ✅ auto-listed ("From gateway"), many models | ❌ dropped by Claude Code |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION` | ❌ not honored | ✅ adds to picker (**one id only**) |
+| `CLAUDE_CODE_MAX_CONTEXT_TOKENS` window | ❌ ignored → 200k default | ✅ applies → set the real window |
+
+So a `claude-…-via-codex` discovery alias is convenient (auto-listed, one-tap) but its context window is **stuck at the 200k default** — the override can't reach a `claude-`-prefixed id ([Effort & Context](/guides/effort-and-context/)). Pick the **discovery alias** for picker convenience across several models (accept the 200k denominator), or a **non-`claude-` id via `ANTHROPIC_CUSTOM_MODEL_OPTION`** for an accurate window, one model at a time.
+
 ### Per-agent diversion
 
-Per-context selection works via Claude Code's own knobs — a subagent's `model:` frontmatter, or `CLAUDE_CODE_SUBAGENT_MODEL` for all subagents — so you can divert only one agent while the main session stays on Claude:
+Per-context selection works via Claude Code's own knobs — divert one agent to a mapped model while the main session stays on Claude:
 
 ```yaml
 # .claude/agents/researcher.md
@@ -94,6 +104,8 @@ name: researcher
 model: gpt-5.6-sol   # this agent's inference is diverted; the main session stays on Claude
 ---
 ```
+
+A named subagent's `model:` frontmatter is the **only** way to put a subagent on a `gpt-*` id: that field takes any string, whereas the Agent/Task tool's `model` parameter is restricted to the built-in aliases (`opus`/`sonnet`/`haiku`/`fable`) and can't take a gateway id. Spawn the agent by its type **without** a `model` override — the tool parameter outranks frontmatter (`CLAUDE_CODE_SUBAGENT_MODEL` > tool `model` > frontmatter > `inherit`), so passing one would shadow the mapped model. `CLAUDE_CODE_SUBAGENT_MODEL` forces every subagent onto one model. The window follows the model id automatically, so one global `CLAUDE_CODE_MAX_CONTEXT_TOKENS` sizes the mapped subagent while the Claude main keeps its own.
 
 ## 5. Verify
 

--- a/site/src/content/docs/guides/effort-and-context.md
+++ b/site/src/content/docs/guides/effort-and-context.md
@@ -47,11 +47,15 @@ The 200k default can be overridden client-side with `CLAUDE_CODE_MAX_CONTEXT_TOK
 export CLAUDE_CODE_MAX_CONTEXT_TOKENS=372000
 ```
 
+Because the override applies **only** to ids that don't start with `claude-`, a [discovery alias](/guides/model-discovery/) (which *must* begin with `claude-`) can't take it — its window stays pinned at the 200k default. Convenient in the picker, but use a non-`claude-` id (via `ANTHROPIC_CUSTOM_MODEL_OPTION`) when you need the accurate window.
+
 :::caution
-The value is **global** — one value for every non-`claude-` model in the session — and setting it larger than the real upstream window delays auto-compact until the upstream rejects the request with a context-length error. shunt [rewrites that error](#context-overflow-recovery) so Claude Code compacts and retries automatically, but each overflow round-trip is wasted latency — match the value to the smallest real window among your mapped models.
+The value is **global** — one value for every non-`claude-` model in the session — and setting it larger than the real upstream window delays auto-compact until requests overflow the real limit. shunt [rewrites that overflow error](#context-overflow-recovery) so Claude Code compacts and retries automatically, but each overflow round-trip is wasted latency — match the value to the smallest real window among your mapped models.
+
+Live-verified boundary for `gpt-5.6-sol` (real window 372k): 365k input tokens answer normally; at 372k+ the streaming request returns a `prompt is too long` error that triggers auto-compaction (`gpt-5.5` is 272000). A *non*-streaming request instead degrades to an empty `200` with `input_tokens: 0`, but Claude Code's main loop always streams.
 :::
 
-The other client-side lever is the `[1m]` model-id suffix, which forces a 1M window — only use it when the upstream really has that window.
+The other client-side lever is the `[1m]` model-id suffix, which forces a 1M window — only use it when the upstream really has that window. (shunt strips a trailing `[1m]` before route matching and forwarding, so the hint stays purely client-side and the provider never sees it.)
 
 | Field | Mapped (`responses`) model | Claude passthrough |
 | :-- | :-- | :-- |

--- a/src/adapters/anthropic.rs
+++ b/src/adapters/anthropic.rs
@@ -40,6 +40,7 @@ async fn forward(
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     let credential = resolve_credential(&state.config, &route, &state.http_client).await?;
     let request_headers = outbound_headers(headers, &credential);
+    let body = normalize_upstream_model(body, &route.upstream_model);
     let upstream = state
         .http_client
         .post(upstream_url(&state, &route, uri))
@@ -79,6 +80,41 @@ async fn forward(
         .expect("response builder uses valid upstream status and headers")
         .into_response();
     Ok((status, response))
+}
+
+/// Rewrite the outbound request body's `model` to the routed `upstream_model`
+/// when they differ. The passthrough adapter forwards the client body verbatim,
+/// so without this two things leak to the provider: a `[1m]` context-window hint
+/// (which `routing::strip_context_window_hint` removes from the routing key but
+/// not from the body — and api.anthropic.com does not recognize a `[1m]`-suffixed
+/// model id), and an explicit `[[routes]]` `upstream_model` remap (otherwise
+/// ignored for an Anthropic-provider route). The common case — body model already
+/// equal to `upstream_model` — re-serializes nothing and forwards the original
+/// bytes untouched, preserving byte-for-byte passthrough.
+fn normalize_upstream_model(body: Vec<u8>, upstream_model: &str) -> Vec<u8> {
+    #[derive(serde::Deserialize)]
+    struct ModelView {
+        model: String,
+    }
+
+    // Cheap guard: peek only the `model` field. A body that isn't JSON, has no
+    // `model`, or whose model already matches is forwarded unchanged.
+    match serde_json::from_slice::<ModelView>(&body) {
+        Ok(view) if view.model != upstream_model => {
+            let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
+                return body;
+            };
+            let Some(object) = value.as_object_mut() else {
+                return body;
+            };
+            object.insert(
+                "model".to_string(),
+                serde_json::Value::String(upstream_model.to_string()),
+            );
+            serde_json::to_vec(&value).unwrap_or(body)
+        }
+        _ => body,
+    }
 }
 
 /// Build the headers sent upstream. For a passthrough provider (api.anthropic.com)
@@ -134,7 +170,7 @@ mod tests {
 
     use crate::config::ApiKeyHeader;
 
-    use super::{outbound_headers, Credential};
+    use super::{normalize_upstream_model, outbound_headers, Credential};
 
     fn client_headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
@@ -176,5 +212,33 @@ mod tests {
         );
         assert_eq!(out.get("x-api-key").unwrap(), "provider-key");
         assert!(out.get("authorization").is_none());
+    }
+
+    #[test]
+    fn normalize_rewrites_model_when_upstream_differs() {
+        // A `[1m]` context-window hint must not reach the provider verbatim.
+        let body = br#"{"model":"claude-sonnet-4-6[1m]","max_tokens":1}"#.to_vec();
+        let out = normalize_upstream_model(body, "claude-sonnet-4-6");
+        let value: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(value["model"], "claude-sonnet-4-6");
+        // The rest of the body survives the rewrite.
+        assert_eq!(value["max_tokens"], 1);
+    }
+
+    #[test]
+    fn normalize_leaves_body_untouched_when_model_matches() {
+        // Common case: byte-for-byte passthrough, no re-serialization.
+        let body = br#"{"model":"claude-sonnet-4-6","max_tokens":1}"#.to_vec();
+        let original = body.clone();
+        let out = normalize_upstream_model(body, "claude-sonnet-4-6");
+        assert_eq!(out, original);
+    }
+
+    #[test]
+    fn normalize_leaves_non_json_body_untouched() {
+        let body = b"not json".to_vec();
+        let original = body.clone();
+        let out = normalize_upstream_model(body, "claude-sonnet-4-6");
+        assert_eq!(out, original);
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -52,21 +52,13 @@ pub fn resolve(config: &Config, body: &[u8]) -> Result<Route, ShuntError> {
 /// providers (Codex/OpenAI) reject a `gpt-5.6-sol[1m]` slug, and an explicit
 /// `[[routes]]` entry would never match it. Strip a single trailing `[1m]`
 /// (ASCII case-insensitive) before route matching and before forwarding upstream
-/// so the documented `[1m]` lever works through the gateway. Byte-wise ASCII
-/// checks keep this panic-free on non-ASCII ids.
+/// so the documented `[1m]` lever works through the gateway. `strip_suffix`
+/// operates on char boundaries, so this stays panic-free on non-ASCII ids.
 fn strip_context_window_hint(model: &str) -> &str {
-    let bytes = model.as_bytes();
-    let n = bytes.len();
-    if n >= 4
-        && bytes[n - 4] == b'['
-        && bytes[n - 3] == b'1'
-        && (bytes[n - 2] == b'm' || bytes[n - 2] == b'M')
-        && bytes[n - 1] == b']'
-    {
-        &model[..n - 4]
-    } else {
-        model
-    }
+    model
+        .strip_suffix("[1m]")
+        .or_else(|| model.strip_suffix("[1M]"))
+        .unwrap_or(model)
 }
 
 pub fn resolve_model(config: &Config, model: &str) -> Route {

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -46,7 +46,31 @@ pub fn resolve(config: &Config, body: &[u8]) -> Result<Route, ShuntError> {
     Ok(resolve_model(config, &view.model))
 }
 
+/// Claude Code appends a `[1m]` suffix to a model id as a *client-side* hint that
+/// raises its own context-window / auto-compact threshold (see `docs/running.md`
+/// §5). The suffix is not part of the real model name: upstream `responses`
+/// providers (Codex/OpenAI) reject a `gpt-5.6-sol[1m]` slug, and an explicit
+/// `[[routes]]` entry would never match it. Strip a single trailing `[1m]`
+/// (ASCII case-insensitive) before route matching and before forwarding upstream
+/// so the documented `[1m]` lever works through the gateway. Byte-wise ASCII
+/// checks keep this panic-free on non-ASCII ids.
+fn strip_context_window_hint(model: &str) -> &str {
+    let bytes = model.as_bytes();
+    let n = bytes.len();
+    if n >= 4
+        && bytes[n - 4] == b'['
+        && bytes[n - 3] == b'1'
+        && (bytes[n - 2] == b'm' || bytes[n - 2] == b'M')
+        && bytes[n - 1] == b']'
+    {
+        &model[..n - 4]
+    } else {
+        model
+    }
+}
+
 pub fn resolve_model(config: &Config, model: &str) -> Route {
+    let model = strip_context_window_hint(model);
     for route in &config.routes {
         if route.model == model {
             return route_for(
@@ -93,7 +117,63 @@ fn route_for(
 mod tests {
     use crate::config::{Config, RouteConfig, RoutePrefixConfig};
 
-    use super::{resolve_model, AdapterKind};
+    use super::{resolve_model, strip_context_window_hint, AdapterKind};
+
+    #[test]
+    fn strip_context_window_hint_removes_only_a_trailing_1m_suffix() {
+        assert_eq!(strip_context_window_hint("gpt-5.6-sol[1m]"), "gpt-5.6-sol");
+        assert_eq!(strip_context_window_hint("gpt-5.6-sol[1M]"), "gpt-5.6-sol");
+        // Not a suffix / not the hint: left untouched.
+        assert_eq!(strip_context_window_hint("gpt-5.6-sol"), "gpt-5.6-sol");
+        assert_eq!(
+            strip_context_window_hint("[1m]gpt-5.6-sol"),
+            "[1m]gpt-5.6-sol"
+        );
+        assert_eq!(strip_context_window_hint("gpt-[1m]-sol"), "gpt-[1m]-sol");
+        assert_eq!(strip_context_window_hint("[1m]"), "");
+        // Non-ASCII id must not panic on the byte-index slice.
+        assert_eq!(strip_context_window_hint("모델[1m]"), "모델");
+        assert_eq!(strip_context_window_hint("모델"), "모델");
+    }
+
+    #[test]
+    fn one_million_suffix_is_stripped_before_matching_and_forwarding() {
+        let config = Config {
+            routes: vec![RouteConfig {
+                model: "claude-gpt-5.6-sol-via-codex".to_string(),
+                provider: "codex".to_string(),
+                upstream_model: Some("gpt-5.6-sol".to_string()),
+                effort: None,
+            }],
+            ..Config::default()
+        };
+
+        // The `[1m]` variant resolves to the same route, and the upstream slug
+        // never carries the suffix (Codex would reject it otherwise).
+        let route = resolve_model(&config, "claude-gpt-5.6-sol-via-codex[1m]");
+        assert_eq!(route.provider, "codex");
+        assert_eq!(route.adapter, AdapterKind::Responses);
+        assert_eq!(route.upstream_model, "gpt-5.6-sol");
+        assert_eq!(route.model, "claude-gpt-5.6-sol-via-codex");
+    }
+
+    #[test]
+    fn one_million_suffix_is_stripped_on_prefix_routes() {
+        let config = Config {
+            route_prefixes: vec![RoutePrefixConfig {
+                prefix: "gpt-".to_string(),
+                provider: "openai".to_string(),
+            }],
+            ..Config::default()
+        };
+
+        // Prefix routing forwards the incoming id as the upstream model, so the
+        // suffix must be gone before it reaches the provider.
+        let route = resolve_model(&config, "gpt-5.6-sol[1m]");
+        assert_eq!(route.provider, "openai");
+        assert_eq!(route.upstream_model, "gpt-5.6-sol");
+        assert_eq!(route.model, "gpt-5.6-sol");
+    }
 
     #[test]
     fn explicit_routes_win_before_prefix_and_default() {


### PR DESCRIPTION
## Summary

Strips the `[1m]` context-window hint suffix that Claude Code appends to a
model id (see `docs/running.md`) before route matching *and* before
forwarding upstream, so ids like `gpt-5.6-sol[1m]` /
`claude-…-via-codex[1m]` resolve to the correct route and the upstream
provider never sees the suffix (upstream `responses` providers such as
Codex reject the raw `[1m]` slug). Mirrors raine's proxy
`normalize_incoming_model` behavior. Also documents the codex-path
context-window accounting in `docs/running.md` and the Starlight guides,
and adds three GPT-5.6 subagent definitions routed through shunt.

## Milestone / spec

N/A — routing fix + doc updates, no frozen spec deviation.

## Changes

- `src/routing.rs`: new `strip_context_window_hint()`, applied in
  `resolve_model()` before both route matching and upstream forwarding.
  Byte-wise ASCII check (case-insensitive `[1m]`/`[1M]`), panic-free on
  non-ASCII ids. Passthrough (no matching route) is unaffected. 3 new unit
  tests.
- `docs/running.md` + `site/src/content/docs/guides/connect-claude-code.md`
  + `site/src/content/docs/guides/effort-and-context.md`: document the
  `/context` "Messages" double-count on the codex path, the
  `claude-`/`anthropic-` prefix boundary (model discovery vs
  `ANTHROPIC_CUSTOM_MODEL_OPTION` vs `CLAUDE_CODE_MAX_CONTEXT_TOKENS`), the
  verified 372k codex ceiling with streaming overflow → auto-compact
  recovery, and subagent-on-codex guidance (frontmatter `model:` only —
  the Agent tool's `model` param can't take a gateway id).
- `.claude/agents/gpt-5.6-{sol,luna,terra}.md`: three general-purpose
  subagent definitions whose `model:` frontmatter routes through shunt to
  GPT-5.6 Sol/Luna/Terra.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — 144 tests
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] Any new GitHub Action is pinned to a full commit SHA (N/A — no workflow changes)

## Notes for reviewers

- `strip_context_window_hint` only strips a single trailing `[1m]`/`[1M]`;
  it will not touch the suffix if it appears anywhere else in the model id
  (see the "not a suffix" test cases).
- Two new unit tests cover both explicit `[[routes]]` matching and prefix
  routing (`route_prefixes`), since the suffix must be stripped before
  either code path forwards the id upstream.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips a trailing `[1m]` context hint from model IDs before route matching and forwarding, and also rewrites the passthrough body so providers never see the suffix. Documents codex-path context accounting and adds GPT‑5.6 subagent presets; includes a small agent-memory note.

- **New Features**
  - Routing: strip a single trailing `[1m]`/`[1M]` in `resolve_model()` before matching and forwarding; works for explicit and prefix routes; 3 tests.
  - Passthrough: rewrite Anthropic outbound body `model` to the routed `upstream_model` so `[1m]` and `[[routes]]` remaps never reach the provider; no-op when already matching; 3 tests.
  - Docs: clarified `claude-`/`anthropic-` discovery vs `ANTHROPIC_CUSTOM_MODEL_OPTION` and `CLAUDE_CODE_MAX_CONTEXT_TOKENS`, streaming overflow behavior, verified windows, and subagent mapping order.
  - Subagents: added `gpt-5.6-{sol,luna,terra}` presets routed through the gateway.
  - Dev notes: added `.claude/agent-memory` reference for the repo PR template and a `gh please pr create` quiet-stdout quirk.

<sup>Written for commit 189365b1ed817be2a959d2093754b6ebc2135780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

