### PR TITLE
fix(codex-ws): install rustls crypto provider to prevent wss panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,7 @@ dependencies = [
  "futures-util",
  "notify",
  "reqwest 0.12.28",
+ "rustls",
  "sentry",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # (aws-lc-rs via sentry's reqwest `rustls` feature, ring via reqwest's own
 # `rustls-tls` feature), so rustls refuses to auto-select one. tokio-tungstenite
 # pulls rustls/tokio-rustls with no provider feature, so it needs the default
-# installed. Depend on rustls directly to install the process-wide default at
-# startup — see `install_crypto_provider` in main.rs.
+# installed. Depend on rustls directly to install the process-wide default on
+# the first websocket handshake — see `ensure_crypto_provider` in
+# src/adapters/codex_ws.rs.
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 sentry = { version = "0.48.4", default-features = false, features = ["backtrace", "contexts", "metrics", "panic", "reqwest", "rustls", "tracing"] }
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ figment = { version = "0.10", features = ["toml", "env"] }
 futures-util = "0.3"
 notify = "8.2.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+# Feature unification compiles both rustls crypto providers into the binary
+# (aws-lc-rs via reqwest/sentry, ring via the tokio-tungstenite chain), so
+# rustls refuses to auto-select one. Depend on rustls directly to install the
+# process-wide default at startup — see `install_crypto_provider` in main.rs.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 sentry = { version = "0.48.4", default-features = false, features = ["backtrace", "contexts", "metrics", "panic", "reqwest", "rustls", "tracing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,11 @@ futures-util = "0.3"
 notify = "8.2.0"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 # Feature unification compiles both rustls crypto providers into the binary
-# (aws-lc-rs via reqwest/sentry, ring via the tokio-tungstenite chain), so
-# rustls refuses to auto-select one. Depend on rustls directly to install the
-# process-wide default at startup — see `install_crypto_provider` in main.rs.
+# (aws-lc-rs via sentry's reqwest `rustls` feature, ring via reqwest's own
+# `rustls-tls` feature), so rustls refuses to auto-select one. tokio-tungstenite
+# pulls rustls/tokio-rustls with no provider feature, so it needs the default
+# installed. Depend on rustls directly to install the process-wide default at
+# startup — see `install_crypto_provider` in main.rs.
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 sentry = { version = "0.48.4", default-features = false, features = ["backtrace", "contexts", "metrics", "panic", "reqwest", "rustls", "tracing"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/adapters/codex_ws.rs
+++ b/src/adapters/codex_ws.rs
@@ -353,12 +353,31 @@ pub async fn begin(
     })
 }
 
+/// Install the rustls process-wide crypto provider on the first websocket
+/// handshake. Feature unification compiles two providers into the binary —
+/// aws-lc-rs (via sentry's reqwest `rustls` feature) and ring (via reqwest's own
+/// `rustls-tls` feature) — so rustls 0.23 refuses to auto-select one, and
+/// `tokio_tungstenite::connect_async` — which pulls tokio-rustls with no provider
+/// feature of its own — panics without an installed default. Doing it here rather
+/// than only in `main` covers the library target: integration tests and external
+/// consumers reach this path without running `main`. `Once` keeps it idempotent
+/// and race-free across concurrent first turns; pin aws-lc-rs to match reqwest/sentry.
+fn ensure_crypto_provider() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // `install_default` errors only if a provider is already installed, which
+        // is harmless — discard it rather than panicking.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
 /// Perform the websocket handshake, mapping a refused upgrade to a status-bearing
 /// [`CodexWsError`] and capturing the handshake `x-codex-turn-state` if present.
 async fn connect(
     ws_url: &str,
     headers: HeaderMap,
 ) -> Result<(WsStream, Option<String>), CodexWsError> {
+    ensure_crypto_provider();
     let mut request = ws_url
         .into_client_request()
         .map_err(|error| CodexWsError::transport(format!("invalid websocket request: {error}")))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,12 +63,13 @@ fn main() -> anyhow::Result<()> {
 }
 
 /// Install the rustls process-wide crypto provider once, up front. Feature
-/// unification compiles two providers into the binary — aws-lc-rs (reqwest,
-/// sentry) and ring (the tokio-tungstenite chain) — so rustls 0.23 refuses to
-/// auto-select one. reqwest builds its `ClientConfig` with an explicit provider
-/// and is unaffected, but `tokio_tungstenite::connect_async` relies on the
-/// process default and panics on the first `wss://` Codex turn without this.
-/// Pin aws-lc-rs to match reqwest/sentry.
+/// unification compiles two providers into the binary — aws-lc-rs (via sentry's
+/// reqwest `rustls` feature) and ring (via reqwest's own `rustls-tls` feature) —
+/// so rustls 0.23 refuses to auto-select one. reqwest supplies a provider to the
+/// client config it builds and never panics, but `tokio_tungstenite::connect_async`
+/// pulls tokio-rustls with no provider feature of its own and relies on the
+/// process-wide default, so it panics on the first `wss://` Codex turn without
+/// this. Pin aws-lc-rs to match reqwest/sentry.
 fn install_crypto_provider() {
     // `install_default` errors only if a provider is already installed, which is
     // harmless — keep it idempotent rather than panicking.

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ enum Command {
 }
 
 fn main() -> anyhow::Result<()> {
+    install_crypto_provider();
     init_tracing();
     let cli = Cli::parse();
 
@@ -59,6 +60,19 @@ fn main() -> anyhow::Result<()> {
         None if cli.check => check(cli.config),
         None => run(cli.config),
     }
+}
+
+/// Install the rustls process-wide crypto provider once, up front. Feature
+/// unification compiles two providers into the binary — aws-lc-rs (reqwest,
+/// sentry) and ring (the tokio-tungstenite chain) — so rustls 0.23 refuses to
+/// auto-select one. reqwest builds its `ClientConfig` with an explicit provider
+/// and is unaffected, but `tokio_tungstenite::connect_async` relies on the
+/// process default and panics on the first `wss://` Codex turn without this.
+/// Pin aws-lc-rs to match reqwest/sentry.
+fn install_crypto_provider() {
+    // `install_default` errors only if a provider is already installed, which is
+    // harmless — keep it idempotent rather than panicking.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
 /// The runtime is built by hand (not `#[tokio::main]`) so `run` can initialize

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ enum Command {
 }
 
 fn main() -> anyhow::Result<()> {
-    install_crypto_provider();
     init_tracing();
     let cli = Cli::parse();
 
@@ -60,20 +59,6 @@ fn main() -> anyhow::Result<()> {
         None if cli.check => check(cli.config),
         None => run(cli.config),
     }
-}
-
-/// Install the rustls process-wide crypto provider once, up front. Feature
-/// unification compiles two providers into the binary — aws-lc-rs (via sentry's
-/// reqwest `rustls` feature) and ring (via reqwest's own `rustls-tls` feature) —
-/// so rustls 0.23 refuses to auto-select one. reqwest supplies a provider to the
-/// client config it builds and never panics, but `tokio_tungstenite::connect_async`
-/// pulls tokio-rustls with no provider feature of its own and relies on the
-/// process-wide default, so it panics on the first `wss://` Codex turn without
-/// this. Pin aws-lc-rs to match reqwest/sentry.
-fn install_crypto_provider() {
-    // `install_default` errors only if a provider is already installed, which is
-    // harmless — keep it idempotent rather than panicking.
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
 /// The runtime is built by hand (not `#[tokio::main]`) so `run` can initialize


### PR DESCRIPTION
## Summary

Fixes a fatal panic on the **first real `wss://` Codex turn**: `Could not
automatically determine the process-level CryptoProvider from Rustls crate
features`, raised at `rustls::ClientConfig::builder_with_protocol_versions`
and reached via `tokio_tungstenite::connect_async`.

- Sentry: `SHUNT-1`
- First seen: `shunt-gateway@0.8.0`, 22 events

### Root cause

Cargo feature unification compiles **both** rustls crypto providers into the
single `rustls 0.23` build in this binary:

- **aws-lc-rs** — pulled in via `reqwest`'s `rustls-tls` feature and `sentry`
- **ring** — pulled in via the `tokio-tungstenite` / `rustls-platform-verifier`
  chain

rustls 0.23 refuses to auto-select a provider when more than one is compiled
in and no process-wide default has been installed. `reqwest` and `sentry`
build their own `ClientConfig` with an explicit provider, so they're
unaffected — only `tokio-tungstenite`'s default connector relies on the
process default, which panics.

### Why CI missed it

Every WebSocket test in the suite uses `ws://` (plaintext), so no TLS
handshake — and no crypto-provider lookup — ever runs in CI.

### Fix

- Add `rustls` as a direct dependency (`features = ["aws_lc_rs"]`)
- Call `rustls::crypto::aws_lc_rs::default_provider().install_default()` as
  the first line of `main()` (`install_crypto_provider()`), pinned to
  `aws-lc-rs` to match `reqwest`/`sentry`'s provider

## Milestone / spec

N/A — targeted production bug fix (Sentry SHUNT-1), not tied to an M-series
milestone/spec doc.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (verified with a temporary real `wss://chatgpt.com/`
      connect test — now returns HTTP 403, i.e. TLS negotiates and the server
      is reached, instead of panicking at `ClientConfig::builder`; the temp
      test was removed afterward. Full suite green: 31 integration tests +
      all unit/doc tests, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (n/a, no spec touched)
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a, no workflow changes)

## Notes for reviewers

- `install_crypto_provider()` uses `let _ = ... .install_default()` — it's
  intentionally idempotent (only errors if a provider is already installed),
  not `.expect(...)`, since panicking here would just reproduce the original
  failure mode in a different spot.
- The provider is pinned to `aws-lc-rs` specifically to match what
  `reqwest`/`sentry` already build with, avoiding a second provider mismatch.
- No test in the suite currently exercises a real `wss://` handshake (by
  design, to keep tests network-free); the verification for this fix was done
  manually and the temporary test was not kept.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install a process-wide `rustls` crypto provider to stop the first `wss://` Codex connection from panicking.

- **Bug Fixes**
  - Install the default provider in the WebSocket path via `ensure_crypto_provider()` (called at the top of `connect()` and guarded by `std::sync::Once`) to cover library consumers and tests; pins to `aws_lc_rs` and prevents `tokio_tungstenite::connect_async` panics when multiple providers are compiled.
  - Correct comments: `ring` comes from `reqwest`’s `rustls-tls`; `reqwest` first reads the process default and falls back to its bundled provider if none is set.

- **Dependencies**
  - Add direct `rustls` with `features = ["aws_lc_rs"]`.

<sup>Written for commit 3df35d36d0bc09e483dd988b2f9a0e6732d3c7ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

