### PR TITLE
feat(server): serve GET /protocol gateway-protocol descriptor

### DIFF
--- a/.claude/skills/run-shunt/SKILL.md
+++ b/.claude/skills/run-shunt/SKILL.md
@@ -156,9 +156,9 @@ use `smoke.sh` (mock upstream) rather than this path.
   defaults, so you only need to specify what differs.
 - **A discovery `[[models]]` entry with no matching `[[routes]]`** logs a `WARN` at
   startup/`check` but is not fatal.
-- **No `/protocol` endpoint yet.** The README references the spec's `GET /protocol`,
-  but the current router (`src/server.rs`) only serves `/`, `/v1/models`,
-  `/v1/messages`, and `/v1/messages/count_tokens`. Don't assume `/protocol` exists.
+- **`GET /protocol` is the machine-readable gateway contract.** It is unauthenticated
+  and reports shunt's package version, Anthropic-Messages format, supported endpoints,
+  header handling, attribution behavior, and model-discovery constraints.
 - **zsh quoting:** quote URLs containing `?` (globbing) and mind `noclobber` on `>`
   redirects when driving by hand in this repo's shell.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -244,7 +244,7 @@ layer, not stored in the file.
 | **M1** | **Anthropic ⇄ OpenAI Responses translation + `openai` (API key)** | Config + `routing.rs`; the `responses` adapter (request + **streaming** response converter, tool calls, reasoning effort); drive an OpenAI model end-to-end from Claude Code with `OPENAI_API_KEY`. **Core translation lands here.** |
 | **M2** | **`codex` / `chatgpt` backend (ChatGPT OAuth)** | Reuse M1 translation; add `TokenStore` over `~/.codex/auth.json` (auto-refresh) + `chatgpt-account-id` header + `chatgpt.com/backend-api/codex/responses`; `shunt login` fallback. Delivers OpenAI-family via ChatGPT subscription. |
 | **M3** | **Model map + discovery UX** | `codex/models.rs` (id→codex model + effort); `GET /v1/models`; document `ANTHROPIC_CUSTOM_MODEL_OPTION` path; optional `count_tokens`. |
-| **M4** | **Hardening + observability** | tracing spans on session id; timeouts, upstream retry/backoff, graceful shutdown; optional request capture behind a flag; optional `GET /protocol`. |
+| **M4** | **Hardening + observability** | tracing spans on session id; timeouts, upstream retry/backoff, graceful shutdown; optional request capture behind a flag; shipped `GET /protocol` descriptor. |
 
 MVP for the stated goal = **M0 + M1 + M2** (drive OpenAI **and** Codex/ChatGPT). M3 is UX
 polish; M4 is production-readiness.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod headers;
 pub mod keepalive;
 pub mod metrics;
 pub mod model;
+pub mod protocol;
 pub mod proxy;
 pub mod reload;
 pub mod routes;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,164 @@
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolDescriptor {
+    pub name: &'static str,
+    pub version: &'static str,
+    pub format: &'static str,
+    pub spec_url: &'static str,
+    pub endpoints: Vec<EndpointDescriptor>,
+    pub request_headers: RequestHeaders,
+    pub system_prompt_attribution: SystemPromptAttribution,
+    pub model_discovery: ModelDiscovery,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EndpointDescriptor {
+    pub method: &'static str,
+    pub path: &'static str,
+    pub description: &'static str,
+    pub optional: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RequestHeaders {
+    pub forward_unchanged: Vec<HeaderDescriptor>,
+    pub consumed: Vec<HeaderDescriptor>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeaderDescriptor {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SystemPromptAttribution {
+    pub behavior: &'static str,
+    pub disable_client_side: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelDiscovery {
+    pub startup_request: &'static str,
+    pub enable_client_side: &'static str,
+    pub picker_filter: &'static str,
+    pub non_claude_models: &'static str,
+}
+
+/// Describe the gateway-protocol contract implemented by this shunt version.
+pub async fn get() -> Json<ProtocolDescriptor> {
+    let descriptor = ProtocolDescriptor {
+        name: "shunt",
+        version: env!("CARGO_PKG_VERSION"),
+        format: "anthropic-messages",
+        spec_url: "https://code.claude.com/docs/en/llm-gateway-protocol",
+        endpoints: vec![
+            EndpointDescriptor {
+                method: "POST",
+                path: "/v1/messages",
+                description: "Anthropic Messages inference, including SSE streaming responses",
+                optional: false,
+            },
+            EndpointDescriptor {
+                method: "POST",
+                path: "/v1/messages/count_tokens",
+                description: "Token counting; may pass through, estimate locally, or report unsupported depending on the route",
+                optional: true,
+            },
+            EndpointDescriptor {
+                method: "GET",
+                path: "/v1/models",
+                description: "Anthropic-compatible model discovery",
+                optional: false,
+            },
+            EndpointDescriptor {
+                method: "GET",
+                path: "/routes",
+                description: "Shunt-native configured route table",
+                optional: false,
+            },
+            EndpointDescriptor {
+                method: "GET",
+                path: "/health",
+                description: "Process liveness and package version",
+                optional: false,
+            },
+            EndpointDescriptor {
+                method: "GET",
+                path: "/protocol",
+                description: "This gateway-protocol descriptor",
+                optional: false,
+            },
+        ],
+        request_headers: RequestHeaders {
+            forward_unchanged: vec![
+                HeaderDescriptor {
+                    name: "anthropic-version",
+                    description: "Anthropic API version requested by the client",
+                },
+                HeaderDescriptor {
+                    name: "anthropic-beta",
+                    description: "Anthropic beta feature identifiers requested by the client",
+                },
+            ],
+            consumed: vec![
+                HeaderDescriptor {
+                    name: "authorization",
+                    description: "Client credential used or replaced according to the selected route authentication mode",
+                },
+                HeaderDescriptor {
+                    name: "x-api-key",
+                    description: "Client credential used or replaced according to the selected route authentication mode",
+                },
+                HeaderDescriptor {
+                    name: "x-claude-code-session-id",
+                    description: "Claude Code session identifier used for tracing and transport connection reuse",
+                },
+                HeaderDescriptor {
+                    name: "x-claude-code-agent-id",
+                    description: "Claude Code agent metadata accepted by the gateway",
+                },
+                HeaderDescriptor {
+                    name: "x-claude-code-parent-agent-id",
+                    description: "Claude Code parent-agent metadata accepted by the gateway",
+                },
+            ],
+        },
+        system_prompt_attribution: SystemPromptAttribution {
+            behavior: "Shunt forwards the Claude Code attribution block unchanged and never strips, reorders, or merges it",
+            disable_client_side: "Set CLAUDE_CODE_ATTRIBUTION_HEADER=0 in the Claude Code client",
+        },
+        model_discovery: ModelDiscovery {
+            startup_request: "GET /v1/models?limit=1000",
+            enable_client_side: "Set CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 in the Claude Code client",
+            picker_filter: "Claude Code ignores discovered entries whose id does not begin with claude or anthropic",
+            non_claude_models: "Use ANTHROPIC_CUSTOM_MODEL_OPTION for non-Claude model ids",
+        },
+    };
+
+    tracing::info!("served GET /protocol descriptor");
+    Json(descriptor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get;
+
+    #[tokio::test]
+    async fn returns_gateway_protocol_descriptor() {
+        let response = get().await;
+        let body = serde_json::to_value(response.0).unwrap();
+
+        assert_eq!(body["format"], "anthropic-messages");
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+        let endpoints = body["endpoints"].as_array().unwrap();
+        assert!(endpoints
+            .iter()
+            .any(|endpoint| endpoint["path"] == "/protocol"));
+        assert!(endpoints
+            .iter()
+            .any(|endpoint| endpoint["path"] == "/v1/messages"));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::{
     auth::inbound::InboundAuth,
     config::{Config, ConfigError},
-    discovery, proxy,
+    discovery, protocol, proxy,
     reload::{RuntimeState, SharedState},
     routes,
 };
@@ -69,6 +69,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState), ConfigError
     let router = Router::new()
         .route("/", get(root_index))
         .route("/health", get(health))
+        .route("/protocol", get(protocol::get))
         .route("/v1/models", get(discovery::get))
         .route("/routes", get(routes::get))
         .route("/v1/messages", post(proxy::post))
@@ -81,7 +82,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState), ConfigError
 /// which keeps the pre-existing liveness probe working.
 async fn root_index() -> String {
     format!(
-        "shunt v{} — Anthropic Messages proxy. Endpoints: /v1/models, /routes, /v1/messages, /v1/messages/count_tokens, /health\n",
+        "shunt v{} — Anthropic Messages proxy. Endpoints: /v1/models, /routes, /v1/messages, /v1/messages/count_tokens, /protocol, /health\n",
         env!("CARGO_PKG_VERSION")
     )
 }

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -149,6 +149,26 @@ async fn get_health_returns_ok_status_and_version() {
 }
 
 #[tokio::test]
+async fn get_protocol_returns_descriptor_format_and_version() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let upstream = MockServer::start().await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{}/protocol", gateway.base_url))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_eq!(body["format"], "anthropic-messages");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[tokio::test]
 async fn messages_forwards_anthropic_headers_verbatim_and_preserves_query() {
     if !can_bind_loopback() {
         return;


### PR DESCRIPTION
## Summary

Adds an unauthenticated `GET /protocol` route that serves shunt's machine-readable gateway-protocol descriptor, resolving the docs/behavior drift where `README.md` advertised the endpoint but no route existed.

- New `src/protocol.rs` implementing the descriptor: request/response format, endpoints, header handling, attribution behavior, and model-discovery constraints.
- Wires the route into `src/server.rs` / `src/lib.rs`.
- Unit tests in `src/protocol.rs` plus an integration test in `tests/passthrough.rs`.
- Updates `docs/implementation-plan.md` (M4 note) and `.claude/skills/run-shunt/SKILL.md` to remove the now-false "no /protocol endpoint yet" note.

## Milestone / spec

M4 (optional work item) — see `docs/implementation-plan.md:247` and `docs/comparison.md` §6 item F.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] Any new GitHub Action is pinned to a full commit SHA (no new Actions in this change)

## Notes for reviewers

`GET /protocol` is intentionally unauthenticated (no API key required) since it only serves a static, machine-readable descriptor of shunt's own gateway contract — no upstream credentials or request data are involved.

Closes #49


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an unauthenticated GET /protocol that returns a machine-readable gateway-protocol descriptor for shunt. This fixes the README drift and lets clients discover capabilities.

- **New Features**
  - Serve /protocol via a new protocol descriptor (version, `anthropic-messages` format, spec URL, supported endpoints with optionality, header handling, attribution, and model discovery notes).
  - Wire route into the axum router and update the root index to list /protocol.
  - Add unit and integration tests; update docs and skills to reflect the shipped endpoint.

<sup>Written for commit 1b26038c76f8c7c8558dcec770b62910f15da439. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

