### PR TITLE
feat: add GET /routes endpoint exposing routable model slugs

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -209,6 +209,7 @@ e.g. `RUST_LOG=shunt=debug cargo run -- run`.
 | `GET`  | `/`                           | Human-readable landing (version + endpoint list)    |
 | `GET`  | `/health`                     | Healthcheck — `{"status":"ok","version":"x.y.z"}`   |
 | `GET`  | `/v1/models`                  | Model discovery (returns your `[[models]]` entries) |
+| `GET`  | `/routes`                     | Route discovery (returns your `[[routes]]` table)   |
 | `POST` | `/v1/messages`                | Inference — routed per the request's `model` id     |
 | `POST` | `/v1/messages/count_tokens`   | Token counting (see below)                          |
 
@@ -640,8 +641,11 @@ export SHUNT_CLIENT_TOKENS="minsu:$(openssl rand -hex 32),alice:$(openssl rand -
 
 Startup **fails closed** if `[server.auth]` is present but the env var is unset or
 malformed. Requests to mapped models without a valid token get a 401
-`authentication_error`; `GET /v1/models`, `GET|HEAD /`, `GET /health`, and passthrough
-models stay open.
+`authentication_error`; `GET /v1/models`, `GET /routes`, `GET|HEAD /`, `GET /health`, and
+passthrough models stay open. `GET /routes` is unauthenticated by the same discovery-endpoint
+design as `GET /v1/models` — it exposes routing metadata (the configured provider/upstream-model
+mapping), never credentials, which live only in provider config and are never read by that
+handler.
 The token header is always stripped before forwarding, matching is constant-time, and
 token values are never logged (client *names* are, per request).
 

--- a/site/src/content/docs/guides/shared-gateway.md
+++ b/site/src/content/docs/guides/shared-gateway.md
@@ -20,7 +20,7 @@ tokens_env = "SHUNT_CLIENT_TOKENS"
 export SHUNT_CLIENT_TOKENS="minsu:$(openssl rand -hex 32),alice:$(openssl rand -hex 32)"
 ```
 
-Startup **fails closed** if `[server.auth]` is present but the env var is unset or malformed. Requests to mapped models without a valid token get a 401 `authentication_error`; `GET /v1/models`, `GET|HEAD /`, `GET /health`, and passthrough models stay open.
+Startup **fails closed** if `[server.auth]` is present but the env var is unset or malformed. Requests to mapped models without a valid token get a 401 `authentication_error`; `GET /v1/models`, `GET /routes`, `GET|HEAD /`, `GET /health`, and passthrough models stay open. `GET /routes` is unauthenticated by the same discovery-endpoint design as `GET /v1/models` — it exposes routing metadata (the configured provider/upstream-model mapping), never credentials, which live only in provider config and are never read by that handler.
 
 The token header is always stripped before forwarding, matching is constant-time, and token values are never logged (client *names* are, per request).
 

--- a/site/src/content/docs/reference/endpoints.md
+++ b/site/src/content/docs/reference/endpoints.md
@@ -9,6 +9,7 @@ description: The endpoints shunt serves as a Claude Code LLM gateway.
 | `GET` | `/` | Human-readable landing (version + endpoint list) |
 | `GET` | `/health` | Healthcheck — `{"status":"ok","version":"x.y.z"}` |
 | `GET` | `/v1/models` | [Model discovery](/guides/model-discovery/) — returns your `[[models]]` entries |
+| `GET` | `/routes` | shunt-native route discovery — returns the configured `[[routes]]` table verbatim (model → provider/upstream_model/effort mapping, including claude-prefixed discovery aliases); distinct from `/v1/models`, which serves the narrower Anthropic-protocol discovery response (`id`/`display_name` only) |
 | `POST` | `/v1/messages` | Inference — routed per the request's `model` id |
 | `POST` | `/v1/messages/count_tokens` | [Token counting](/guides/effort-and-context/#token-counting-count_tokens) |
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod metrics;
 pub mod model;
 pub mod proxy;
 pub mod reload;
+pub mod routes;
 pub mod routing;
 pub mod server;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -18,10 +18,10 @@ pub struct RouteEntry {
     pub effort: Option<String>,
 }
 
-/// Shunt-native endpoint exposing the configured `[[routes]]` table (routable,
-/// non-`claude-` model slugs). Distinct from `/v1/models`, which serves the
-/// Anthropic-protocol model-discovery response and drops any id that doesn't
-/// begin with `claude`/`anthropic`.
+/// Shunt-native endpoint exposing the configured `[[routes]]` table verbatim,
+/// including any `claude-`/`anthropic-`-prefixed discovery aliases. Distinct
+/// from `/v1/models`, which serves the narrower Anthropic-protocol
+/// model-discovery response (only `id`/`display_name` from `[[models]]`).
 pub async fn get(State(state): State<AppState>) -> Json<RoutesResponse> {
     // Snapshot the live config so this response reflects the latest reload.
     let state = state.refreshed();

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,0 +1,105 @@
+use axum::{extract::State, Json};
+use serde::Serialize;
+
+use crate::server::AppState;
+
+#[derive(Debug, Serialize)]
+pub struct RoutesResponse {
+    pub data: Vec<RouteEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RouteEntry {
+    pub model: String,
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// Shunt-native endpoint exposing the configured `[[routes]]` table (routable,
+/// non-`claude-` model slugs). Distinct from `/v1/models`, which serves the
+/// Anthropic-protocol model-discovery response and drops any id that doesn't
+/// begin with `claude`/`anthropic`.
+pub async fn get(State(state): State<AppState>) -> Json<RoutesResponse> {
+    // Snapshot the live config so this response reflects the latest reload.
+    let state = state.refreshed();
+    let data: Vec<RouteEntry> = state
+        .config
+        .routes
+        .iter()
+        .map(|route| RouteEntry {
+            model: route.model.clone(),
+            provider: route.provider.clone(),
+            upstream_model: route.upstream_model.clone(),
+            effort: route.effort.clone(),
+        })
+        .collect();
+    tracing::info!(routes = data.len(), "served GET /routes discovery");
+    Json(RoutesResponse { data })
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::State;
+    use serde_json::json;
+
+    use crate::{
+        config::RouteConfig,
+        server::{self, AppState},
+    };
+
+    use super::get;
+
+    #[tokio::test]
+    async fn returns_configured_routes_with_optional_fields() {
+        let config = crate::config::Config {
+            routes: vec![
+                RouteConfig {
+                    model: "gpt-5.6-luna".to_string(),
+                    provider: "codex".to_string(),
+                    upstream_model: Some("gpt-5.6-luna".to_string()),
+                    effort: Some("high".to_string()),
+                },
+                RouteConfig {
+                    model: "gpt-5.2".to_string(),
+                    provider: "openai".to_string(),
+                    upstream_model: None,
+                    effort: None,
+                },
+            ],
+            ..crate::config::Config::default()
+        };
+        let state = AppState::new(config, reqwest::Client::new()).unwrap();
+
+        let response = get(State(state)).await;
+        let body = serde_json::to_value(response.0).unwrap();
+
+        assert_eq!(
+            body,
+            json!({
+                "data": [
+                    {"model": "gpt-5.6-luna", "provider": "codex", "upstream_model": "gpt-5.6-luna", "effort": "high"},
+                    {"model": "gpt-5.2", "provider": "openai"}
+                ]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_empty_data_when_routes_are_unconfigured() {
+        let state =
+            AppState::new(crate::config::Config::default(), reqwest::Client::new()).unwrap();
+
+        let response = get(State(state)).await;
+        let body = serde_json::to_value(response.0).unwrap();
+
+        assert_eq!(body, json!({"data": []}));
+    }
+
+    #[test]
+    fn router_includes_get_routes_route() {
+        let (_router, _shared) = server::build_router(crate::config::Config::default()).unwrap();
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@ use crate::{
     config::{Config, ConfigError},
     discovery, proxy,
     reload::{RuntimeState, SharedState},
+    routes,
 };
 
 #[derive(Clone)]
@@ -69,6 +70,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState), ConfigError
         .route("/", get(root_index))
         .route("/health", get(health))
         .route("/v1/models", get(discovery::get))
+        .route("/routes", get(routes::get))
         .route("/v1/messages", post(proxy::post))
         .route("/v1/messages/count_tokens", post(proxy::post))
         .with_state(state);
@@ -79,7 +81,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState), ConfigError
 /// which keeps the pre-existing liveness probe working.
 async fn root_index() -> String {
     format!(
-        "shunt v{} — Anthropic Messages proxy. Endpoints: /v1/models, /v1/messages, /v1/messages/count_tokens, /health\n",
+        "shunt v{} — Anthropic Messages proxy. Endpoints: /v1/models, /routes, /v1/messages, /v1/messages/count_tokens, /health\n",
         env!("CARGO_PKG_VERSION")
     )
 }


### PR DESCRIPTION
## Summary

Adds a shunt-native `GET /routes` endpoint that exposes the configured `[[routes]]` table (routable, non-`claude-` model slugs), distinct from the Anthropic-protocol `/v1/models` discovery endpoint. This lets consumers like `pf config`'s haiku-override picker discover window-correct model ids instead of only the `claude-…-via-codex` discovery aliases (which are capped at the 200k default context window).

## Milestone / spec

Implements the proposal in #34 (no frozen `docs/` spec covers this; see issue for full design rationale).

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it — not applicable, no existing spec covers this endpoint
- [x] Any new GitHub Action is pinned to a full commit SHA — not applicable, no new GitHub Actions

## Notes for reviewers

- `src/routes.rs` (new) mirrors the `discovery.rs` pattern: `RoutesResponse { data: Vec<RouteEntry> }`, with `RouteEntry` a direct mirror of `RouteConfig` (`model`, `provider`, optional `upstream_model`/`effort` via `skip_serializing_if`). Includes unit tests for configured routes, empty routes, and router registration.
- `src/server.rs` registers `.route("/routes", get(routes::get))` next to `/v1/models` and adds `/routes` to the `root_index` endpoint list.
- Design choices resolved with the repo owner from the issue's open questions:
  - Path is `GET /routes` (not `/v1/routes`) — shunt-native, signals it's outside the Anthropic protocol surface.
  - No `display_name` cross-referencing against `[[models]]` in this v1 — response is a direct mirror of `RouteConfig`.
  - `route_prefixes` (catch-all prefix routes) deferred, not included in this response.
- Manually smoke-tested: booted the gateway with a sample `[[routes]]` config and confirmed `curl /routes` returns the expected JSON while `/v1/models` still only exposes the `claude-`-prefixed alias.

Closes #34

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shunt-native GET `/routes` endpoint that returns the configured `[[routes]]` table verbatim (model → provider/upstream_model/effort). This gives clients a clear, protocol-agnostic view of routable model IDs, separate from the narrower `/v1/models` discovery.

- **New Features**
  - Adds `/routes` returning `{"data":[{ "model", "provider", "upstream_model"?, "effort"? }]}`, mirroring `RouteConfig` and including any `claude-`/`anthropic-` aliases.
  - Registers the route in the router and root index; documents it and clarifies it’s an unauthenticated discovery endpoint; `/v1/models` behavior stays the same.

<sup>Written for commit fa54ee341dd168f3ab2ce2424aee834a98cab43a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

