### PR TITLE
feat(config): support YAML config files alongside TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -297,9 +297,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -552,6 +552,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "serde_yaml",
  "toml",
  "uncased",
  "version_check",
@@ -1697,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1780,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1792,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2115,7 +2116,7 @@ version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c44ee52fa3d30581f951b57aec754ef9cd70186df5fb788367804360c48097"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
@@ -2153,7 +2154,7 @@ checksum = "1be93ef0435a5ab91f88178fb7681249437e875d004f996ecb35be94dc99a0e0"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2235,6 +2236,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2427,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2491,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2775,6 +2789,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 keywords = ["claude", "gateway", "proxy", "anthropic", "openai"]
 categories = ["command-line-utilities", "web-programming::http-server"]
 # Keep the published tarball to what's needed to build and use the crate.
-include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "shunt.toml.example"]
+include = ["src/**", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "shunt.toml.example", "shunt.yaml.example"]
 
 [lib]
 name = "shunt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ arc-swap = "1.9.2"
 axum = "0.8"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["toml", "yaml", "env"] }
 futures-util = "0.3"
 notify = "8.2.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The name is the mechanism: an electrical/railway *shunt* diverts a selected part of the flow onto a parallel path. Here, a mapped model's inference is diverted to another provider while Claude Code's tools and skills stay intact.
 
-It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table away, no code changes.
+It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table or YAML mapping away, no code changes.
 
 ## Install
 
@@ -51,7 +51,7 @@ Unmapped models (all your `claude-*` ids) keep working exactly as before — shu
 
 ## Providers
 
-A provider is a `[providers.<name>]` TOML table — two adapter kinds cover everything: `kind = "anthropic"` (the upstream speaks Anthropic Messages; passed through, optionally with a different key) and `kind = "responses"` (the upstream speaks the OpenAI Responses API; shunt translates Anthropic Messages ⇄ Responses, streaming included).
+A provider is a `[providers.<name>]` TOML table (or an entry under the YAML `providers` mapping) — two adapter kinds cover everything: `kind = "anthropic"` (the upstream speaks Anthropic Messages; passed through, optionally with a different key) and `kind = "responses"` (the upstream speaks the OpenAI Responses API; shunt translates Anthropic Messages ⇄ Responses, streaming included).
 
 **Built in:**
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -43,12 +43,16 @@ You can also run straight from the source tree with `cargo run -- <args>` (examp
 shunt loads configuration from, in increasing precedence:
 
 1. Built-in defaults (all providers preconfigured — see `src/config.rs`).
-2. A **TOML file**. With `--config <path>` that exact file is used (a missing
-   file is an error). Otherwise shunt takes the first file found in:
-   `./shunt.toml` → `$XDG_CONFIG_HOME/shunt/shunt.toml` (defaulting to
-   `~/.config/shunt/shunt.toml`) → `$HOMEBREW_PREFIX/etc/shunt.toml`
-   (defaulting to the `/opt/homebrew` and `/usr/local` prefixes). Boot
-   logs report which file was loaded, or that defaults are in use.
+2. A **TOML or YAML file**. The format is chosen by extension — `.toml` is
+   TOML, `.yaml`/`.yml` is YAML (any other extension is parsed as TOML). With
+   `--config <path>` that exact file is used (a missing file is an error).
+   Otherwise shunt takes the first file found, probing each directory for
+   `shunt.toml`, then `shunt.yaml`, then `shunt.yml`, in this directory order:
+   `./` → `$XDG_CONFIG_HOME/shunt/` (defaulting to `~/.config/shunt/`) →
+   `$HOMEBREW_PREFIX/etc/` (defaulting to the `/opt/homebrew` and
+   `/usr/local` prefixes). A local `shunt.yaml` therefore still wins over a
+   config file in a later directory. Boot logs report which file was loaded,
+   or that defaults are in use.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys
    (e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`).
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -61,11 +61,12 @@ shunt loads configuration from, in increasing precedence:
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys
    (e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`).
 
-Because the defaults already define every provider, your `shunt.toml` only needs the parts you
-want to change. Start from the template:
+Because the defaults already define every provider, your config only needs the parts you
+want to change. Start from either template:
 
 ```bash
-cp shunt.toml.example shunt.toml
+cp shunt.toml.example shunt.toml  # TOML
+cp shunt.yaml.example shunt.yaml  # YAML
 ```
 
 ### 3.1 Config reference

--- a/docs/running.md
+++ b/docs/running.md
@@ -53,6 +53,11 @@ shunt loads configuration from, in increasing precedence:
    `/usr/local` prefixes). A local `shunt.yaml` therefore still wins over a
    config file in a later directory. Boot logs report which file was loaded,
    or that defaults are in use.
+
+   > **YAML 1.1 caveat:** the YAML backend parses YAML 1.1, where bare `yes`,
+   > `no`, `on`, `off`, `y`, `n` (any case) become booleans. Quote any string
+   > value that is one of these tokens (e.g. `api_key_env: "no"`), or
+   > deserialization fails with a type error. TOML is unaffected.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys
    (e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`).
 

--- a/shunt.yaml.example
+++ b/shunt.yaml.example
@@ -1,0 +1,42 @@
+# shunt configuration — copy to ./shunt.yaml and edit.
+# The full annotated template is shunt.toml.example; this file demonstrates the
+# equivalent YAML structure. Every provider has built-in defaults, so only
+# override values you need.
+
+server:
+  bind: "127.0.0.1:3001"
+  default_provider: anthropic
+
+providers:
+  anthropic:
+    kind: anthropic
+    base_url: https://api.anthropic.com
+
+  openai:
+    kind: responses
+    base_url: https://api.openai.com/v1
+    auth: api_key
+    api_key_env: OPENAI_API_KEY
+
+  codex:
+    kind: responses
+    base_url: https://chatgpt.com/backend-api
+    auth: chatgpt_oauth
+
+# Exact routes take precedence over prefix routes.
+routes:
+  - model: gpt-5.6-sol
+    provider: codex
+
+route_prefixes:
+  - prefix: gpt-
+    provider: openai
+
+# YAML 1.1 treats bare yes/no/on/off/y/n values as booleans. Quote one of
+# those tokens when using it in a string field, for example:
+# providers:
+#   custom:
+#     kind: anthropic
+#     base_url: https://example.com/anthropic
+#     auth: api_key
+#     api_key_env: "no"

--- a/site/src/content/docs/guides/configuration.md
+++ b/site/src/content/docs/guides/configuration.md
@@ -6,12 +6,12 @@ description: How shunt loads configuration — files, environment variables, and
 shunt loads configuration from, in increasing precedence:
 
 1. **Built-in defaults** — every provider (`anthropic`, `openai`, `codex`, …) is preconfigured.
-2. A **TOML file**. With `--config <path>` that exact file is used (a missing file is an error). Otherwise shunt takes the first file found in:
-   - `./shunt.toml`
-   - `$XDG_CONFIG_HOME/shunt/shunt.toml` (default `~/.config/shunt/shunt.toml`)
-   - `$HOMEBREW_PREFIX/etc/shunt.toml` (default `/opt/homebrew` and `/usr/local` prefixes)
+2. A **TOML or YAML file**. The format is chosen by extension — `.toml` is TOML, `.yaml`/`.yml` is YAML (any other extension is parsed as TOML). With `--config <path>` that exact file is used (a missing file is an error). Otherwise shunt probes each directory for `shunt.toml`, then `shunt.yaml`, then `shunt.yml`, and takes the first file found:
+   - `./`
+   - `$XDG_CONFIG_HOME/shunt/` (default `~/.config/shunt/`)
+   - `$HOMEBREW_PREFIX/etc/` (default `/opt/homebrew` and `/usr/local` prefixes)
 
-   Boot logs report which file was loaded, or that defaults are in use.
+   A local `shunt.yaml` therefore still wins over a config file in a later directory, while an existing `shunt.toml` alongside it takes priority within the same directory. Boot logs report which file was loaded, or that defaults are in use.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys — e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`.
 
 Because the defaults already define every provider, your `shunt.toml` only needs the parts you want to change. Start from [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example).
@@ -60,6 +60,31 @@ provider = "openai"
 # [[models]]
 # id = "claude-opus-via-codex"
 # display_name = "Opus (via Codex)"
+```
+
+### YAML equivalent
+
+The same schema in YAML — save as `shunt.yaml` or `shunt.yml`. Tables become mappings and `[[...]]` arrays become lists:
+
+```yaml
+server:
+  bind: "127.0.0.1:3001"
+  default_provider: anthropic
+
+providers:
+  openai:
+    kind: responses
+    base_url: https://api.openai.com/v1
+    auth: api_key
+    api_key_env: OPENAI_API_KEY
+
+routes:
+  - model: gpt-5.6-sol
+    provider: codex
+
+route_prefixes:
+  - prefix: gpt-
+    provider: openai
 ```
 
 ## Routing precedence

--- a/site/src/content/docs/guides/configuration.md
+++ b/site/src/content/docs/guides/configuration.md
@@ -14,7 +14,7 @@ shunt loads configuration from, in increasing precedence:
    A local `shunt.yaml` therefore still wins over a config file in a later directory, while an existing `shunt.toml` alongside it takes priority within the same directory. Boot logs report which file was loaded, or that defaults are in use.
 3. **Environment variables** prefixed `SHUNT_`, using `__` for nested keys — e.g. `SHUNT_SERVER__BIND=0.0.0.0:3001`.
 
-Because the defaults already define every provider, your `shunt.toml` only needs the parts you want to change. Start from [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example).
+Because the defaults already define every provider, your config only needs the parts you want to change. Start from [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example) for TOML or [`shunt.yaml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.yaml.example) for YAML.
 
 ## Annotated example
 

--- a/site/src/content/docs/guides/configuration.md
+++ b/site/src/content/docs/guides/configuration.md
@@ -87,6 +87,10 @@ route_prefixes:
     provider: openai
 ```
 
+:::caution[Quote boolean-like string values]
+The YAML backend parses **YAML 1.1**, where the bare tokens `yes`, `no`, `on`, `off`, `y`, `n` (any case) are read as booleans, not strings. If a string field's value is one of these, quote it — e.g. `api_key_env: "no"` — or deserialization fails with an opaque type error. All the built-in keys take normal identifiers, so this only bites unusual values, but quoting is the safe habit. TOML is unaffected.
+:::
+
 ## Routing precedence
 
 1. Exact `[[routes]]` match on the request's `model` id.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -14,7 +14,7 @@ shunt run --config /path/to/shunt.toml
 
 On start it logs `shunt listening` with the bound address (default `127.0.0.1:3001`). Set log verbosity with `RUST_LOG`, e.g. `RUST_LOG=shunt=debug shunt run`.
 
-Without `--config`, shunt searches `./shunt.toml` → `~/.config/shunt/shunt.toml` → `$HOMEBREW_PREFIX/etc/shunt.toml`; with `--config`, a missing file is an error. See [Configuration](/guides/configuration/).
+Config files may be TOML or YAML, chosen by extension (`.toml`, or `.yaml`/`.yml`). Without `--config`, shunt probes each directory for `shunt.toml` → `shunt.yaml` → `shunt.yml` across `./` → `~/.config/shunt/` → `$HOMEBREW_PREFIX/etc/`; with `--config`, a missing file is an error. See [Configuration](/guides/configuration/).
 
 ## `shunt check`
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -3,7 +3,7 @@ title: Configuration Reference
 description: Every shunt.toml key — server, providers, routes, models.
 ---
 
-See [Configuration](/guides/configuration/) for file locations, precedence, and an annotated example. Full template: [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example).
+The keys below are shown in TOML, but a config file may also be written in YAML (`shunt.yaml`/`shunt.yml`) — the schema is identical, only the syntax differs. See [Configuration](/guides/configuration/) for file locations, precedence, and an annotated example. Full template: [`shunt.toml.example`](https://github.com/pleaseai/shunt/blob/main/shunt.toml.example).
 
 ## `[server]`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1040,6 +1040,17 @@ provider = "kimi"
                 .as_nanos()
         ));
         std::fs::create_dir_all(&dir).unwrap();
+
+        // RAII guard so the temp dir is removed even if an assertion below
+        // panics (mirrors the pattern in main.rs's run test).
+        struct TempDirGuard(std::path::PathBuf);
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _guard = TempDirGuard(dir.clone());
+
         let path = dir.join("shunt.yaml");
         std::fs::write(
             &path,
@@ -1077,7 +1088,5 @@ routes:
             .routes
             .iter()
             .any(|route| route.model == "kimi-k2.7-code" && route.provider == "kimi"));
-
-        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1033,7 +1033,8 @@ provider = "kimi"
     #[test]
     fn yaml_adds_a_provider_and_merges_builtin_overrides() {
         let dir = std::env::temp_dir().join(format!(
-            "shunt-config-yaml-test-{}",
+            "shunt-config-yaml-test-{}-{}",
+            std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use figment::{
-    providers::{Env, Format, Serialized, Toml},
+    providers::{Env, Format, Serialized, Toml, Yaml},
     Figment,
 };
 use serde::{Deserialize, Serialize};
@@ -377,26 +377,57 @@ impl Default for Config {
     }
 }
 
-/// Standard config search order: `./shunt.toml`, then
-/// `$XDG_CONFIG_HOME/shunt/shunt.toml` (defaulting to `~/.config`), then
-/// `<homebrew prefix>/etc/shunt.toml` (`$HOMEBREW_PREFIX`, or the stock
-/// `/opt/homebrew` and `/usr/local` prefixes when unset).
+/// Config file basenames tried in each search directory, in priority order.
+/// TOML stays first so an existing `shunt.toml` always wins over a `.yaml`
+/// dropped alongside it; `.yaml` is preferred over the terser `.yml`.
+const CONFIG_FILENAMES: [&str; 3] = ["shunt.toml", "shunt.yaml", "shunt.yml"];
+
+/// Standard config search directories, in order: the current directory, then
+/// `$XDG_CONFIG_HOME/shunt` (defaulting to `~/.config`), then
+/// `<homebrew prefix>/etc` (`$HOMEBREW_PREFIX`, or the stock `/opt/homebrew`
+/// and `/usr/local` prefixes when unset). Each directory is probed for every
+/// name in [`CONFIG_FILENAMES`] before moving on, so a local `shunt.yaml`
+/// still wins over a config in a later directory.
 fn config_file_candidates(
     xdg_config_home: Option<PathBuf>,
     homebrew_prefix: Option<PathBuf>,
 ) -> Vec<PathBuf> {
-    let mut candidates = vec![PathBuf::from("./shunt.toml")];
+    let mut dirs = vec![PathBuf::from(".")];
     if let Some(dir) = xdg_config_home {
-        candidates.push(dir.join("shunt").join("shunt.toml"));
+        dirs.push(dir.join("shunt"));
     }
     let brew_prefixes = match homebrew_prefix {
         Some(prefix) => vec![prefix],
         None => vec![PathBuf::from("/opt/homebrew"), PathBuf::from("/usr/local")],
     };
     for prefix in brew_prefixes {
-        candidates.push(prefix.join("etc").join("shunt.toml"));
+        dirs.push(prefix.join("etc"));
     }
-    candidates
+    dirs.into_iter()
+        .flat_map(|dir| CONFIG_FILENAMES.iter().map(move |name| dir.join(name)))
+        .collect()
+}
+
+/// A config file's serialization format, selected by its extension so both
+/// `--config foo.yaml` and a discovered `shunt.yaml` are parsed as YAML.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigFormat {
+    Toml,
+    Yaml,
+}
+
+impl ConfigFormat {
+    /// Detect the format from a path's extension. `.yaml`/`.yml` (any case)
+    /// are YAML; everything else — including no extension — is TOML, which
+    /// preserves the historical `shunt.toml` default.
+    fn from_path(path: &Path) -> Self {
+        match path.extension().and_then(|ext| ext.to_str()) {
+            Some(ext) if ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml") => {
+                ConfigFormat::Yaml
+            }
+            _ => ConfigFormat::Toml,
+        }
+    }
 }
 
 impl Config {
@@ -421,7 +452,12 @@ impl Config {
                     }
                 }
             })?;
-            figment = figment.merge(Toml::string(&raw));
+            // The parser is chosen by extension so TOML and YAML configs are
+            // both accepted; an unknown extension is treated as TOML.
+            figment = match ConfigFormat::from_path(path) {
+                ConfigFormat::Toml => figment.merge(Toml::string(&raw)),
+                ConfigFormat::Yaml => figment.merge(Yaml::string(&raw)),
+            };
         }
         let config: Self = figment
             .merge(Env::prefixed("SHUNT_").split("__"))
@@ -641,8 +677,8 @@ mod tests {
     };
 
     use super::{
-        config_file_candidates, AuthMode, Config, ConfigError, ModelConfig, ProviderKind,
-        ResponsesFlavor,
+        config_file_candidates, AuthMode, Config, ConfigError, ConfigFormat, ModelConfig,
+        ProviderKind, ResponsesFlavor,
     };
 
     struct BufferWriter {
@@ -883,8 +919,14 @@ mod tests {
             candidates,
             [
                 "./shunt.toml",
+                "./shunt.yaml",
+                "./shunt.yml",
                 "/home/u/.config/shunt/shunt.toml",
+                "/home/u/.config/shunt/shunt.yaml",
+                "/home/u/.config/shunt/shunt.yml",
                 "/opt/homebrew/etc/shunt.toml",
+                "/opt/homebrew/etc/shunt.yaml",
+                "/opt/homebrew/etc/shunt.yml",
             ]
         );
     }
@@ -900,8 +942,14 @@ mod tests {
             candidates,
             [
                 "./shunt.toml",
+                "./shunt.yaml",
+                "./shunt.yml",
                 "/opt/homebrew/etc/shunt.toml",
+                "/opt/homebrew/etc/shunt.yaml",
+                "/opt/homebrew/etc/shunt.yml",
                 "/usr/local/etc/shunt.toml",
+                "/usr/local/etc/shunt.yaml",
+                "/usr/local/etc/shunt.yml",
             ]
         );
     }
@@ -948,6 +996,87 @@ provider = "kimi"
         assert_eq!(codex.base_url, "https://chatgpt.com/backend-api");
         assert_eq!(codex.auth, AuthMode::ChatgptOauth);
         assert_eq!(codex.effort.as_deref(), Some("high"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn config_format_is_selected_by_extension() {
+        use std::path::Path;
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("shunt.toml")),
+            ConfigFormat::Toml
+        );
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("shunt.yaml")),
+            ConfigFormat::Yaml
+        );
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("shunt.yml")),
+            ConfigFormat::Yaml
+        );
+        // Case-insensitive, and an unknown/absent extension falls back to TOML.
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("/etc/shunt.YAML")),
+            ConfigFormat::Yaml
+        );
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("shunt.conf")),
+            ConfigFormat::Toml
+        );
+        assert_eq!(
+            ConfigFormat::from_path(Path::new("shunt")),
+            ConfigFormat::Toml
+        );
+    }
+
+    #[test]
+    fn yaml_adds_a_provider_and_merges_builtin_overrides() {
+        let dir = std::env::temp_dir().join(format!(
+            "shunt-config-yaml-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("shunt.yaml");
+        std::fs::write(
+            &path,
+            r#"
+providers:
+  kimi:
+    kind: anthropic
+    base_url: https://api.moonshot.ai/anthropic
+    auth: api_key
+    api_key_env: KIMI_API_KEY
+  codex:
+    effort: high
+routes:
+  - model: kimi-k2.7-code
+    provider: kimi
+"#,
+        )
+        .unwrap();
+
+        let config = Config::load(Some(&path)).unwrap();
+
+        // New provider added from YAML.
+        let kimi = config.provider("kimi").unwrap();
+        assert_eq!(kimi.kind, ProviderKind::Anthropic);
+        assert_eq!(kimi.auth, AuthMode::ApiKey);
+        assert_eq!(kimi.api_key_env.as_deref(), Some("KIMI_API_KEY"));
+        // Built-in codex kept its default base_url/auth while gaining effort,
+        // so YAML deep-merges over the seeded defaults just like TOML does.
+        let codex = config.provider("codex").unwrap();
+        assert_eq!(codex.base_url, "https://chatgpt.com/backend-api");
+        assert_eq!(codex.auth, AuthMode::ChatgptOauth);
+        assert_eq!(codex.effort.as_deref(), Some("high"));
+        // The YAML route is applied.
+        assert!(config
+            .routes
+            .iter()
+            .any(|route| route.model == "kimi-k2.7-code" && route.provider == "kimi"));
 
         let _ = std::fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
## Summary

Adds YAML config-file support to the `shunt` gateway alongside the existing TOML.

**What changed:**

- `Cargo.toml`: enabled figment's `yaml` feature (pulls in `serde_yaml`).
- `src/config.rs`:
  - New `ConfigFormat` enum with `from_path()` selecting the parser by file extension — `.yaml`/`.yml` (case-insensitive) → YAML, everything else → TOML (preserves the historical `shunt.toml` default).
  - `Config::load` now merges via `Yaml::string` vs `Toml::string` based on that detection, so `--config foo.yaml` parses as YAML. The self-read + explicit missing-file/parse-error handling is unchanged, so malformed YAML still fails loudly at boot.
  - `config_file_candidates` refactored to probe each search directory for `shunt.toml` → `shunt.yaml` → `shunt.yml` in order. Directory precedence is preserved (a local `shunt.yaml` beats a config in a later directory; `shunt.toml` wins within the same directory).
- Docs: `docs/running.md` and the Astro docs site (`site/src/content/docs/{guides/configuration.md,reference/configuration.md,reference/cli.md}`) now document TOML/YAML format selection, the updated search order, and include a YAML example.

**Tests:**

- Added `config_format_is_selected_by_extension` and `yaml_adds_a_provider_and_merges_builtin_overrides` (mirrors the existing TOML deep-merge test); updated the two candidate-order tests for the new extensions. No existing tests weakened.

## Milestone / spec

Not tied to a specific milestone spec — general enhancement to config loading. No frozen spec in `docs/` describes config file format selection, so none needed updating beyond `docs/running.md` (already listed above).

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Source files stay under 500 lines — `src/config.rs` is already over the limit pre-existing this change (~870 lines before, 1023 after); not introduced by this PR but flagging since the added code grows it further
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (n/a — no frozen spec covers this)
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a — no new Action)

## Notes for reviewers

No config keys or provider semantics changed — this only adds an accepted file format and extends file discovery. `shunt.toml.example` was kept as the canonical TOML template.

**Verification:**

- `cargo fmt --all --check` ✅, `cargo clippy --all-targets --all-features -- -D warnings` ✅, `cargo test --all-features --workspace` → 143 passed / 0 failed ✅.
- End-to-end: built the binary and ran `shunt check` against a real YAML file via both explicit `--config foo.yaml` and `./shunt.yaml` auto-discovery — both loaded and logged the path. A deliberately malformed YAML exited non-zero with a precise line/column parse error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds YAML config support alongside TOML. Format is selected by file extension for both `--config` and auto-discovery; tests now use an RAII temp-dir guard with the PID for reliable cleanup.

- **New Features**
  - Format is chosen by extension for `--config <path>` and auto-discovery (`.toml` → TOML, `.yaml`/`.yml` → YAML; unknown → TOML).
  - Discovery probes `shunt.toml` → `shunt.yaml` → `shunt.yml` within each directory; within a directory TOML wins over YAML, earlier directories still take precedence.
  - Error handling is unchanged: missing or invalid files fail at startup with clear messages.
  - Docs updated with format selection, search order, a YAML example, and a YAML 1.1 boolean-coercion caveat; added `shunt.yaml.example`.

- **Dependencies**
  - Enabled `figment`’s `yaml` feature, which pulls in `serde_yaml`.

<sup>Written for commit 76419c3d25976769025e978874aeb15abea05c5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

