### PR TITLE
feat(xai): add grok subscription-OAuth provider via the Grok CLI proxy

### DIFF
--- a/docs/m6-xai-provider.md
+++ b/docs/m6-xai-provider.md
@@ -1,23 +1,29 @@
 # M6 — xAI Grok provider (spec)
 
-> **⚠️ Experimental — not yet verified against the live xAI API.** The flow is validated
-> against the reference implementations (Hermes, OpenCode) and unit tests with mocked
-> endpoints only; it has not been exercised with a real SuperGrok account or `XAI_API_KEY`.
-> Endpoints, request quirks, and error semantics may change once verified live.
+> **⚠️ Experimental.** Live-tested against a real SuperGrok OAuth login (2026-07): the device
+> flow, token store, refresh, and bearer injection all work end-to-end. The key correction from
+> that test is baked in below — the subscription OAuth path targets the **Grok CLI chat proxy**
+> (`cli-chat-proxy.grok.com`), not the developer API (`api.x.ai`), which rejects a subscription
+> bearer with a **402** (`personal-team-blocked:spending-limit`) / **403** tier gate. Whether a
+> given account can use the OAuth path at all depends on its tier (xAI has gated it to SuperGrok
+> Heavy at times); accounts without API entitlement should use the `XAI_API_KEY` path.
 
 > Companion to [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) and
-> [`m1-responses-translation.md`](m1-responses-translation.md). Adds the `xai` provider: the
-> xAI Grok Responses API, reachable two ways — an **API key** (`XAI_API_KEY`) or a
-> **subscription OAuth** login (SuperGrok / X Premium+) via the RFC 8628 device-code flow.
-> Reuses the whole M1 translation core; only the per-backend quirks and a new credential
-> source are added. Reference implementations: OpenCode's `xai.ts` and Hermes' `auth.py` /
-> `transports/codex.py` (device flow, refresh, request shaping).
+> [`m1-responses-translation.md`](m1-responses-translation.md). Adds two built-in providers for
+> xAI Grok — an **API key** `xai` (developer API, `XAI_API_KEY`) and a **subscription OAuth**
+> `grok` (SuperGrok / X Premium+, RFC 8628 device-code flow). Reuses the whole M1 translation
+> core; only the per-backend quirks and a new credential source are added. Reference
+> implementations: OpenCode's `xai.ts`, Hermes' `auth.py`, and raine/claude-code-proxy's
+> `src/providers/grok` (which pinned down the CLI-proxy endpoint + identity headers).
 
 ## 1. Scope
 
-- A built-in `xai` provider (`kind = "responses"`, `base_url = https://api.x.ai/v1`) that
-  defaults to the **API-key** path (`XAI_API_KEY`) and can be flipped to **subscription OAuth**
-  (`auth = "xai_oauth"`) in `shunt.toml`.
+- Two built-in providers (`kind = "responses"`):
+  - `xai` — the **API-key** path, `base_url = https://api.x.ai/v1`, `auth = api_key`
+    (`XAI_API_KEY`). The developer API, billed per token.
+  - `grok` — the **subscription OAuth** path, `base_url = https://cli-chat-proxy.grok.com/v1`,
+    `auth = xai_oauth`. The Grok CLI chat proxy, which honors a SuperGrok / X Premium+ login and
+    is not subject to API billing. Sends the Grok-CLI identity headers (§6).
 - A `shunt login xai` subcommand that runs the device-code flow and writes a shunt-owned
   credential file, refreshed automatically on expiry.
 - xAI-flavored request translation (a third [`ResponsesFlavor`] beside OpenAI and ChatGPT/Codex).
@@ -32,9 +38,14 @@ Out of scope: any change to the M1 response translation / SSE state machine.
 | device authorization URL | `https://auth.x.ai/oauth2/device/code` |
 | token URL | `https://auth.x.ai/oauth2/token` |
 | `client_id` | `b1a00492-073a-47ea-816f-4c329264a828` (public Grok-CLI client, no secret) |
-| scope | `openid profile email offline_access grok-cli:access api:access` |
+| scope | `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write` |
 | device-code grant | `urn:ietf:params:oauth:grant-type:device_code` |
-| API endpoint | `POST https://api.x.ai/v1/responses` (OpenAI Responses shape) |
+| API endpoint (OAuth `grok`) | `POST https://cli-chat-proxy.grok.com/v1/responses` (Grok CLI proxy) |
+| API endpoint (API-key `xai`) | `POST https://api.x.ai/v1/responses` (developer API) |
+
+The `conversations:read`/`conversations:write` scopes are required by the CLI proxy; the OpenAI
+Responses shape is identical on both surfaces. The subscription request also carries the Grok-CLI
+identity headers (§6).
 
 All token/device requests are `application/x-www-form-urlencoded` with `Accept: application/json`.
 The API request carries `Authorization: Bearer <access_token>` only — no account-id or
@@ -105,10 +116,17 @@ All gateway-owned errors use the Anthropic error envelope via the `auth_error` h
 
 ## 6. Request shaping — the `xai` [`ResponsesFlavor`]
 
-Detected table-driven, not by provider name: `auth = chatgpt_oauth` → ChatGPT; a base_url host
-of `x.ai`/`*.x.ai` → xAI (covers both the API-key and OAuth `xai` providers); else OpenAI. The
-xai flavor differs from the stock OpenAI translation in three ways (learned from 400s in the
-reference impls):
+Detected table-driven, not by provider name: `auth = chatgpt_oauth` → ChatGPT; `auth = xai_oauth`
+→ xAI (the OAuth `grok` provider, whose `grok.com` host isn't an `x.ai` host); a base_url host of
+`x.ai`/`*.x.ai` → xAI (the API-key `xai` provider); else OpenAI. The xai flavor differs from the
+stock OpenAI translation in three ways (learned from 400s in the reference impls):
+
+**Grok-CLI identity headers.** The subscription OAuth path (`Credential::XaiOauth`) additionally
+sends `x-xai-token-auth: xai-grok-cli`, `x-grok-client-identifier: grok-shell`,
+`x-grok-client-version: 0.2.93`, and `accept: text/event-stream` — the CLI proxy
+(`cli-chat-proxy.grok.com`) gates on them and otherwise answers as if the caller were an
+unentitled API client. The API-key `xai` path sends the bearer only. Neither sends `OpenAI-Beta`.
+
 
 | Field | OpenAI | ChatGPT/Codex | **xAI** |
 | :-- | :-- | :-- | :-- |
@@ -127,17 +145,21 @@ or sent per-request via `output_config.effort`. Derived defaults (thinking flag,
 stay off. Encrypted-reasoning
 replay (`include`) stays gated on the client's extended-thinking flag, exactly like the codex path.
 
+Live note (2026-07): `grok-4.5` on the CLI proxy **accepts** `reasoning.effort` (HTTP 200 with a
+configured `effort = "high"` route), so it is not among the models that 400; the opt-in default
+stays as the safe choice for the families that still reject it.
+
 ## 7. Config & validation (`config.rs`)
 
-- New `AuthMode::XaiOauth`. Built-in `xai` provider seeded in `Config::default()`
-  (`kind = responses`, `base_url = https://api.x.ai/v1`, `auth = api_key`,
-  `api_key_env = XAI_API_KEY`).
+- `AuthMode::XaiOauth`. Two built-in providers seeded in `Config::default()`: `xai`
+  (`base_url = https://api.x.ai/v1`, `auth = api_key`, `api_key_env = XAI_API_KEY`) and `grok`
+  (`base_url = https://cli-chat-proxy.grok.com/v1`, `auth = xai_oauth`). Both `kind = responses`.
 - **Bearer-leak guard:** a provider with `auth = "xai_oauth"` must be `kind = "responses"`
   (the anthropic adapter has no XaiOauth injection and would forward the client's own
   credential), use an **https** base_url (never plaintext), and have a base_url host of
-  `x.ai` or `*.x.ai` — else startup fails with `XaiOauthWrongKind` / `XaiOauthNotHttps` /
-  `XaiOauthNonXaiHost`. shunt refuses to inject a subscription token toward another origin
-  (mirrors Hermes' endpoint re-validation).
+  `x.ai`/`*.x.ai` **or** `grok.com`/`*.grok.com` (`host_is_grok_subscription`) — else startup
+  fails with `XaiOauthWrongKind` / `XaiOauthNotHttps` / `XaiOauthNonXaiHost`. shunt refuses to
+  inject a subscription token toward any other origin.
 
 ## 8. Security
 
@@ -160,5 +182,15 @@ replay (`include`) stays gated on the client's extended-thinking flag, exactly l
   1h for long-lived SuperGrok tokens, tightened for ~15-min device-code JWTs) to avoid burning
   single-use refresh tokens on every call. If device-code tokens prove very short-lived in
   practice, revisit the buffer.
-- **Live-API validation.** The flow is verified against the reference implementations and unit
-  tests (mocked token endpoint); it has not been exercised against a live SuperGrok account.
+- **Live-API validation.** ✅ Confirmed end-to-end against a live SuperGrok account (2026-07):
+  `grok-4.5` returns HTTP 200 through the `grok` provider (`cli-chat-proxy.grok.com`) for
+  non-streaming, streaming, and `reasoning.effort` requests. The `api.x.ai` surface returned a 402
+  entitlement gate for the same token, which is what motivated retargeting the OAuth path to the CLI
+  proxy with the Grok-CLI headers. (Whether every account tier is entitled on the CLI proxy still
+  varies — see below.)
+- **Tier gate.** xAI has restricted OAuth API access to SuperGrok Heavy at times (Hermes #26847),
+  surfacing as a 402/403 even for active standard subscribers. shunt keeps both paths so an
+  un-entitled account can fall back to `XAI_API_KEY`. If the CLI proxy proves to honor all tiers,
+  this note can be relaxed.
+- **`grok_client_version` pinning.** `0.2.93` is hardcoded (mirrors the reference Grok CLI). If the
+  proxy starts rejecting stale client versions, make it configurable like the base_url.

--- a/shunt.toml.example
+++ b/shunt.toml.example
@@ -71,14 +71,19 @@ auth = "chatgpt_oauth"         # reads + auto-refreshes ~/.codex/auth.json
                                # input. Only honored for this ChatGPT/Codex backend;
                                # falls back to HTTP if the socket can't be opened.
 
-# xAI Grok (EXPERIMENTAL — not yet verified against the live xAI API).
-# Built-in as an API-key provider (export XAI_API_KEY); to reuse a
-# SuperGrok / X Premium+ subscription instead, uncomment the auth line below and
-# run `shunt login xai`. See docs/m6-xai-provider.md.
-# [providers.xai]              # grok-build-0.1, grok-4.5, grok-4.3
-# kind = "responses"
-# base_url = "https://api.x.ai/v1"
-# auth = "xai_oauth"           # subscription OAuth (~/.shunt/xai-auth.json); omit to use XAI_API_KEY
+# xAI Grok (EXPERIMENTAL). Two built-in providers cover the two ways in — you
+# only need to add [[routes]] (grok-build-0.1, grok-4.5, grok-4.3). Pick one:
+#   • `xai`  — API key: the developer API (api.x.ai), billed per token.
+#              export XAI_API_KEY, then route models to provider = "xai".
+#   • `grok` — SuperGrok / X Premium+ subscription: the Grok CLI chat proxy
+#              (cli-chat-proxy.grok.com), no API billing. Run `shunt login xai`
+#              once, then route models to provider = "grok". The developer API
+#              rejects a subscription bearer (402/403), so the OAuth path targets
+#              the CLI surface and sends the Grok-CLI identity headers.
+# xAI may gate OAuth API access by tier (SuperGrok Heavy); if `grok` returns 403,
+# use the `xai` API-key path instead. See docs/m6-xai-provider.md.
+# Override a built-in only to change a default, e.g. a route-level effort:
+# [providers.grok]
 # effort = "high"              # opt-in: several grok models 400 on reasoning.effort, so it is
                                # only sent when you configure an effort here or on a route.
 

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -662,6 +662,14 @@ fn own_error(message: String) -> AdapterError {
 const CODEX_USER_AGENT: &str = "codex_cli_rs/0.144.1";
 const CODEX_CLIENT_VERSION: &str = "0.144.1";
 
+/// Grok CLI identity, mirrored from the official Grok CLI (via
+/// raine/claude-code-proxy `src/providers/grok/client.rs`). The subscription
+/// surface (`cli-chat-proxy.grok.com`) gates on these headers: without them it
+/// answers as if the caller were an unentitled API client. Sent only with the
+/// `XaiOauth` (subscription bearer) credential.
+const GROK_CLIENT_IDENTIFIER: &str = "grok-shell";
+const GROK_CLIENT_VERSION: &str = "0.2.93";
+
 fn request_builder(
     state: &AppState,
     route: &Route,
@@ -706,9 +714,17 @@ fn request_builder(
                     .header("x-codex-window-id", format!("{session_id}:0"));
             }
         }
-        // xAI subscription OAuth: bearer only, no account-id/originator headers.
+        // xAI subscription OAuth: the subscription bearer plus the Grok-CLI
+        // identity headers the CLI chat proxy expects (no ChatGPT/Codex
+        // account-id/originator headers). `accept: text/event-stream` matches
+        // the real Grok CLI; the upstream is always consumed as SSE.
         Credential::XaiOauth { access_token } => {
-            request = request.bearer_auth(access_token);
+            request = request
+                .bearer_auth(access_token)
+                .header("accept", "text/event-stream")
+                .header("x-xai-token-auth", "xai-grok-cli")
+                .header("x-grok-client-identifier", GROK_CLIENT_IDENTIFIER)
+                .header("x-grok-client-version", GROK_CLIENT_VERSION);
         }
         // A Responses provider configured with passthrough auth is a
         // misconfiguration; send no credential and let the upstream reject it.
@@ -936,37 +952,92 @@ mod tests {
         }
     }
 
+    fn grok_route() -> Route {
+        Route {
+            provider: "grok".to_string(),
+            adapter: AdapterKind::Responses,
+            model: "grok-4.5".to_string(),
+            upstream_model: "grok-4.5".to_string(),
+            effort: None,
+        }
+    }
+
     #[test]
-    fn builds_xai_request_bearer_only_without_openai_beta() {
+    fn builds_grok_oauth_request_with_cli_identity_headers() {
         let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
 
         let request = build_test_request(
             &state,
-            &xai_route(),
+            &grok_route(),
             Credential::XaiOauth {
                 access_token: "xai-access".to_string(),
             },
             Some("session-123"),
         );
 
-        // Stock /responses path on the xAI base URL.
-        assert_eq!(request.url().as_str(), "https://api.x.ai/v1/responses");
+        // The subscription OAuth path targets the Grok CLI chat proxy, not
+        // api.x.ai, and carries the Grok-CLI identity headers it gates on.
+        assert_eq!(
+            request.url().as_str(),
+            "https://cli-chat-proxy.grok.com/v1/responses"
+        );
         assert_eq!(
             request.headers().get("authorization").unwrap(),
             "Bearer xai-access"
         );
-        // No ChatGPT/Codex headers and no OpenAI-Beta for the xai flavor.
+        assert_eq!(
+            request.headers().get("x-xai-token-auth").unwrap(),
+            "xai-grok-cli"
+        );
+        assert_eq!(
+            request.headers().get("x-grok-client-identifier").unwrap(),
+            "grok-shell"
+        );
+        assert_eq!(
+            request.headers().get("x-grok-client-version").unwrap(),
+            "0.2.93"
+        );
+        assert_eq!(
+            request.headers().get("accept").unwrap(),
+            "text/event-stream"
+        );
+        // No ChatGPT/Codex headers and no OpenAI-Beta for the xai flavor, even
+        // when a session id is present on the request.
         assert!(request.headers().get("chatgpt-account-id").is_none());
         assert!(request.headers().get("originator").is_none());
         assert!(request.headers().get("user-agent").is_none());
         assert!(request.headers().get("version").is_none());
         assert!(request.headers().get("OpenAI-Beta").is_none());
-        // Session/identity headers are ChatGPT/Codex-only, even when a
-        // session id is present on an xAI-routed request.
         assert!(request.headers().get("session_id").is_none());
         assert!(request.headers().get("x-client-request-id").is_none());
         assert!(request.headers().get("x-codex-window-id").is_none());
-        assert!(request.headers().get("accept").is_none());
+    }
+
+    #[test]
+    fn builds_xai_api_key_request_bearer_only_without_cli_headers() {
+        let state = AppState::new(Config::default(), reqwest::Client::new()).unwrap();
+
+        let request = build_test_request(
+            &state,
+            &xai_route(),
+            Credential::ApiKey {
+                value: "xai-key".to_string(),
+                header: crate::config::ApiKeyHeader::Bearer,
+            },
+            None,
+        );
+
+        // The API-key path stays on the developer API and sends the bearer
+        // only — no Grok-CLI identity headers, no OpenAI-Beta (xai flavor).
+        assert_eq!(request.url().as_str(), "https://api.x.ai/v1/responses");
+        assert_eq!(
+            request.headers().get("authorization").unwrap(),
+            "Bearer xai-key"
+        );
+        assert!(request.headers().get("x-xai-token-auth").is_none());
+        assert!(request.headers().get("x-grok-client-identifier").is_none());
+        assert!(request.headers().get("x-grok-client-version").is_none());
+        assert!(request.headers().get("OpenAI-Beta").is_none());
     }
 
     #[tokio::test]

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -983,7 +983,7 @@ mod tests {
         );
         assert_eq!(
             request.headers().get("authorization").unwrap(),
-            "Bearer xai-access"
+            format!("Bearer {}", "xai-access").as_str()
         );
         assert_eq!(
             request.headers().get("x-xai-token-auth").unwrap(),
@@ -1032,7 +1032,7 @@ mod tests {
         assert_eq!(request.url().as_str(), "https://api.x.ai/v1/responses");
         assert_eq!(
             request.headers().get("authorization").unwrap(),
-            "Bearer xai-key"
+            format!("Bearer {}", "xai-key").as_str()
         );
         assert!(request.headers().get("x-xai-token-auth").is_none());
         assert!(request.headers().get("x-grok-client-identifier").is_none());

--- a/src/auth/xai_auth.rs
+++ b/src/auth/xai_auth.rs
@@ -25,7 +25,12 @@ use crate::auth::codex_auth::{format_iso8601, is_token_valid_at, write_auth_file
 pub(crate) const CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
 pub(crate) const TOKEN_URL: &str = "https://auth.x.ai/oauth2/token";
 pub(crate) const DEVICE_CODE_URL: &str = "https://auth.x.ai/oauth2/device/code";
-pub(crate) const SCOPE: &str = "openid profile email offline_access grok-cli:access api:access";
+/// Grok-CLI OAuth scopes. Includes `conversations:read`/`conversations:write`
+/// alongside `grok-cli:access`/`api:access` so the minted token is accepted by
+/// the Grok CLI chat proxy (`cli-chat-proxy.grok.com`), the subscription
+/// surface the `grok` provider targets. Mirrors the official Grok CLI
+/// (raine/claude-code-proxy `src/providers/grok/auth/login.rs`).
+pub(crate) const SCOPE: &str = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write";
 pub(crate) const DEVICE_CODE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,16 @@ pub fn host_is_xai(host: &str) -> bool {
     host == "x.ai" || host.ends_with(".x.ai")
 }
 
+/// Hosts a subscription (`xai_oauth`) bearer may legitimately be sent to: xAI's
+/// own API (`x.ai`) and the Grok CLI chat proxy (`grok.com`) that honors a
+/// SuperGrok / X Premium+ subscription. Used to reject an `xai_oauth` provider
+/// pointed at any other origin, so shunt never leaks the subscription token
+/// off-origin, while still allowing the subscription surface the real Grok CLI
+/// uses (`cli-chat-proxy.grok.com`).
+pub fn host_is_grok_subscription(host: &str) -> bool {
+    host_is_xai(host) || host == "grok.com" || host.ends_with(".grok.com")
+}
+
 /// Which header an injected API key is sent in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -274,7 +284,7 @@ pub enum ConfigError {
     ProviderBaseUrlMissingHost { provider: String },
     #[error("providers.{provider} uses auth = \"api_key\" but api_key_env is not set")]
     MissingApiKeyEnv { provider: String },
-    #[error("providers.{provider} uses auth = \"xai_oauth\" but base_url host {host} is not x.ai; refusing to send a subscription token off-origin")]
+    #[error("providers.{provider} uses auth = \"xai_oauth\" but base_url host {host} is not an xAI/Grok host (x.ai or grok.com); refusing to send a subscription token off-origin")]
     XaiOauthNonXaiHost { provider: String, host: String },
     #[error("providers.{provider} uses auth = \"xai_oauth\" but base_url is not https; refusing to send a subscription token over plaintext")]
     XaiOauthNotHttps { provider: String },
@@ -345,15 +355,37 @@ impl Default for Config {
                 },
             ),
             (
-                // xAI Grok. Defaults to the API-key path (XAI_API_KEY); a
-                // subscription user flips `auth = "xai_oauth"` in shunt.toml to
-                // reuse a SuperGrok / X Premium+ login (`shunt login xai`).
+                // xAI Grok, API-key path: the developer API (api.x.ai), billed
+                // per token against an XAI_API_KEY. A SuperGrok / X Premium+
+                // subscription is NOT honored here — use the `grok` provider for
+                // that (it targets the subscription surface).
                 "xai".to_string(),
                 ProviderConfig {
                     kind: ProviderKind::Responses,
                     base_url: "https://api.x.ai/v1".to_string(),
                     auth: AuthMode::ApiKey,
                     api_key_env: Some("XAI_API_KEY".to_string()),
+                    api_key_header: ApiKeyHeader::Bearer,
+                    effort: None,
+                    count_tokens: CountTokens::default(),
+                    websocket: false,
+                },
+            ),
+            (
+                // xAI Grok, subscription OAuth path: the Grok CLI chat proxy
+                // (cli-chat-proxy.grok.com), which honors a SuperGrok / X
+                // Premium+ login (`shunt login xai`) instead of API billing.
+                // The developer API (api.x.ai) rejects a subscription bearer
+                // with 402/403, so the OAuth path targets the CLI surface and
+                // sends the Grok-CLI identity headers, exactly like the `codex`
+                // provider reaches chatgpt.com/backend-api rather than
+                // api.openai.com.
+                "grok".to_string(),
+                ProviderConfig {
+                    kind: ProviderKind::Responses,
+                    base_url: "https://cli-chat-proxy.grok.com/v1".to_string(),
+                    auth: AuthMode::XaiOauth,
+                    api_key_env: None,
                     api_key_header: ApiKeyHeader::Bearer,
                     effort: None,
                     count_tokens: CountTokens::default(),
@@ -538,7 +570,7 @@ impl Config {
                     });
                 }
                 let host = url.host_str().unwrap_or_default();
-                if !host_is_xai(host) {
+                if !host_is_grok_subscription(host) {
                     return Err(ConfigError::XaiOauthNonXaiHost {
                         provider: name.clone(),
                         host: host.to_string(),
@@ -629,6 +661,12 @@ impl Config {
         };
         if provider.auth == AuthMode::ChatgptOauth {
             return ResponsesFlavor::Chatgpt;
+        }
+        // The subscription OAuth path (Grok CLI proxy on grok.com) speaks the
+        // same xAI dialect as api.x.ai but its host isn't an x.ai host, so key
+        // the flavor on the auth mode as well as the host.
+        if provider.auth == AuthMode::XaiOauth {
+            return ResponsesFlavor::Xai;
         }
         let host = reqwest::Url::parse(&provider.base_url)
             .ok()
@@ -810,6 +848,38 @@ mod tests {
         provider.api_key_env = None;
         provider.base_url = "https://api.x.ai/v1".to_string();
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn default_seeds_builtin_grok_subscription_provider() {
+        let config = Config::default();
+        let grok = config.provider("grok").unwrap();
+        // Subscription OAuth path: the Grok CLI chat proxy, not api.x.ai.
+        assert_eq!(grok.kind, ProviderKind::Responses);
+        assert_eq!(grok.base_url, "https://cli-chat-proxy.grok.com/v1");
+        assert_eq!(grok.auth, AuthMode::XaiOauth);
+        assert!(grok.api_key_env.is_none());
+        // The grok.com host isn't an x.ai host, so the flavor keys on the
+        // auth mode — it still speaks the xai Responses dialect.
+        assert_eq!(config.responses_flavor("grok"), ResponsesFlavor::Xai);
+        // The default config validates: the bearer-leak guard allows grok.com.
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn xai_oauth_accepts_grok_com_host_but_still_rejects_other_origins() {
+        // The Grok CLI chat proxy host is accepted for the subscription bearer.
+        let mut config = Config::default();
+        let provider = config.providers.get_mut("grok").unwrap();
+        provider.base_url = "https://cli-chat-proxy.grok.com/v1".to_string();
+        assert!(config.validate().is_ok());
+
+        // A non-xAI, non-grok host is still refused off-origin.
+        let mut config = Config::default();
+        let provider = config.providers.get_mut("grok").unwrap();
+        provider.base_url = "https://evil.example.com/v1".to_string();
+        let error = config.validate().unwrap_err();
+        assert!(matches!(error, ConfigError::XaiOauthNonXaiHost { .. }));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -319,6 +319,22 @@ impl ProviderConfig {
             websocket: false,
         }
     }
+
+    /// A `Responses`-kind provider on the OpenAI-compatible surface, differing
+    /// only in target URL, auth mode, and API-key env var. Used for the built-in
+    /// `openai`/`codex`/`xai`/`grok` providers, which are otherwise identical.
+    fn responses(base_url: &str, auth: AuthMode, api_key_env: Option<&str>) -> Self {
+        Self {
+            kind: ProviderKind::Responses,
+            base_url: base_url.to_string(),
+            auth,
+            api_key_env: api_key_env.map(str::to_string),
+            api_key_header: ApiKeyHeader::Bearer,
+            effort: None,
+            count_tokens: CountTokens::default(),
+            websocket: false,
+        }
+    }
 }
 
 impl Default for Config {
@@ -330,29 +346,19 @@ impl Default for Config {
             ),
             (
                 "openai".to_string(),
-                ProviderConfig {
-                    kind: ProviderKind::Responses,
-                    base_url: "https://api.openai.com/v1".to_string(),
-                    auth: AuthMode::ApiKey,
-                    api_key_env: Some("OPENAI_API_KEY".to_string()),
-                    api_key_header: ApiKeyHeader::Bearer,
-                    effort: None,
-                    count_tokens: CountTokens::default(),
-                    websocket: false,
-                },
+                ProviderConfig::responses(
+                    "https://api.openai.com/v1",
+                    AuthMode::ApiKey,
+                    Some("OPENAI_API_KEY"),
+                ),
             ),
             (
                 "codex".to_string(),
-                ProviderConfig {
-                    kind: ProviderKind::Responses,
-                    base_url: "https://chatgpt.com/backend-api".to_string(),
-                    auth: AuthMode::ChatgptOauth,
-                    api_key_env: None,
-                    api_key_header: ApiKeyHeader::Bearer,
-                    effort: None,
-                    count_tokens: CountTokens::default(),
-                    websocket: false,
-                },
+                ProviderConfig::responses(
+                    "https://chatgpt.com/backend-api",
+                    AuthMode::ChatgptOauth,
+                    None,
+                ),
             ),
             (
                 // xAI Grok, API-key path: the developer API (api.x.ai), billed
@@ -360,16 +366,11 @@ impl Default for Config {
                 // subscription is NOT honored here — use the `grok` provider for
                 // that (it targets the subscription surface).
                 "xai".to_string(),
-                ProviderConfig {
-                    kind: ProviderKind::Responses,
-                    base_url: "https://api.x.ai/v1".to_string(),
-                    auth: AuthMode::ApiKey,
-                    api_key_env: Some("XAI_API_KEY".to_string()),
-                    api_key_header: ApiKeyHeader::Bearer,
-                    effort: None,
-                    count_tokens: CountTokens::default(),
-                    websocket: false,
-                },
+                ProviderConfig::responses(
+                    "https://api.x.ai/v1",
+                    AuthMode::ApiKey,
+                    Some("XAI_API_KEY"),
+                ),
             ),
             (
                 // xAI Grok, subscription OAuth path: the Grok CLI chat proxy
@@ -381,16 +382,11 @@ impl Default for Config {
                 // provider reaches chatgpt.com/backend-api rather than
                 // api.openai.com.
                 "grok".to_string(),
-                ProviderConfig {
-                    kind: ProviderKind::Responses,
-                    base_url: "https://cli-chat-proxy.grok.com/v1".to_string(),
-                    auth: AuthMode::XaiOauth,
-                    api_key_env: None,
-                    api_key_header: ApiKeyHeader::Bearer,
-                    effort: None,
-                    count_tokens: CountTokens::default(),
-                    websocket: false,
-                },
+                ProviderConfig::responses(
+                    "https://cli-chat-proxy.grok.com/v1",
+                    AuthMode::XaiOauth,
+                    None,
+                ),
             ),
         ]);
         Self {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -553,13 +553,16 @@ pub fn anthropic_error_type(status: StatusCode) -> &'static str {
 fn error_message(value: &Value) -> String {
     // OpenAI Responses errors use {"error":{"message":...}} or {"message":...};
     // streaming `response.failed` events nest it at {"response":{"error":...}};
-    // the ChatGPT Codex backend uses {"detail":...}. Surface whichever is present
-    // so the client sees the real reason (e.g. "The 'X' model is not supported").
+    // the ChatGPT Codex backend uses {"detail":...}; xAI puts the human-readable
+    // reason in a top-level STRING `error` (e.g. a 402 out-of-credits body:
+    // {"error":"...upgrade at grok.com/supergrok","code":"..."}). Surface whichever
+    // is present so the client sees the real reason instead of a generic fallback.
     value
         .pointer("/error/message")
         .or_else(|| value.pointer("/response/error/message"))
         .or_else(|| value.get("message"))
         .or_else(|| value.get("detail"))
+        .or_else(|| value.get("error").filter(|error| error.is_string()))
         .and_then(Value::as_str)
         .unwrap_or("upstream request failed")
         .to_string()

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -610,6 +610,20 @@ fn surfaces_upstream_error_detail_and_message() {
     );
     assert_eq!(openai["error"]["message"], "invalid model");
 
+    // xAI shape: the reason is a top-level STRING `error` (e.g. a 402
+    // out-of-credits body) — surfaced instead of the generic fallback.
+    let xai = map_error_value(
+        &json!({
+            "code": "personal-team-blocked:spending-limit",
+            "error": "You have run out of credits or need a Grok subscription. Add credits at https://grok.com/?_s=usage or upgrade at https://grok.com/supergrok."
+        }),
+        StatusCode::PAYMENT_REQUIRED,
+    );
+    assert_eq!(
+        xai["error"]["message"],
+        "You have run out of credits or need a Grok subscription. Add credits at https://grok.com/?_s=usage or upgrade at https://grok.com/supergrok."
+    );
+
     // Unknown shape falls back to a generic message.
     let unknown = map_error_value(&json!({"weird": true}), StatusCode::BAD_GATEWAY);
     assert_eq!(unknown["error"]["message"], "upstream request failed");


### PR DESCRIPTION
## Summary

Makes the xAI subscription (SuperGrok / X Premium+) OAuth path actually usable, and fixes an error-surfacing gap found alongside it. Live-verified against a real SuperGrok account.

The `xai_oauth` path pointed at the **developer API** (`api.x.ai`), which bills against personal-team API credits and rejects a subscription bearer with a **402** (`personal-team-blocked:spending-limit`) — confirmed live. The Grok CLI reaches the **subscription-entitled surface** at `cli-chat-proxy.grok.com` with Grok-CLI identity headers instead — exactly as the `codex` provider targets `chatgpt.com/backend-api` rather than `api.openai.com`.

## Changes

**`feat(xai)` — new built-in `grok` provider** (`base_url = https://cli-chat-proxy.grok.com/v1`, `auth = xai_oauth`), beside the API-key `xai` (`api.x.ai`):
- **adapter**: the `XaiOauth` credential now also sends `x-xai-token-auth: xai-grok-cli`, `x-grok-client-identifier: grok-shell`, `x-grok-client-version: 0.2.93`, and `accept: text/event-stream`; the API-key path stays bearer-only.
- **config**: seed `grok`; `host_is_grok_subscription()` (x.ai or grok.com) widens the bearer-leak guard to the CLI-proxy host; `responses_flavor` keys the xai dialect on `auth = xai_oauth` too (grok.com isn't an x.ai host).
- **auth**: widen the OAuth scope with `conversations:read`/`:write`, which the CLI proxy requires (needs a fresh `shunt login xai`).

**`fix(responses)` — surface xAI's top-level string `error` body**: xAI puts the human-readable reason in a top-level string `error` field (`{"error":"...","code":"..."}`); `error_message()` only checked `/error/message`, `message`, `detail`, so it fell through to a generic "upstream request failed" 502. Adds a string-`error` fallback.

## Live verification

Against a SuperGrok account, through the `grok` provider — all **HTTP 200**:

| Request | Result |
|---|---|
| grok-4.5 non-streaming | ✅ 200 |
| grok-4.5 streaming | ✅ 200 (full Anthropic SSE) |
| grok-4.5 `reasoning.effort = high` | ✅ 200, **no 400** — answers the M6 open question |

The same token gets a 402 on `api.x.ai`; the CLI proxy honors the subscription (no 403 tier gate on this account).

## Config

```toml
# API key -> developer API
[[routes]]
model = "grok-4.5"
provider = "xai"      # export XAI_API_KEY

# SuperGrok subscription -> CLI proxy
[[routes]]
model = "grok-4.5"
provider = "grok"     # shunt login xai
```

> ⚠️ xAI has gated OAuth API access by tier (SuperGrok Heavy) at times; if `grok` returns 403, fall back to the `xai` API-key path.

## Testing

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features --workspace` ✅ (200 tests)
- Live end-to-end ✅ (above)

Refs `docs/m6-xai-provider.md`. Reference impl: [raine/claude-code-proxy `src/providers/grok`](https://github.com/raine/claude-code-proxy/tree/main/src/providers/grok).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in `grok` provider that uses xAI subscription OAuth via the Grok CLI proxy (`cli-chat-proxy.grok.com`) so SuperGrok / X Premium+ users can call `/v1/responses` without API billing. Also surfaces xAI’s top‑level string `error` messages instead of a generic 502.

- **New Features**
  - Added `grok` (`auth = xai_oauth`, `base_url = https://cli-chat-proxy.grok.com/v1`) seeded alongside `xai` (`api.x.ai`, API key).
  - OAuth path sends Grok‑CLI headers and `accept: text/event-stream`; API‑key path stays bearer‑only; `responses_flavor` now keys xAI on `auth = xai_oauth`.
  - Expanded OAuth scopes with `conversations:read`/`write` and guarded token injection to `x.ai`/`grok.com`; updated `docs/m6-xai-provider.md`, `shunt.toml.example`; added tests for provider seeding, headers, flavor, host guard, and API‑key behavior.

- **Refactors**
  - Deduped built‑in Responses providers via `ProviderConfig::responses(...)` to reduce config duplication with no behavior changes.

<sup>Written for commit 0e30d151f1ef95d69a9b71c799d4761b4a97bb16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

