### PR TITLE
feat: add shunt-codex Claude Code plugin with GPT-5.6 subagents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "shunt",
+  "owner": {
+    "name": "pleaseai",
+    "url": "https://github.com/pleaseai/shunt"
+  },
+  "metadata": {
+    "description": "Claude Code subagents for models the shunt gateway diverts to other providers."
+  },
+  "plugins": [
+    {
+      "name": "shunt-codex",
+      "source": "./plugins/shunt-codex",
+      "description": "Subagents on ChatGPT/Codex GPT-5.6 models (Luna, Sol, Terra), routed through shunt at the inference layer.",
+      "keywords": ["codex", "chatgpt", "gpt-5.6"]
+    }
+  ]
+}

--- a/plugins/shunt-codex/.claude-plugin/plugin.json
+++ b/plugins/shunt-codex/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "shunt-codex",
+  "displayName": "shunt · Codex models",
+  "version": "0.1.0",
+  "description": "Subagents that run on ChatGPT/Codex GPT-5.6 models (Luna, Sol, Terra), routed through the shunt gateway at the inference layer while staying inside Claude Code's harness.",
+  "author": {
+    "name": "Minsu Lee",
+    "email": "minsu.lee@pleaseai.dev",
+    "url": "https://github.com/amondnet"
+  },
+  "homepage": "https://github.com/pleaseai/shunt",
+  "repository": "https://github.com/pleaseai/shunt",
+  "license": "MIT OR Apache-2.0",
+  "keywords": ["shunt", "codex", "chatgpt", "gpt-5.6", "subagent", "llm-gateway"]
+}

--- a/plugins/shunt-codex/README.md
+++ b/plugins/shunt-codex/README.md
@@ -51,8 +51,17 @@ and is configured to route the model ids above to the Codex provider:
 3. **Map the slugs** in your `shunt.toml` to the Codex provider (see
    [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example)):
    ```toml
+   # [[routes]] is a TOML array-of-tables: one block per model slug.
    [[routes]]
-   model = "gpt-5.6-sol"     # (and gpt-5.6-luna / gpt-5.6-terra)
+   model = "gpt-5.6-sol"
+   provider = "codex"
+
+   [[routes]]
+   model = "gpt-5.6-terra"
+   provider = "codex"
+
+   [[routes]]
+   model = "gpt-5.6-luna"
    provider = "codex"
    ```
 
@@ -79,6 +88,9 @@ Without a running shunt gateway mapping these ids, Claude Code will send the
 
 Or set every subagent to a Codex model for a session with
 `CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol`.
+
+Both require a running shunt gateway with the slug routed to the Codex provider —
+see [Prerequisites](#prerequisites). Without it the request fails against Anthropic.
 
 ## License
 

--- a/plugins/shunt-codex/README.md
+++ b/plugins/shunt-codex/README.md
@@ -42,7 +42,7 @@ and is configured to route the model ids above to the Codex provider:
 
 1. **Run shunt** and point Claude Code at it:
    ```bash
-   export ANTHROPIC_BASE_URL=http://localhost:8787   # your shunt address
+   export ANTHROPIC_BASE_URL=http://127.0.0.1:3001   # shunt's default bind address
    ```
 2. **Authenticate the ChatGPT/Codex subscription** shunt reuses:
    ```bash

--- a/plugins/shunt-codex/README.md
+++ b/plugins/shunt-codex/README.md
@@ -1,0 +1,81 @@
+# shunt-codex
+
+Claude Code subagents that run on ChatGPT/Codex **GPT-5.6** models — **Luna**,
+**Sol**, and **Terra** — routed through the [shunt](https://github.com/pleaseai/shunt)
+gateway.
+
+Unlike a CLI hand-off (which drops persona and preloaded skills), shunt diverts
+only *token generation* at the inference layer. The session keeps running inside
+Claude Code's harness: same tool loop, same skills, same script-path resolution.
+Only the model that generates the tokens changes.
+
+## Agents
+
+| Agent (`@`-mention)         | Model id (`model:`) | Native effort | Supported effort levels                     |
+| --------------------------- | ------------------- | ------------- | ------------------------------------------- |
+| `shunt-codex:gpt-5.6-sol`   | `gpt-5.6-sol`       | low (fast)    | low · medium · high · xhigh · max · ultra   |
+| `shunt-codex:gpt-5.6-terra` | `gpt-5.6-terra`     | medium        | low · medium · high · xhigh · max · ultra   |
+| `shunt-codex:gpt-5.6-luna`  | `gpt-5.6-luna`      | medium        | low · medium · high · xhigh · max           |
+
+Each agent's `model:` frontmatter pins the request to a Codex slug, so only that
+subagent diverts — the main session stays on Claude. All three share a 372k-token
+context window.
+
+> **Effort levels are from openai/codex's [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).**
+> Note the difference: **Luna does not support the `ultra` level** — its top level
+> is `max`. Sending `ultra` to Luna (via shunt's `effort` config or an `effort:`
+> override) is rejected upstream. Sol and Terra accept `ultra`.
+
+> The agents' system prompts are written for **Claude Code's harness** — these
+> models run inside Claude Code's tool loop (Read/Edit/Bash, skills), not Codex's.
+> The `gpt-5.6-*` entries in `models.json` ship no `instructions_template`, so
+> there is nothing Codex-specific to inherit; shunt only diverts token generation.
+
+## Prerequisites
+
+These agents only work when a shunt gateway is running in front of Claude Code
+and is configured to route the model ids above to the Codex provider:
+
+1. **Run shunt** and point Claude Code at it:
+   ```bash
+   export ANTHROPIC_BASE_URL=http://localhost:8787   # your shunt address
+   ```
+2. **Authenticate the ChatGPT/Codex subscription** shunt reuses:
+   ```bash
+   codex login   # writes ~/.codex/auth.json, which shunt reads + auto-refreshes
+   ```
+3. **Map the slugs** in your `shunt.toml` to the Codex provider (see
+   [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example)):
+   ```toml
+   [[routes]]
+   model = "gpt-5.6-sol"     # (and gpt-5.6-luna / gpt-5.6-terra)
+   provider = "codex"
+   ```
+
+> The ChatGPT-account backend only accepts the slugs your account is entitled to.
+> The latest are `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna`; older accounts
+> may only have `gpt-5.5` / `gpt-5.4` / `gpt-5.2`. The canonical catalog is
+> openai/codex's [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
+
+Without a running shunt gateway mapping these ids, Claude Code will send the
+`gpt-5.6-*` model id straight to Anthropic and the request will fail.
+
+## Install
+
+```
+/plugin marketplace add pleaseai/shunt
+/plugin install shunt-codex@shunt
+```
+
+## Usage
+
+```
+@shunt-codex:gpt-5.6-sol  refactor this module and run the tests
+```
+
+Or set every subagent to a Codex model for a session with
+`CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol`.
+
+## License
+
+MIT OR Apache-2.0, matching the shunt project.

--- a/plugins/shunt-codex/README.md
+++ b/plugins/shunt-codex/README.md
@@ -28,8 +28,12 @@ context window.
 
 > The agents' system prompts are written for **Claude Code's harness** — these
 > models run inside Claude Code's tool loop (Read/Edit/Bash, skills), not Codex's.
-> The `gpt-5.6-*` entries in `models.json` ship no `instructions_template`, so
-> there is nothing Codex-specific to inherit; shunt only diverts token generation.
+> The `gpt-5.6-*` entries in `models.json` do carry a substantial Codex system
+> prompt (`model_messages.instructions_template`, ~16k chars, "You are Codex…"),
+> but it describes Codex's own tools, personality, and workflow — none of which
+> exist here. shunt diverts only token generation, not that prompt: Claude Code
+> supplies its own system prompt, so the Codex one is never sent and there is
+> nothing Codex-specific to reproduce in these agents.
 
 ## Prerequisites
 

--- a/plugins/shunt-codex/agents/gpt-5.6-luna.md
+++ b/plugins/shunt-codex/agents/gpt-5.6-luna.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-luna
+description: General-purpose agent that runs on GPT-5.6-Luna (routed through the shunt gateway to the ChatGPT/Codex subscription). Luna is balanced — its native reasoning effort is medium, tunable up to max (Luna does not support the ultra level). Use when you want a task handled by GPT-5.6-Luna instead of the default Claude model.
+model: gpt-5.6-luna
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Luna.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.

--- a/plugins/shunt-codex/agents/gpt-5.6-sol.md
+++ b/plugins/shunt-codex/agents/gpt-5.6-sol.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-sol
+description: General-purpose agent that runs on GPT-5.6-Sol (routed through the shunt gateway to the ChatGPT/Codex subscription). Sol is the fast default — its native reasoning effort is low, tunable up to ultra. Use when you want a task handled by GPT-5.6-Sol instead of the default Claude model.
+model: gpt-5.6-sol
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Sol.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.

--- a/plugins/shunt-codex/agents/gpt-5.6-terra.md
+++ b/plugins/shunt-codex/agents/gpt-5.6-terra.md
@@ -1,0 +1,14 @@
+---
+name: gpt-5.6-terra
+description: General-purpose agent that runs on GPT-5.6-Terra (routed through the shunt gateway to the ChatGPT/Codex subscription). Terra is balanced — its native reasoning effort is medium, tunable up to ultra. Use when you want a task handled by GPT-5.6-Terra instead of the default Claude model.
+model: gpt-5.6-terra
+---
+
+You are a capable, autonomous engineering agent running on GPT-5.6-Terra.
+
+Complete the task you are given end to end. Investigate before acting: read the
+relevant files, understand the surrounding conventions, and ground your work in
+what the code actually does rather than assumptions.
+
+When you finish, report concisely: what you did, what you verified, and anything
+that still needs the user's attention.


### PR DESCRIPTION
## Summary

Adds a new Claude Code plugin marketplace at the repo root (`.claude-plugin/marketplace.json`, name `shunt`) and its first plugin, **shunt-codex**, under `plugins/shunt-codex/`.

shunt-codex bundles three subagents — `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra` — whose `model:` frontmatter routes them through the shunt gateway to ChatGPT/Codex GPT-5.6 models at the inference layer. The Claude Code session itself stays in Claude Code's own harness; only token generation is diverted to the Codex-backed model. Agent prompts are written natively for Claude Code's harness rather than copied from Codex, since the `gpt-5.6-*` entries in openai/codex's `models.json` ship no `instructions_template` — there is nothing Codex-specific to inherit.

The plugin README documents prerequisites (running shunt behind `ANTHROPIC_BASE_URL`, `codex login`, routing the model slugs to the codex provider) and an effort-level table sourced from `models.json`. Note that Luna does not support the `ultra` effort level (its top tier is `max`), while Sol and Terra do.

The marketplace/plugin layout is structured to support a future sibling `shunt-kimi` plugin.

## Milestone / spec

N/A — this is a Claude Code tooling addition (plugin marketplace), not part of the M0–M3 gateway spec tracked in `docs/`.

## Checklist

- [ ] `cargo build` passes — N/A, no Rust source changed
- [ ] `cargo test` passes — N/A, no Rust source changed
- [ ] `cargo clippy --all-targets -- -D warnings` clean — N/A, no Rust source changed
- [ ] `cargo fmt --all --check` clean — N/A, no Rust source changed
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it — N/A, no spec deviation
- [ ] Any new GitHub Action is pinned to a full commit SHA — N/A, no GitHub Actions added
- [x] `claude plugin validate --strict` passes for both the marketplace and the shunt-codex plugin

## Notes for reviewers

- Review the `model:` frontmatter in each agent file (`plugins/shunt-codex/agents/gpt-5.6-*.md`) for correct routing to the shunt gateway.
- The README's effort-level table (including the Luna `ultra`-not-supported / `max`-is-top caveat) is sourced from openai/codex's `models.json` — worth double-checking against upstream if it has moved since.
- No issue is linked to this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `shunt` marketplace and the `shunt-codex` plugin with three GPT‑5.6 subagents (Luna, Sol, Terra). Sessions stay in Claude Code; only token generation is routed through the `shunt` gateway to ChatGPT/Codex.

- **New Features**
  - Added `.claude-plugin/marketplace.json` registering the `shunt` marketplace and `shunt-codex` plugin.
  - Added `plugins/shunt-codex` with agents pinned via `model:` (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`); 372k context window. Luna does not support `ultra`; Sol and Terra do.
  - README clarifies Codex models include a system prompt in `models.json`, but `shunt` does not forward it; Claude Code supplies its own harness prompt.
  - README updates: default bind `ANTHROPIC_BASE_URL=http://127.0.0.1:3001`; route example shows all three `[[routes]]` blocks; usage notes `@`-mentions/`CLAUDE_CODE_SUBAGENT_MODEL` require a running `shunt` route.

- **Migration**
  - Run `shunt`, set `ANTHROPIC_BASE_URL=http://127.0.0.1:3001`, `codex login`, and route `gpt-5.6-*` to the Codex provider in `shunt.toml` (one `[[routes]]` block per slug). Without this routing, requests to these models will fail.

<sup>Written for commit b311731bc33901cb2c589ac9b0ebf7588d46dd67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

