### PR TITLE
chore: keep internal Claude config out of the public repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
     "ENABLE_TOOL_SEARCH": "1"
   },
   "enabledPlugins": {
-    "claude-code-docs@passionfactory": true,
+    "claude-code-docs@pleaseai": true,
     "astro-lsp@code-intelligence": true,
     "astro@pleaseai": true
   },

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ site/.wrangler/
 
 # Local worktrees created by the worktree workflow (per-branch, not shared)
 .claude/worktrees/
+
+# Personal Claude Code overrides (internal marketplaces, telemetry label) — never shared upstream
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Keeps internal Claude Code configuration out of this public repo, following an OSS-standards pass (`/standards:setup --oss`).

- `.gitignore` — adds `.claude/settings.local.json` so the personal Claude Code overrides file (internal marketplaces + telemetry label) is ignored for every contributor, not just via a personal global gitignore.
- `.claude/settings.json` — moves the `claude-code-docs` plugin from the private `@passionfactory` marketplace to the public `@pleaseai` marketplace, so the committed public settings reference only public marketplaces.

## Milestone / spec

N/A — repo hygiene / OSS-standards chore, not milestone work.

## Checklist

- [x] `cargo build` passes (no source files touched)
- [x] `cargo test` passes (no source files touched)
- [x] `cargo clippy --all-targets -- -D warnings` clean (no source files touched)
- [x] `cargo fmt --all --check` clean (no source files touched)
- [x] Source files stay under 500 lines (n/a, config-only change)
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (n/a, no spec impact)
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a, no workflow changes)

## Notes for reviewers

Config-only change — no Rust source touched. No linked issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep internal Claude Code config out of the public repo and align settings with OSS standards. Add `.claude/settings.local.json` to `.gitignore` and switch `claude-code-docs@passionfactory` to `claude-code-docs@pleaseai`.

<sup>Written for commit f697f23290a2caf68b2b3084d9c59c72560652a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

