### PR TITLE
feat(adapters): forward codex session/identity headers on chatgpt oauth

### DIFF
--- a/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-code-reviewer/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [shunt responses adapter](project_shunt_responses_adapter.md) — AGENTS.md rules for src/adapters/responses.rs and how to verify "real Codex CLI" header claims via GitHub code search.

--- a/.claude/agent-memory/review-review-code-reviewer/project_shunt_responses_adapter.md
+++ b/.claude/agent-memory/review-review-code-reviewer/project_shunt_responses_adapter.md
@@ -1,0 +1,27 @@
+---
+name: project-shunt-responses-adapter
+description: shunt repo Rust/axum LLM gateway — src/adapters/responses.rs conventions and how to verify Codex header claims
+metadata:
+  type: project
+---
+
+shunt (`/Users/lms/orca/workspaces/shunt/feat-adapters-forward-codex-session-identity-hea`) is a Rust/axum LLM
+gateway. Repo rule: read `AGENTS.md` before working in `src/` (both root and `src/CLAUDE.md` just point there).
+Key AGENTS.md points relevant to adapter review: keep gateway-owned errors in Anthropic error shape, preserve
+streaming semantics (don't buffer SSE unless client requested non-streaming), prefer table-driven config over
+hardcoded provider logic, always add focused test coverage for protocol changes, run fmt/clippy/tests before
+declaring done.
+
+`src/adapters/responses.rs` implements the ChatGPT/Codex `/codex/responses` and OpenAI/xAI `/responses` adapter.
+It gates ChatGPT-only headers (originator/user-agent/version, and session/identity headers like `session_id`,
+`x-client-request-id`, `x-codex-window-id`, `accept: text/event-stream`) on the `Credential::ChatGptOAuth` match
+arm inside `request_builder`. This credential variant is asserted (not just assumed) to correspond to
+`config.is_chatgpt_backend()` — confirmed by checking `src/auth/mod.rs` (ChatGptOAuth is only constructed for
+that backend) — so gating on the credential enum is equivalent to gating on the backend flag.
+
+When reviewing claims in code comments here about "what the real Codex CLI sends" (e.g. header names/values,
+`x-codex-window-id` format `{id}:0`, reusing the session/conversation id for both `session_id` and
+`x-client-request-id`), verify via `mcp__plugin_context_grep__searchGitHub` against openai/codex (codex-rs) and
+known third-party Codex proxies (icebear0828/codex-proxy, tailcallhq/forgecode, Wei-Shaw/sub2api) rather than
+trusting the comment at face value — in the one case checked (2026-07-11), the claims held up (multiple
+independent proxy implementations mirror the same header shape).

--- a/.claude/agent-memory/review-review-code-reviewer/project_shunt_responses_adapter.md
+++ b/.claude/agent-memory/review-review-code-reviewer/project_shunt_responses_adapter.md
@@ -5,7 +5,7 @@ metadata:
   type: project
 ---
 
-shunt (`/Users/lms/orca/workspaces/shunt/feat-adapters-forward-codex-session-identity-hea`) is a Rust/axum LLM
+shunt is a Rust/axum LLM
 gateway. Repo rule: read `AGENTS.md` before working in `src/` (both root and `src/CLAUDE.md` just point there).
 Key AGENTS.md points relevant to adapter review: keep gateway-owned errors in Anthropic error shape, preserve
 streaming semantics (don't buffer SSE unless client requested non-streaming), prefer table-driven config over

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -283,7 +283,7 @@ fn request_builder(
             // cross-checked against codex-rs/login/src/auth/default_client.rs).
             // Only sent when a session id is available; xAI/OpenAI-compatible
             // upstreams never reach this branch.
-            if let Some(session_id) = session_id {
+            if let Some(session_id) = session_id.filter(|s| !s.is_empty()) {
                 request = request
                     .header("accept", "text/event-stream")
                     .header("session_id", session_id)
@@ -481,6 +481,26 @@ mod tests {
             request.headers().get("x-codex-window-id").unwrap(),
             "session-123:0"
         );
+    }
+
+    #[test]
+    fn omits_session_headers_when_session_id_is_empty_string() {
+        let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
+
+        let request = build_test_request(
+            &state,
+            &codex_route(),
+            Credential::ChatGptOAuth {
+                access_token: "access-token".to_string(),
+                account_id: "account-id".to_string(),
+            },
+            Some(""),
+        );
+
+        assert!(request.headers().get("accept").is_none());
+        assert!(request.headers().get("session_id").is_none());
+        assert!(request.headers().get("x-client-request-id").is_none());
+        assert!(request.headers().get("x-codex-window-id").is_none());
     }
 
     #[test]

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -468,7 +468,10 @@ mod tests {
             Some("session-123"),
         );
 
-        assert_eq!(request.headers().get("accept").unwrap(), "text/event-stream");
+        assert_eq!(
+            request.headers().get("accept").unwrap(),
+            "text/event-stream"
+        );
         assert_eq!(request.headers().get("session_id").unwrap(), "session-123");
         assert_eq!(
             request.headers().get("x-client-request-id").unwrap(),

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -30,8 +30,7 @@ impl Adapter for ResponsesAdapter {
     ) -> AdapterFuture<'a> {
         let session_id = headers
             .get("x-claude-code-session-id")
-            .and_then(|value| value.to_str().ok())
-            .map(ToOwned::to_owned);
+            .and_then(|value| value.to_str().ok());
         Box::pin(async move { forward(state, route, body, session_id).await })
     }
 }
@@ -40,7 +39,7 @@ async fn forward(
     state: AppState,
     route: Route,
     body: Vec<u8>,
-    session_id: Option<String>,
+    session_id: Option<&str>,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     let request_json = serde_json::from_slice::<Value>(&body).ok();
     let client_wants_stream = request_json
@@ -64,7 +63,7 @@ async fn forward(
         "responses upstream request"
     );
     let credential = resolve_credential(&state.config, &route, &state.http_client).await?;
-    let upstream = request_builder(&state, &route, credential, session_id.as_deref())
+    let upstream = request_builder(&state, &route, credential, session_id)
         .body(upstream_body.to_string())
         .send()
         .await

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -25,10 +25,14 @@ impl Adapter for ResponsesAdapter {
         state: AppState,
         route: Route,
         _uri: &'a Uri,
-        _headers: &'a HeaderMap,
+        headers: &'a HeaderMap,
         body: Vec<u8>,
     ) -> AdapterFuture<'a> {
-        Box::pin(async move { forward(state, route, body).await })
+        let session_id = headers
+            .get("x-claude-code-session-id")
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        Box::pin(async move { forward(state, route, body, session_id).await })
     }
 }
 
@@ -36,6 +40,7 @@ async fn forward(
     state: AppState,
     route: Route,
     body: Vec<u8>,
+    session_id: Option<String>,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     let request_json = serde_json::from_slice::<Value>(&body).ok();
     let client_wants_stream = request_json
@@ -59,7 +64,7 @@ async fn forward(
         "responses upstream request"
     );
     let credential = resolve_credential(&state.config, &route, &state.http_client).await?;
-    let upstream = request_builder(&state, &route, credential)
+    let upstream = request_builder(&state, &route, credential, session_id.as_deref())
         .body(upstream_body.to_string())
         .send()
         .await
@@ -246,6 +251,7 @@ fn request_builder(
     state: &AppState,
     route: &Route,
     credential: Credential,
+    session_id: Option<&str>,
 ) -> reqwest::RequestBuilder {
     let mut request = state
         .http_client
@@ -272,6 +278,18 @@ fn request_builder(
                 .header("originator", "codex_cli_rs")
                 .header("user-agent", CODEX_USER_AGENT)
                 .header("version", CODEX_CLIENT_VERSION);
+            // Session/identity headers the real Codex CLI sends alongside the
+            // client identity above (raine/claude-code-proxy build_codex_headers,
+            // cross-checked against codex-rs/login/src/auth/default_client.rs).
+            // Only sent when a session id is available; xAI/OpenAI-compatible
+            // upstreams never reach this branch.
+            if let Some(session_id) = session_id {
+                request = request
+                    .header("accept", "text/event-stream")
+                    .header("session_id", session_id)
+                    .header("x-client-request-id", session_id)
+                    .header("x-codex-window-id", format!("{session_id}:0"));
+            }
         }
         // xAI subscription OAuth: bearer only, no account-id/originator headers.
         Credential::XaiOauth { access_token } => {
@@ -304,8 +322,9 @@ pub fn build_test_request(
     state: &AppState,
     route: &Route,
     credential: Credential,
+    session_id: Option<&str>,
 ) -> reqwest::Request {
-    request_builder(state, route, credential)
+    request_builder(state, route, credential, session_id)
         .body("{}")
         .build()
         .expect("test request should build")
@@ -399,6 +418,7 @@ mod tests {
                 access_token: "access-token".to_string(),
                 account_id: "account-id".to_string(),
             },
+            None,
         );
 
         assert_eq!(
@@ -425,6 +445,38 @@ mod tests {
         assert_eq!(
             request.headers().get("OpenAI-Beta").unwrap(),
             "responses=experimental"
+        );
+        // No session id was supplied: the session/identity headers must not
+        // be sent, since a fabricated value would be worse than omitting them.
+        assert!(request.headers().get("session_id").is_none());
+        assert!(request.headers().get("x-client-request-id").is_none());
+        assert!(request.headers().get("x-codex-window-id").is_none());
+        assert!(request.headers().get("accept").is_none());
+    }
+
+    #[test]
+    fn forwards_session_headers_on_codex_backend_when_session_id_present() {
+        let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
+
+        let request = build_test_request(
+            &state,
+            &codex_route(),
+            Credential::ChatGptOAuth {
+                access_token: "access-token".to_string(),
+                account_id: "account-id".to_string(),
+            },
+            Some("session-123"),
+        );
+
+        assert_eq!(request.headers().get("accept").unwrap(), "text/event-stream");
+        assert_eq!(request.headers().get("session_id").unwrap(), "session-123");
+        assert_eq!(
+            request.headers().get("x-client-request-id").unwrap(),
+            "session-123"
+        );
+        assert_eq!(
+            request.headers().get("x-codex-window-id").unwrap(),
+            "session-123:0"
         );
     }
 
@@ -456,6 +508,7 @@ mod tests {
             Credential::XaiOauth {
                 access_token: "xai-access".to_string(),
             },
+            Some("session-123"),
         );
 
         // Stock /responses path on the xAI base URL.
@@ -470,6 +523,12 @@ mod tests {
         assert!(request.headers().get("user-agent").is_none());
         assert!(request.headers().get("version").is_none());
         assert!(request.headers().get("OpenAI-Beta").is_none());
+        // Session/identity headers are ChatGPT/Codex-only, even when a
+        // session id is present on an xAI-routed request.
+        assert!(request.headers().get("session_id").is_none());
+        assert!(request.headers().get("x-client-request-id").is_none());
+        assert!(request.headers().get("x-codex-window-id").is_none());
+        assert!(request.headers().get("accept").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Forwards Codex session/identity headers from the inbound Claude Code request onto the outbound `/codex/responses` request when using the ChatGPT/Codex backend (`Credential::ChatGptOAuth`).

`ResponsesAdapter::forward` now extracts the inbound `x-claude-code-session-id` header and threads it through to `request_builder`. When the credential is `Credential::ChatGptOAuth` and a session id is present, four headers are added to the outbound request:

- `accept: text/event-stream`
- `session_id`
- `x-client-request-id` (same value as `session_id`)
- `x-codex-window-id` (`{session_id}:0`)

These headers are never added for xAI or OpenAI-compatible (`ApiKey`) credential flavors.

## Milestone / spec

N/A — small header-forwarding fix, no spec deviation.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (N/A, no spec deviation)
- [x] Any new GitHub Action is pinned to a full commit SHA (N/A, no workflow changes)

## Notes for reviewers

Tests in `src/adapters/responses.rs` assert the four headers are present on the ChatGPT/Codex flavor and absent on xAI even when a session id is supplied — please double check the xAI negative-case assertions match intent.

## Related Issues

Closes #30

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward Codex session/identity headers to the ChatGPT/Codex backend when using `Credential::ChatGptOAuth`. We read `x-claude-code-session-id` from the inbound request and, if present, add `accept: text/event-stream`, `session_id`, `x-client-request-id`, and `x-codex-window-id={id}:0` to `/codex/responses`.

- **Bug Fixes**
  - Headers are gated to `Credential::ChatGptOAuth` only; never sent for xAI or OpenAI-compatible (`ApiKey`) credentials.
  - Skip all session headers unless the session id is non-empty; tests cover present, empty, missing, and xAI negative paths.

<sup>Written for commit 3bbae079245b18738053d429f032641904a5ab9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

