### PR TITLE
docs(readme): note OpenAI's public welcome of Codex via other harnesses

### DIFF
--- a/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
+++ b/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
@@ -13,31 +13,32 @@ under Summary). Checklist enforces `cargo build`/`test`/`clippy -D warnings`/
 sync, and SHA-pinned GitHub Actions — run these locally before filling the
 checklist rather than checking boxes blind.
 
-`gh please pr create --repo <owner>/<repo> --draft ...` printed **no stdout at
+`gh please pr create --repo "$OWNER_REPO" --draft ...` printed **no stdout at
 all** on a successful create (both title and body args accepted, empty
 output). Don't treat empty output as failure — verify with
-`gh pr list --head <branch> --repo <owner>/<repo>` (plain `gh`, not `gh
+`gh pr list --head "$BRANCH" --repo "$OWNER_REPO"` (plain `gh`, not `gh
 please pr list`, which errored with exit 1 / a stray `--json` flag artifact
 in this environment) before assuming the create failed and retrying.
 
 **Worse variant confirmed on PR #39**: `gh please pr create ... --body-file -`
 fed via a bash heredoc (`<<'PRBODY' ... PRBODY`) silently created the PR with
 an **empty body** — no error, exit 0, title set correctly, but
-`gh pr view {number} --json body` came back `""`. Always verify body content after
-create (`gh pr view {number} --json body --jq .body | head`), not just that the PR
-exists. Fix: write the body to a real file with the Write tool and run plain
-`gh pr edit {number} --repo <owner>/<repo> --body-file <path>` — that reliably set
-a 3000+ char body. Prefer writing the body to a file and using `--body-file
-<path>` (not `-`/stdin/heredoc) on the initial `gh please pr create` call too,
-to avoid the empty-body failure mode altogether.
+`gh pr view "$PR_NUMBER" --json body` came back `""`. Always verify body content
+after create (`gh pr view "$PR_NUMBER" --json body --jq .body | head`), not just
+that the PR exists. Fix: write the body to a real file with the Write tool and
+run plain `gh pr edit "$PR_NUMBER" --repo "$OWNER_REPO" --body-file "$BODY_FILE"`
+— that reliably set a 3000+ char body. Prefer writing the body to a file and
+using `--body-file "$BODY_FILE"` (not `-`/stdin/heredoc) on the initial
+`gh please pr create` call too, to avoid the empty-body failure mode altogether.
 
 pleaseai/shunt is not a Graphite repo (`detect-stack-tool.sh` prints nothing) —
 plain `gh please pr create` / `gh pr create` is the right tool, no `gt submit`.
 
 **Confirmed fix works on initial create too (PR #44)**: passing
-`--body-file <path>` (Write-tool-authored file, not stdin/heredoc) directly on
-the first `gh please pr create --draft ...` call produced a correct non-empty
-body (verified via `gh pr view {number} --json body --jq '.body | length'`) —
-no need to create-then-edit. Command still printed no stdout on success;
-`gh pr list --head <branch> --repo pleaseai/shunt --json number,title,isDraft,url`
+`--body-file "$BODY_FILE"` (Write-tool-authored file, not stdin/heredoc) directly
+on the first `gh please pr create --draft ...` call produced a correct non-empty
+body (verified via
+`gh pr view "$PR_NUMBER" --json body --jq '.body | length'`) — no need to
+create-then-edit. Command still printed no stdout on success;
+`gh pr list --head "$BRANCH" --repo pleaseai/shunt --json number,title,isDraft,url`
 (plain gh) is the reliable way to confirm the PR exists and get its number.

--- a/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
+++ b/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
@@ -23,10 +23,10 @@ in this environment) before assuming the create failed and retrying.
 **Worse variant confirmed on PR #39**: `gh please pr create ... --body-file -`
 fed via a bash heredoc (`<<'PRBODY' ... PRBODY`) silently created the PR with
 an **empty body** — no error, exit 0, title set correctly, but
-`gh pr view <n> --json body` came back `""`. Always verify body content after
-create (`gh pr view <n> --json body --jq .body | head`), not just that the PR
+`gh pr view {number} --json body` came back `""`. Always verify body content after
+create (`gh pr view {number} --json body --jq .body | head`), not just that the PR
 exists. Fix: write the body to a real file with the Write tool and run plain
-`gh pr edit <n> --repo <owner>/<repo> --body-file <path>` — that reliably set
+`gh pr edit {number} --repo <owner>/<repo> --body-file <path>` — that reliably set
 a 3000+ char body. Prefer writing the body to a file and using `--body-file
 <path>` (not `-`/stdin/heredoc) on the initial `gh please pr create` call too,
 to avoid the empty-body failure mode altogether.
@@ -37,7 +37,7 @@ plain `gh please pr create` / `gh pr create` is the right tool, no `gt submit`.
 **Confirmed fix works on initial create too (PR #44)**: passing
 `--body-file <path>` (Write-tool-authored file, not stdin/heredoc) directly on
 the first `gh please pr create --draft ...` call produced a correct non-empty
-body (verified via `gh pr view <n> --json body --jq '.body | length'`) —
+body (verified via `gh pr view {number} --json body --jq '.body | length'`) —
 no need to create-then-edit. Command still printed no stdout on success;
 `gh pr list --head <branch> --repo pleaseai/shunt --json number,title,isDraft,url`
 (plain gh) is the reliable way to confirm the PR exists and get its number.

--- a/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
+++ b/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
@@ -40,5 +40,5 @@ on the first `gh please pr create --draft ...` call produced a correct non-empty
 body (verified via
 `gh pr view "$PR_NUMBER" --json body --jq '.body | length'`) — no need to
 create-then-edit. Command still printed no stdout on success;
-`gh pr list --head "$BRANCH" --repo pleaseai/shunt --json number,title,isDraft,url`
+`gh pr list --head "$BRANCH" --repo "$OWNER_REPO" --json number,title,isDraft,url`
 (plain gh) is the reliable way to confirm the PR exists and get its number.

--- a/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
+++ b/.claude/agent-memory/github-pr-manager/reference_shunt-pr-template-and-quirks.md
@@ -33,3 +33,11 @@ to avoid the empty-body failure mode altogether.
 
 pleaseai/shunt is not a Graphite repo (`detect-stack-tool.sh` prints nothing) —
 plain `gh please pr create` / `gh pr create` is the right tool, no `gt submit`.
+
+**Confirmed fix works on initial create too (PR #44)**: passing
+`--body-file <path>` (Write-tool-authored file, not stdin/heredoc) directly on
+the first `gh please pr create --draft ...` call produced a correct non-empty
+body (verified via `gh pr view <n> --json body --jq '.body | length'`) —
+no need to create-then-edit. Command still printed no stdout on success;
+`gh pr list --head <branch> --repo pleaseai/shunt --json number,title,isDraft,url`
+(plain gh) is the reliable way to confirm the PR exists and get its number.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A provider is a `[providers.<name>]` TOML table — two adapter kinds cover ever
 
 OpenAI's Thibault Sottiaux has publicly welcomed running Codex through other coding harnesses:
 
-> [Share the recipe. People want to know how to use GPT-5.6 Sol in CC. We don't discriminate on the harness.](https://x.com/thsottiaux/status/2075830097488249060)
+> Share the recipe. People want to know how to use GPT-5.6 Sol in CC. We don't discriminate on the harness. ([Source](https://x.com/thsottiaux/status/2075830097488249060))
 
 He [followed up](https://x.com/thsottiaux/status/2076119366647894371) by walking through pointing Claude Code ("your orange crab") at GPT-5.6 Sol himself — exactly the inference-layer swap `shunt` performs, no separate app required.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ A provider is a `[providers.<name>]` TOML table — two adapter kinds cover ever
 | `openai` | `responses` | `OPENAI_API_KEY` | `api.openai.com/v1` |
 | `codex` | `responses` | ChatGPT OAuth | `chatgpt.com/backend-api` — reuses `~/.codex/auth.json` (`codex login`) |
 
+OpenAI's Thibault Sottiaux has publicly welcomed running Codex through other coding harnesses:
+
+> [Share the recipe. People want to know how to use GPT-5.6 Sol in CC. We don't discriminate on the harness.](https://x.com/thsottiaux/status/2075830097488249060)
+
+He [followed up](https://x.com/thsottiaux/status/2076119366647894371) by walking through pointing Claude Code ("your orange crab") at GPT-5.6 Sol himself — exactly the inference-layer swap `shunt` performs, no separate app required.
+
+That said, reusing your ChatGPT/Codex subscription (or the Kimi, Cursor, or other backends) from an unofficial client is your own call — a public welcome doesn't guarantee future policy or account enforcement. Use at your own risk.
+
 **Any Anthropic-compatible backend** is one table away — no code changes:
 
 | Provider | `base_url` | Example model IDs |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAI's Thibault Sottiaux has publicly welcomed running Codex through other cod
 
 He [followed up](https://x.com/thsottiaux/status/2076119366647894371) by walking through pointing Claude Code ("your orange crab") at GPT-5.6 Sol himself — exactly the inference-layer swap `shunt` performs, no separate app required.
 
-That said, reusing your ChatGPT/Codex subscription (or the Kimi, Cursor, or other backends) from an unofficial client is your own call — a public welcome doesn't guarantee future policy or account enforcement. Use at your own risk.
+That said, reusing your ChatGPT/Codex subscription (or Kimi, Cursor, or other backends) from an unofficial client is your own call — a public welcome doesn't guarantee future policy or account enforcement. Use at your own risk.
 
 **Any Anthropic-compatible backend** is one table away — no code changes:
 


### PR DESCRIPTION
## Summary

Docs-only change: adds a note in the README (near the built-in providers table, next to the `codex` provider row) quoting OpenAI's Thibault Sottiaux publicly welcoming running Codex through other coding harnesses, plus a terms-of-service caveat that this doesn't guarantee future policy/account enforcement and that using unofficial clients with ChatGPT/Codex (or Kimi/Cursor/other backends) carries account risk.

## Milestone / spec

N/A — README-only addition, no behavior change, no `docs/` spec impact.

## Checklist

- [x] `cargo build` passes — N/A, no Rust source changed
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — N/A, no behavior change
- [x] `cargo clippy --all-targets -- -D warnings` clean — N/A, no Rust source changed
- [x] `cargo fmt --all --check` clean — N/A, no Rust source changed
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A, doesn't touch frozen spec
- [x] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes

## Notes for reviewers

Quotes two tweets from Thibault Sottiaux (OpenAI) as external sourcing for the "harness-agnostic" welcome; the caveat paragraph is there so the README doesn't read as an implicit ToS guarantee.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README note next to the `codex` provider quoting OpenAI’s Thibault Sottiaux welcoming use through other harnesses, with a brief risk disclaimer and his Claude Code → GPT‑5.6 Sol example. Updates agent memory with a confirmed fix: write the PR body to a real file and pass `--body-file` on initial `gh please pr create --draft`; verify with `gh pr view --json body --jq '.body | length'` and `gh pr list --head "$BRANCH" --repo "$OWNER_REPO" --json number,title,isDraft,url` since create prints no stdout.

<sup>Written for commit 622e2f89e99322ba7fa002d2563b790e3c1b3c38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

