### PR TITLE
docs: add comparison of shunt vs other Claude Code gateways

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -165,27 +165,27 @@ toward being a fleet gateway and warrant a conscious decision first.
   deferred+unloaded tools, inject full schema on `tool_reference`) — reference implementation:
   CLIProxyAPI PR #1892 (`Adamcf123/CLIProxyAPI@main`).
 
-- **B. Codex WS: live-probe the continuation normalization.** Reasoning/`function_call`
+- **B. Codex WS: live-probe the continuation normalization (already tracked: [#45]).** Reasoning/`function_call`
   normalization is schema-validated against 3 sources but not yet live-probed
   (`docs/m7-codex-websocket.md:250-270`). Any unaccounted field silently falls back to the
   safe full-input fallback — correctness-safe, but a *latent missed optimization*. A
   probe pass would confirm continuation fires as often as it should.
 
-- **C. Codex WS: mid-stream failure resumption.** A WS failure *before* streaming
+- **C. Codex WS: mid-stream failure resumption (already tracked: [#46]).** A WS failure *before* streaming
   falls back to HTTP transparently, but a *mid-stream* failure surfaces as an error
   SSE event, not a fallback (`src/adapters/responses.rs:92-135`). Consider
   resuming/replaying so a dropped socket mid-turn degrades to HTTP instead of erroring.
 
-- **D. Codex WS: speculative prewarm (`generate:false`).** Explicitly out of scope
+- **D. Codex WS: speculative prewarm (`generate:false`) (already tracked: [#47]).** Explicitly out of scope
   today (`docs/m7-codex-websocket.md:53-58`), but it is a real Codex latency
   optimization — prewarming the socket/context before the first token. Worth
   revisiting once continuation is live-probed.
 
-- **E. Upstream retry/backoff.** The M4-planned bounded retry/backoff is not
+- **E. Upstream retry/backoff (already tracked: [#48]).** The M4-planned bounded retry/backoff is not
   implemented (`docs/implementation-plan.md:247`); transient upstream 429/5xx errors surface
   directly. A small, idempotent retry would improve resilience without adding scope.
 
-- **F. Doc drift: `GET /protocol`.** README advertises a machine-readable spec at
+- **F. Doc drift: `GET /protocol` (already tracked: [#49]).** README advertises a machine-readable spec at
   `GET /protocol` (`README.md:110`) but no such route exists in `src/server.rs`.
   Implement it (cheap, and it's part of the gateway-protocol story) or correct the docs.
 
@@ -221,3 +221,8 @@ mid-stream fallback); the biggest deliberate gap to weigh is minimal fill-first
 multi-account for ChatGPT/Codex.
 
 [#43]: https://github.com/pleaseai/shunt/issues/43
+[#45]: https://github.com/pleaseai/shunt/issues/45
+[#46]: https://github.com/pleaseai/shunt/issues/46
+[#47]: https://github.com/pleaseai/shunt/issues/47
+[#48]: https://github.com/pleaseai/shunt/issues/48
+[#49]: https://github.com/pleaseai/shunt/issues/49

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -49,7 +49,7 @@ Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
 | tool-search / `defer_loading` / `tool_reference` handling | ◐ (works, no ctx savings) | ○⁵ | ◐ (upstream) / ● (fork) | ○ | ○ |
 | Reasoning round-trip to Claude Code `thinking` | ● (encrypted) | ◐ (Kimi/Grok; **Codex dropped**) | ◐ | ○ | ◐ |
 | Multi-account load balancing / failover | ○ | ○ | ● | some | ● |
-| Backend breadth | 4 kinds¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
+| Backend breadth | 4 providers¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
 | Management API / dashboard | ○ | ◐ (monitor TUI) | ● | some | ● |
 | Usage / quota / cost tracking | ○ (Sentry metrics only) | ○ | ● | some | ● |
 | Plugin / interceptor system | ○ | ○ | ● | some | ● |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -128,7 +128,7 @@ possible backends*, not the same product.
 - **No multi-account load balancing / failover.** shunt resolves exactly one
   credential per provider (`src/auth/mod.rs:36-70`); there is no account pool,
   selector, round-robin/fill-first, or cross-credential cooldown. CLIProxyAPI,
-  LiteLLM, Portkey all do. *Deliberate* — but see §6, item B (heavy ChatGPT/Codex
+  LiteLLM, Portkey all do. *Deliberate* — but see §6, item G (heavy ChatGPT/Codex
   rolling-window users are the case where this hurts most).
 - **Narrow backend breadth.** Only Anthropic-Messages passthrough or OpenAI-Responses
   translation; no native Gemini/Bedrock/Azure/Ollama unless they expose one of those

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,186 @@
+# shunt vs. other Claude Code gateways & LLM proxies
+
+A grounded comparison of `shunt` against the tools it sits closest to. The goal is
+to make shunt's design boundaries explicit: what it deliberately does *not* do, and
+where the real, in-scope improvement opportunities are.
+
+> Scope note: claims about shunt cite `file:line` in this repo. Claims about
+> CLIProxyAPI were verified against `router-for-me/CLIProxyAPI@main`. Claims about
+> general gateways (LiteLLM/Portkey/bifrost) are kept at the level the projects
+> themselves advertise and match shunt's own README "Related work" framing.
+
+## 1. What shunt is (and isn't)
+
+shunt is a **spec-compliant Claude Code LLM gateway**: it implements Claude Code's
+official `ANTHROPIC_BASE_URL` gateway contract (`/v1/messages`, `/v1/models`
+discovery, attribution/header pass-through) and does **selective, per-`model`-id**
+diversion — keep the main session on Claude, divert only the models you name onto
+another provider (ChatGPT/Codex, OpenAI, xAI). It translates Anthropic Messages ⇄
+the OpenAI Responses API for mapped models, and passes everything else through to
+Anthropic unchanged. Routing is purely by the request's `model` id — no
+prompt-shape fingerprinting (`README.md:104-131`).
+
+That focus is the axis every comparison below turns on. shunt optimizes for
+**translation fidelity and Claude-Code-native behavior on a single subscription**,
+not for breadth of backends or multi-tenant fleet operation.
+
+## 2. The peer groups
+
+| Group | Examples | Relationship to shunt |
+|---|---|---|
+| **Broad Claude-Code proxy w/ Codex OAuth** | **CLIProxyAPI** (router-for-me) | Closest broad peer — overlaps on Codex/ChatGPT OAuth, Codex WebSocket v2, tool translation |
+| **Narrow Claude Code → Codex swap** | insightflo/chatgpt-codex-proxy | Same inference-layer swap, single backend |
+| **General Claude-Code routers** | musistudio/claude-code-router, 1rgs/fuergaosi233 claude-code-proxy | Usually a *global* model swap, not per-model diversion |
+| **General AI gateways** | LiteLLM, Portkey, bifrost, modelgate | Adjacent infra — possible *backends*, not Claude-Code-native |
+
+## 3. Feature matrix
+
+Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
+
+| Capability | shunt | CLIProxyAPI | General CC routers | General gateways (LiteLLM/Portkey) |
+|---|:--:|:--:|:--:|:--:|
+| Claude Code gateway-protocol compliance (`/v1/models` discovery, attribution pass-through) | ● | ◐ | ◐ | ○ |
+| Selective per-`model`-id diversion (not a global swap) | ● | ◐ | ○ | ◐ |
+| Anthropic Messages ⇄ OpenAI Responses translation | ● | ● | ◐ (mostly chat-completions) | ◐ (chat-completions) |
+| ChatGPT/Codex **subscription** (OAuth) backend | ● | ● | rare | ○ |
+| Codex **WebSocket v2** transport (`responses_websockets=2026-02-06`) | ● | ● | ○ | ○ |
+| Upload trimming (`previous_response_id` continuation) **on the translation path** | ● | ○ (passthrough only) | ○ | ○ |
+| tool-search / `defer_loading` / `tool_reference` handling | ◐ (works, no ctx savings) | ◐ (upstream) / ● (fork) | ○ | ○ |
+| Multi-account load balancing / failover | ○ | ● | some | ● |
+| Backend breadth | 4 kinds¹ | 11 backends² | varies | 100–1600+ |
+| Management API / dashboard | ○ | ● | some | ● |
+| Usage / quota / cost tracking | ○ (Sentry metrics only) | ● | some | ● |
+| Plugin / interceptor system | ○ | ● | some | ● |
+| Guardrails / policy / RBAC | ○ | ◐ | rare | ● |
+| Language / footprint | Rust, single binary | Go | Node/Python | Go/Node/Python |
+| Config model | TOML + env, hot-reload | YAML + management API | varies | YAML/UI |
+
+¹ shunt: two adapter *kinds* (`anthropic` passthrough, `responses` translation) with
+4 built-in providers (Anthropic, OpenAI, ChatGPT/Codex, xAI) — any Anthropic-Messages
+or OpenAI-Responses endpoint is config-only (`src/config.rs:180-190,316-363`).
+² CLIProxyAPI: aistudio, antigravity, claude, codex, codex-ws, gemini, gemini-vertex,
+kimi, openai-compat, xai, xai-ws.
+
+## 4. Where shunt leads
+
+- **Claude-Code-native fidelity.** shunt implements the *official* gateway contract
+  instead of the "hash the subagent system prompt" heuristic older CC proxies use;
+  the session stays inside Claude Code's harness (same tool loop, skills, script
+  paths) — only token generation is outsourced (`README.md:97-131`). Most general
+  routers and gateways are OpenAI-chat-completions-centric and don't honor Claude
+  Code's discovery/attribution surface.
+
+- **Upload trimming on the *translation* path (the standout).** Both shunt and
+  CLIProxyAPI speak Codex WebSocket v2, but they occupy different roles:
+  - **shunt actively synthesizes continuation.** Because it translates
+    Anthropic ⇄ Responses (Claude Code never sends `previous_response_id`), shunt
+    stores the transcript on the pooled connection, diffs the next request against
+    it with type-aware normalization to defeat translation drift, and injects
+    `previous_response_id` + input-delta — achieving real upload trimming on the
+    Claude→Codex path (`src/adapters/codex_continuation.rs:79-114`,
+    `src/adapters/codex_ws.rs`).
+  - **CLIProxyAPI's WS is a warm-socket passthrough.** Its session struct stores no
+    transcript/response-id; it relies on the client (Codex CLI) to send
+    `previous_response_id`. On its *translation* path (Claude→Codex) it re-sends full
+    input every turn — connection reuse only, no upload trimming — and needs a
+    separate tool-output "repair" cache to keep tool-call pairing consistent.
+
+- **Translation drift correctness.** shunt's normalization (strips backend-only
+  `id/phase/status`, parses `function_call.arguments`, round-trips reasoning
+  `encrypted_content`) makes echoed turns match backend items so continuation
+  actually fires; any unforeseen shape falls back to full input — never wrong
+  context, only a missed optimization (`src/adapters/codex_continuation.rs:11-48`).
+
+- **Small, auditable footprint.** Single Rust binary, TOML+env config with
+  fail-closed boot validation and hot-reload; no runtime plugin surface to secure.
+
+## 5. Where shunt trails — and why
+
+Most gaps are **deliberate scope boundaries**, not oversights. shunt's own README
+positions general gateways (LiteLLM/Portkey/bifrost) as *adjacent infrastructure /
+possible backends*, not the same product.
+
+- **No multi-account load balancing / failover.** shunt resolves exactly one
+  credential per provider (`src/auth/mod.rs:36-70`); there is no account pool,
+  selector, round-robin/fill-first, or cross-credential cooldown. CLIProxyAPI,
+  LiteLLM, Portkey all do. *Deliberate* — but see §6, item B (heavy ChatGPT/Codex
+  rolling-window users are the case where this hurts most).
+- **Narrow backend breadth.** Only Anthropic-Messages passthrough or OpenAI-Responses
+  translation; no native Gemini/Bedrock/Azure/Ollama unless they expose one of those
+  two protocols.
+- **No management API / dashboard / usage-quota / cost tracking.** Endpoints are just
+  `/`, `/health`, `/v1/models`, `/routes`, `/v1/messages`, `/v1/messages/count_tokens`
+  (`src/server.rs:69-75`); observability is opt-in Sentry metrics only
+  (`src/metrics.rs`). CLIProxyAPI ships a full management API + quota/usage manager
+  and a third-party dashboard ecosystem.
+- **No plugin / interceptor system.** The adapter set is a fixed two-variant `match`
+  (`src/proxy.rs:152-163`); CLIProxyAPI has a full plugin host (RPC ABI, auth
+  providers, executor routing, request/response translators).
+- **Plain HTTP only** (TLS out of scope, `docs/m4-inbound-auth.md:13`).
+
+## 6. Improvement opportunities (from this comparison)
+
+Ordered by fit with shunt's mission. **In-scope** items advance high-fidelity
+translation / Claude-Code-native behavior; **scope-boundary** items would move shunt
+toward being a fleet gateway and warrant a conscious decision first.
+
+### In-scope
+
+- **A. tool-search context savings (already tracked: [#43]).** shunt renders
+  `tool_reference` as name-only `"Loaded tool: X"` text and forwards *all* deferred
+  tool schemas upfront (`src/model/responses_request.rs:393-403,475-508`) — the loop
+  works but reclaims zero context. Port the server-side emulation (filter
+  deferred+unloaded tools, inject full schema on `tool_reference`) — reference impl:
+  CLIProxyAPI PR #1892 (`Adamcf123/CLIProxyAPI@main`).
+
+- **B. Codex WS: live-probe the continuation normalization.** Reasoning/`function_call`
+  normalization is schema-validated against 3 sources but not yet live-probed
+  (`docs/m7-codex-websocket.md:250-270`). Any unaccounted field silently drops to the
+  safe full-input fallback — correctness-safe, but a *latent missed optimization*. A
+  probe pass would confirm continuation fires as often as it should.
+
+- **C. Codex WS: mid-stream failure resumption.** A WS failure *before* streaming
+  falls back to HTTP transparently, but a *mid-stream* failure surfaces as an error
+  SSE event, not a fallback (`src/adapters/responses.rs:92-135`). Consider
+  resuming/replaying so a dropped socket mid-turn degrades to HTTP instead of erroring.
+
+- **D. Codex WS: speculative prewarm (`generate:false`).** Explicitly out of scope
+  today (`docs/m7-codex-websocket.md:53-58`), but it is a real Codex latency
+  optimization — prewarming the socket/context before the first token. Worth
+  revisiting once continuation is live-probed.
+
+- **E. Upstream retry/backoff.** The M4-planned bounded retry/backoff is not
+  implemented (`docs/implementation-plan.md:247`); transient upstream 429/5xx surface
+  directly. A small, idempotent retry would improve resilience without adding scope.
+
+- **F. Doc drift: `GET /protocol`.** README advertises a machine-readable spec at
+  `GET /protocol` (`README.md:110`) but no such route exists in `src/server.rs`.
+  Implement it (cheap, and it's part of the gateway-protocol story) or correct the docs.
+
+### Scope-boundary (decide before doing)
+
+- **G. Minimal multi-account for ChatGPT/Codex.** Full LB is out of scope, but heavy
+  users hit ChatGPT/Codex rolling-window caps, where a *fill-first* rotation across a
+  handful of `~/.codex/auth.json`-style logins (burn one account's window before
+  moving to the next) is disproportionately valuable. This is the single biggest
+  feature gap vs CLIProxyAPI and the one most worth a design discussion.
+
+- **H. Per-account quota/usage visibility.** Follows G — if multiple subscription
+  accounts are in play, surfacing each account's 5h/7d window (as CLIProxyAPI's
+  ecosystem does) becomes useful. Ties to the observability gap.
+
+- **I. Native Gemini (and other) backends.** Only relevant if shunt broadens past the
+  Anthropic-Messages / OpenAI-Responses duality. Not currently in scope.
+
+## 7. One-line takeaway
+
+shunt is the **high-fidelity, single-subscription, Claude-Code-native** end of the
+spectrum: it wins on translation correctness and on *upload trimming over the
+translation path* (where CLIProxyAPI's WS is only a passthrough), and it trades away
+fleet features (multi-account LB, management, plugins, backend breadth) by design.
+The highest-value in-scope work is finishing the tool-search context savings
+([#43]) and hardening the Codex WS continuation (live-probe + mid-stream fallback);
+the biggest deliberate gap to weigh is minimal fill-first multi-account for
+ChatGPT/Codex.
+
+[#43]: https://github.com/pleaseai/shunt/issues/43

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -67,8 +67,16 @@ the main session on Claude while diverting only the models you name.
 ⁴ raine/ccp implements its **own** ChatGPT OAuth (PKCE browser + device-code login);
 shunt reuses the Codex CLI login (`~/.codex/auth.json`) and its own PKCE flow is an
 open TODO (`src/auth/mod.rs:18-19`).
-⁵ tool-search / `defer_loading` / `tool_reference` handling is not documented for
-raine/ccp; marked ○ conservatively (absence of evidence, not evidence of absence).
+⁵ **Confirmed by reading raine/ccp source** (`fe80a6b`, 2026-07-11): no tool-search
+handling exists (zero matches for `defer_loading` / `tool_reference` / `tool_search` /
+`advanced-tool-use`). Tools are whitelist-rebuilt to `{name, description, parameters}`
+(`src/providers/codex/translate/request.rs:476-494`), so `defer_loading:true` is
+silently dropped — no 400, but no context saved; a `tool_reference` block in a
+ToolSearch result renders as `[unsupported content block omitted: tool_reference]`
+(`request.rs:836-842`) rather than shunt's clean `"Loaded tool: X"`. Hence ○ (vs
+shunt's ◐): force-enabling `ENABLE_TOOL_SEARCH` against raine/ccp degrades the
+discovery-loop result to a placeholder. By default Claude Code's own gate keeps tool
+search off behind a non-first-party base URL, so this stays latent.
 ⁶ raine/ccp subscription backends: Codex (ChatGPT Plus/Pro), Kimi (kimi.com), Grok
 (grok.com), Cursor Agent — all via subscription OAuth.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -31,7 +31,7 @@ not for breadth of backends or multi-tenant fleet operation.
 | **Subscription-backed CC proxy (same class)** | **raine/claude-code-proxy** | **Closest peer overall** — Rust single binary, per-`model` routing, Codex WebSocket + `previous_response_id` continuation, 4 subscription-OAuth backends (Codex/Kimi/Grok/Cursor) |
 | **Broad Claude-Code proxy w/ Codex OAuth** | **CLIProxyAPI** (router-for-me) | Closest *broad* peer — overlaps on Codex/ChatGPT OAuth, Codex WebSocket v2, tool translation |
 | **Narrow Claude Code → Codex swap** | insightflo/chatgpt-codex-proxy | Same inference-layer swap, single backend |
-| **General Claude-Code routers** | musistudio/claude-code-router, 1rgs/fuergaosi233 claude-code-proxy | Usually a *global* model swap, not per-model diversion |
+| **General Claude-Code routers** | musistudio/claude-code-router, 1rgs/claude-code-proxy, fuergaosi233/claude-code-proxy | Usually a *global* model swap, not per-model diversion |
 | **General AI gateways** | LiteLLM, Portkey, bifrost, modelgate | Adjacent infra — possible *backends*, not Claude-Code-native |
 
 ## 3. Feature matrix

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -28,7 +28,8 @@ not for breadth of backends or multi-tenant fleet operation.
 
 | Group | Examples | Relationship to shunt |
 |---|---|---|
-| **Broad Claude-Code proxy w/ Codex OAuth** | **CLIProxyAPI** (router-for-me) | Closest broad peer — overlaps on Codex/ChatGPT OAuth, Codex WebSocket v2, tool translation |
+| **Subscription-backed CC proxy (same class)** | **raine/claude-code-proxy** | **Closest peer overall** — Rust single binary, per-`model` routing, Codex WebSocket + `previous_response_id` continuation, 4 subscription-OAuth backends (Codex/Kimi/Grok/Cursor) |
+| **Broad Claude-Code proxy w/ Codex OAuth** | **CLIProxyAPI** (router-for-me) | Closest *broad* peer — overlaps on Codex/ChatGPT OAuth, Codex WebSocket v2, tool translation |
 | **Narrow Claude Code → Codex swap** | insightflo/chatgpt-codex-proxy | Same inference-layer swap, single backend |
 | **General Claude-Code routers** | musistudio/claude-code-router, 1rgs/fuergaosi233 claude-code-proxy | Usually a *global* model swap, not per-model diversion |
 | **General AI gateways** | LiteLLM, Portkey, bifrost, modelgate | Adjacent infra — possible *backends*, not Claude-Code-native |
@@ -37,29 +38,41 @@ not for breadth of backends or multi-tenant fleet operation.
 
 Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
 
-| Capability | shunt | CLIProxyAPI | General CC routers | General gateways (LiteLLM/Portkey) |
-|---|:--:|:--:|:--:|:--:|
-| Claude Code gateway-protocol compliance (`/v1/models` discovery, attribution pass-through) | ● | ◐ | ◐ | ○ |
-| Selective per-`model`-id diversion (not a global swap) | ● | ◐ | ○ | ◐ |
-| Anthropic Messages ⇄ OpenAI Responses translation | ● | ● | ◐ (mostly chat-completions) | ◐ (chat-completions) |
-| ChatGPT/Codex **subscription** (OAuth) backend | ● | ● | rare | ○ |
-| Codex **WebSocket v2** transport (`responses_websockets=2026-02-06`) | ● | ● | ○ | ○ |
-| Upload trimming (`previous_response_id` continuation) **on the translation path** | ● | ○ (passthrough only) | ○ | ○ |
-| tool-search / `defer_loading` / `tool_reference` handling | ◐ (works, no ctx savings) | ◐ (upstream) / ● (fork) | ○ | ○ |
-| Multi-account load balancing / failover | ○ | ● | some | ● |
-| Backend breadth | 4 kinds¹ | 11 backends² | varies | 100–1600+ |
-| Management API / dashboard | ○ | ● | some | ● |
-| Usage / quota / cost tracking | ○ (Sentry metrics only) | ● | some | ● |
-| Plugin / interceptor system | ○ | ● | some | ● |
-| Guardrails / policy / RBAC | ○ | ◐ | rare | ● |
-| Language / footprint | Rust, single binary | Go | Node/Python | Go/Node/Python |
-| Config model | TOML + env, hot-reload | YAML + management API | varies | YAML/UI |
+| Capability | shunt | raine/ccp | CLIProxyAPI | Gen. CC routers | Gen. gateways |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Claude Code gateway-protocol compliance (`/v1/models` discovery, attribution pass-through) | ● | ◐ | ◐ | ◐ | ○ |
+| Selective per-`model`-id diversion, main session stays on Claude (not a global swap) | ● | ◐³ | ◐ | ○ | ◐ |
+| Anthropic Messages ⇄ OpenAI Responses translation | ● | ● | ● | ◐ (mostly chat-completions) | ◐ (chat-completions) |
+| ChatGPT/Codex **subscription** (OAuth) backend | ● | ●⁴ | ● | rare | ○ |
+| Codex **WebSocket** Responses transport | ● | ● | ● | ○ | ○ |
+| Upload trimming (`previous_response_id` continuation) **on the translation path** | ● | ● | ○ (passthrough only) | ○ | ○ |
+| tool-search / `defer_loading` / `tool_reference` handling | ◐ (works, no ctx savings) | ○⁵ | ◐ (upstream) / ● (fork) | ○ | ○ |
+| Reasoning round-trip to Claude Code `thinking` | ● (encrypted) | ◐ (Kimi/Grok; **Codex dropped**) | ◐ | ○ | ◐ |
+| Multi-account load balancing / failover | ○ | ○ | ● | some | ● |
+| Backend breadth | 4 kinds¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
+| Management API / dashboard | ○ | ◐ (monitor TUI) | ● | some | ● |
+| Usage / quota / cost tracking | ○ (Sentry metrics only) | ○ | ● | some | ● |
+| Plugin / interceptor system | ○ | ○ | ● | some | ● |
+| Language / footprint | Rust, 1 binary | Rust, 1 binary | Go | Node/Python | Go/Node/Python |
+| Config model | TOML + env, hot-reload | env + config file | YAML + mgmt API | varies | YAML/UI |
 
 ¹ shunt: two adapter *kinds* (`anthropic` passthrough, `responses` translation) with
 4 built-in providers (Anthropic, OpenAI, ChatGPT/Codex, xAI) — any Anthropic-Messages
 or OpenAI-Responses endpoint is config-only (`src/config.rs:180-190,316-363`).
 ² CLIProxyAPI: aistudio, antigravity, claude, codex, codex-ws, gemini, gemini-vertex,
 kimi, openai-compat, xai, xai-ws.
+³ raine/ccp routes by `ANTHROPIC_MODEL` per-model like shunt, but has **no
+Anthropic-passthrough adapter** — an unknown model id returns 400, so you cannot keep
+the main session on Claude while diverting only the models you name.
+⁴ raine/ccp implements its **own** ChatGPT OAuth (PKCE browser + device-code login);
+shunt reuses the Codex CLI login (`~/.codex/auth.json`) and its own PKCE flow is an
+open TODO (`src/auth/mod.rs:18-19`).
+⁵ tool-search / `defer_loading` / `tool_reference` handling is not documented for
+raine/ccp; marked ○ conservatively (absence of evidence, not evidence of absence).
+⁶ raine/ccp subscription backends: Codex (ChatGPT Plus/Pro), Kimi (kimi.com), Grok
+(grok.com), Cursor Agent — all via subscription OAuth.
+
+> "raine/ccp" = [raine/claude-code-proxy](https://github.com/raine/claude-code-proxy).
 
 ## 4. Where shunt leads
 
@@ -70,26 +83,30 @@ kimi, openai-compat, xai, xai-ws.
   routers and gateways are OpenAI-chat-completions-centric and don't honor Claude
   Code's discovery/attribution surface.
 
-- **Upload trimming on the *translation* path (the standout).** Both shunt and
-  CLIProxyAPI speak Codex WebSocket v2, but they occupy different roles:
-  - **shunt actively synthesizes continuation.** Because it translates
-    Anthropic ⇄ Responses (Claude Code never sends `previous_response_id`), shunt
-    stores the transcript on the pooled connection, diffs the next request against
-    it with type-aware normalization to defeat translation drift, and injects
-    `previous_response_id` + input-delta — achieving real upload trimming on the
-    Claude→Codex path (`src/adapters/codex_continuation.rs:79-114`,
-    `src/adapters/codex_ws.rs`).
-  - **CLIProxyAPI's WS is a warm-socket passthrough.** Its session struct stores no
-    transcript/response-id; it relies on the client (Codex CLI) to send
-    `previous_response_id`. On its *translation* path (Claude→Codex) it re-sends full
-    input every turn — connection reuse only, no upload trimming — and needs a
-    separate tool-output "repair" cache to keep tool-call pairing consistent.
+- **Upload trimming on the *translation* path.** Because shunt translates
+  Anthropic ⇄ Responses (Claude Code never sends `previous_response_id`), it
+  *synthesizes* continuation: it stores the transcript on the pooled connection,
+  diffs the next request against it with type-aware normalization, and injects
+  `previous_response_id` + input-delta — real upload trimming on the Claude→Codex
+  path (`src/adapters/codex_continuation.rs:79-114`). This is **not** unique:
+  **raine/claude-code-proxy does the same class of thing** (opt-in
+  `CCP_CODEX_PREVIOUS_RESPONSE_ID`, session-keyed, append-only). The two Rust
+  subscription proxies share it — the real contrast is with **passthrough** proxies
+  like **CLIProxyAPI**, whose Codex WS stores no transcript/response-id, relies on
+  the Codex CLI client to send `previous_response_id`, and therefore re-sends full
+  input every turn on *its* translation path (plus a tool-output "repair" cache to
+  keep tool-call pairing consistent).
 
-- **Translation drift correctness.** shunt's normalization (strips backend-only
-  `id/phase/status`, parses `function_call.arguments`, round-trips reasoning
-  `encrypted_content`) makes echoed turns match backend items so continuation
-  actually fires; any unforeseen shape falls back to full input — never wrong
-  context, only a missed optimization (`src/adapters/codex_continuation.rs:11-48`).
+- **Normalization depth + reasoning fidelity (vs the nearest peer).** Within that
+  shared-continuation pair, shunt goes further than raine/claude-code-proxy on two
+  axes: (1) its continuation normalization parses `function_call.arguments` and
+  round-trips reasoning `encrypted_content`/signature, so continuation keeps firing
+  across tool turns where a shape-only comparison would drop it
+  (`src/adapters/codex_continuation.rs:11-48`); and (2) it **forwards Codex reasoning
+  to Claude Code as `thinking`**, whereas raine/claude-code-proxy **drops Codex
+  reasoning blocks entirely** (its README lists this as a limitation). Any unforeseen
+  shape still falls back to full input — never wrong context, only a missed
+  optimization.
 
 - **Small, auditable footprint.** Single Rust binary, TOML+env config with
   fail-closed boot validation and hot-reload; no runtime plugin surface to secure.
@@ -112,7 +129,14 @@ possible backends*, not the same product.
   `/`, `/health`, `/v1/models`, `/routes`, `/v1/messages`, `/v1/messages/count_tokens`
   (`src/server.rs:69-75`); observability is opt-in Sentry metrics only
   (`src/metrics.rs`). CLIProxyAPI ships a full management API + quota/usage manager
-  and a third-party dashboard ecosystem.
+  and a third-party dashboard ecosystem; even the same-class peer
+  raine/claude-code-proxy ships a built-in **monitor TUI** (live sessions, active /
+  recent requests, error events) that shunt has no equivalent of.
+- **No own ChatGPT OAuth login.** shunt reuses the Codex CLI login
+  (`~/.codex/auth.json`); a first-party PKCE flow is an open TODO
+  (`src/auth/mod.rs:18-19`). raine/claude-code-proxy is prior art here — it ships its
+  own `codex auth login` (PKCE) **and** `codex auth device` (device-code), so it works
+  without the Codex CLI installed.
 - **No plugin / interceptor system.** The adapter set is a fixed two-variant `match`
   (`src/proxy.rs:152-163`); CLIProxyAPI has a full plugin host (RPC ABI, auth
   providers, executor routing, request/response translators).
@@ -175,12 +199,17 @@ toward being a fleet gateway and warrant a conscious decision first.
 ## 7. One-line takeaway
 
 shunt is the **high-fidelity, single-subscription, Claude-Code-native** end of the
-spectrum: it wins on translation correctness and on *upload trimming over the
-translation path* (where CLIProxyAPI's WS is only a passthrough), and it trades away
-fleet features (multi-account LB, management, plugins, backend breadth) by design.
-The highest-value in-scope work is finishing the tool-search context savings
-([#43]) and hardening the Codex WS continuation (live-probe + mid-stream fallback);
-the biggest deliberate gap to weigh is minimal fill-first multi-account for
-ChatGPT/Codex.
+spectrum. Its nearest peer is **raine/claude-code-proxy** — same class (Rust,
+subscription OAuth, per-`model` routing, Codex WS + `previous_response_id`
+continuation) — against which shunt's edge is deeper continuation normalization,
+Codex reasoning fidelity (raine drops it), an Anthropic-passthrough path (keep the
+main session on Claude), and xAI OAuth; raine's edge is a built-in monitor TUI, a
+first-party ChatGPT OAuth login, and Kimi/Cursor breadth. Against **CLIProxyAPI**,
+shunt wins on translation-path upload trimming (CLIProxyAPI's WS is a passthrough)
+and trades away fleet features (multi-account LB, management, plugins, backend
+breadth) by design. The highest-value in-scope work is finishing the tool-search
+context savings ([#43]) and hardening the Codex WS continuation (live-probe +
+mid-stream fallback); the biggest deliberate gap to weigh is minimal fill-first
+multi-account for ChatGPT/Codex.
 
 [#43]: https://github.com/pleaseai/shunt/issues/43

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -162,12 +162,12 @@ toward being a fleet gateway and warrant a conscious decision first.
   `tool_reference` as name-only `"Loaded tool: X"` text and forwards *all* deferred
   tool schemas upfront (`src/model/responses_request.rs:393-403,475-508`) — the loop
   works but reclaims zero context. Port the server-side emulation (filter
-  deferred+unloaded tools, inject full schema on `tool_reference`) — reference impl:
+  deferred+unloaded tools, inject full schema on `tool_reference`) — reference implementation:
   CLIProxyAPI PR #1892 (`Adamcf123/CLIProxyAPI@main`).
 
 - **B. Codex WS: live-probe the continuation normalization.** Reasoning/`function_call`
   normalization is schema-validated against 3 sources but not yet live-probed
-  (`docs/m7-codex-websocket.md:250-270`). Any unaccounted field silently drops to the
+  (`docs/m7-codex-websocket.md:250-270`). Any unaccounted field silently falls back to the
   safe full-input fallback — correctness-safe, but a *latent missed optimization*. A
   probe pass would confirm continuation fires as often as it should.
 
@@ -182,7 +182,7 @@ toward being a fleet gateway and warrant a conscious decision first.
   revisiting once continuation is live-probed.
 
 - **E. Upstream retry/backoff.** The M4-planned bounded retry/backoff is not
-  implemented (`docs/implementation-plan.md:247`); transient upstream 429/5xx surface
+  implemented (`docs/implementation-plan.md:247`); transient upstream 429/5xx errors surface
   directly. A small, idempotent retry would improve resilience without adding scope.
 
 - **F. Doc drift: `GET /protocol`.** README advertises a machine-readable spec at


### PR DESCRIPTION
## Summary

Adds `docs/comparison.md`, a new doc positioning shunt against peer tools in the
Claude Code / Codex gateway space: CLIProxyAPI, narrow Claude→Codex swap tools,
general-purpose Claude Code routers, and general AI gateways (LiteLLM, Portkey).

### Changes

- New `docs/comparison.md` with a feature matrix comparing shunt to each peer
  category.
- Documents where shunt leads: translation fidelity, and upload trimming via
  `previous_response_id` continuation on the translation path (versus
  CLIProxyAPI's passthrough WebSocket approach, which re-sends full context).
- Documents where shunt intentionally trails: multi-account load balancing,
  a management API, and a plugin system — these are deliberately out of scope
  for shunt's current focus.
- Includes an "improvement opportunities" section identifying follow-up work,
  which spawned the related issues linked below.

## Milestone / spec

N/A — this is a comparison/positioning doc, not an implementation of a milestone
spec in `docs/`. No frozen spec is affected.

## Checklist

- [x] `cargo build` passes (docs-only change, no source files touched)
- [x] `cargo test` passes (docs-only change, no source files touched)
- [x] `cargo clippy --all-targets -- -D warnings` clean (docs-only change)
- [x] `cargo fmt --all --check` clean (docs-only change)
- [x] Source files stay under 500 lines (no source files changed)
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (N/A, no spec deviation)
- [x] Any new GitHub Action is pinned to a full commit SHA (no workflow changes)

## Notes for reviewers

Docs-only PR, single commit, no runtime code changes. Worth double-checking the
feature matrix and the "leads/trails" framing for accuracy, since it sets public
expectations about shunt's scope relative to CLIProxyAPI and general AI gateways.

## Related Issues

Related to #43, #45, #46, #47, #48, #49

These are the improvement-opportunity issues this comparison doc spawned
(tool-search context savings; Codex WS live-probe, mid-stream fallback,
prewarm, upstream retry, and `GET /protocol`). Not closed by this PR — it's
documentation, not the implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/comparison.md` comparing `shunt` to Claude Code gateways and LLM proxies. Confirms `raine/claude-code-proxy` is the closest peer, corrects continuation framing, and contrasts passthrough proxies like `CLIProxyAPI`.

- **New Features**
  - Added `docs/comparison.md` with a feature matrix and links to issues #43, #45–#49.
  - Clarifies Codex continuation is shared with `raine/claude-code-proxy`; source‑verifies `raine` lacks tool‑search handling; contrasts `CLIProxyAPI`.

- **Bug Fixes**
  - Fixed §6 cross‑reference (B → G); standardized “Backend breadth” to “4 providers”; corrected routers row repo names (`1rgs` and `fuergaosi233` are distinct).

<sup>Written for commit ae4488bc26b463d13778780e429791ad0a2b0910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

