### PR TITLE
feat(cli): add `shunt add provider` to scaffold provider config

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -80,6 +80,12 @@ OpenAI の Thibault Sottiaux は、他のコーディングハーネスを通じ
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 
+`base_url` や `auth` をうろ覚えでも、`shunt add provider <name>` が貼り付け可能なブロックを出力します（有効な TOML なのでそのままパイプできます）:
+
+```console
+$ shunt add provider kimi >> shunt.toml
+```
+
 ```toml
 [providers.kimi]
 kind = "anthropic"
@@ -92,7 +98,7 @@ model = "kimi-k2.7-code"
 provider = "kimi"
 ```
 
-全リストとプロバイダーごとの注意点は [Providers](https://shunt-docs.pages.dev/guides/providers/) を参照してください。
+全リストとプロバイダーごとの注意点は [Providers](https://shunt-docs.pages.dev/guides/providers/) を、`shunt add provider` は [CLI リファレンス](https://shunt-docs.pages.dev/reference/cli/#shunt-add-provider) を参照してください。
 
 ## ドキュメント
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -80,6 +80,12 @@ OpenAI의 Thibault Sottiaux는 다른 코딩 하네스를 통해 Codex를 실행
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 
+`base_url`·`auth`가 기억나지 않으면 `shunt add provider <name>`가 붙여넣기 좋은 블록을 출력합니다(유효한 TOML이라 그대로 파이핑 가능):
+
+```console
+$ shunt add provider kimi >> shunt.toml
+```
+
 ```toml
 [providers.kimi]
 kind = "anthropic"
@@ -92,7 +98,7 @@ model = "kimi-k2.7-code"
 provider = "kimi"
 ```
 
-전체 목록과 프로바이더별 참고 사항은 [프로바이더](https://shunt-docs.pages.dev/guides/providers/)를 참고하세요.
+전체 목록과 프로바이더별 참고 사항은 [프로바이더](https://shunt-docs.pages.dev/guides/providers/)를, `shunt add provider`는 [CLI 레퍼런스](https://shunt-docs.pages.dev/reference/cli/#shunt-add-provider)를 참고하세요.
 
 ## 문서
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ That said, reusing your ChatGPT/Codex subscription (or Kimi, Cursor, or other ba
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 
+Don't remember the exact `base_url`/`auth`? `shunt add provider <name>` prints a ready-to-paste block (valid TOML, so pipe it straight in):
+
+```console
+$ shunt add provider kimi >> shunt.toml
+```
+
 ```toml
 [providers.kimi]
 kind = "anthropic"
@@ -92,7 +98,7 @@ model = "kimi-k2.7-code"
 provider = "kimi"
 ```
 
-See [Providers](https://shunt-docs.pages.dev/guides/providers/) for the full list and per-provider notes.
+See [Providers](https://shunt-docs.pages.dev/guides/providers/) for the full list and per-provider notes, or the [CLI reference](https://shunt-docs.pages.dev/reference/cli/#shunt-add-provider) for `shunt add provider`.
 
 ## Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -80,6 +80,12 @@ OpenAI 的 Thibault Sottiaux 已公开欢迎通过其他编码 harness 运行 Co
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 
+记不清 `base_url`/`auth`？`shunt add provider <name>` 会打印一个可直接粘贴的配置块（是合法 TOML，可直接管道写入）：
+
+```console
+$ shunt add provider kimi >> shunt.toml
+```
+
 ```toml
 [providers.kimi]
 kind = "anthropic"
@@ -92,7 +98,7 @@ model = "kimi-k2.7-code"
 provider = "kimi"
 ```
 
-完整列表和各提供方说明见 [提供方](https://shunt-docs.pages.dev/guides/providers/)。
+完整列表和各提供方说明见 [提供方](https://shunt-docs.pages.dev/guides/providers/)；`shunt add provider` 见 [CLI 参考](https://shunt-docs.pages.dev/reference/cli/#shunt-add-provider)。
 
 ## 文档
 

--- a/site/src/content/docs/guides/providers.md
+++ b/site/src/content/docs/guides/providers.md
@@ -46,7 +46,13 @@ Most third-party "use Claude Code with X" gateways are Anthropic-Messages-compat
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` (accepts `x_api_key`) |
 
-For example, to route Kimi's model through shunt:
+Don't want to look up the exact `base_url`/`auth`? [`shunt add provider <name>`](/reference/cli/#shunt-add-provider) prints a ready-to-paste block for any of these (plus the built-ins). The output is valid TOML — hints ride along as comments — so you can append it straight to your config:
+
+```bash
+shunt add provider kimi >> shunt.toml
+```
+
+For example, to route Kimi's model through shunt by hand:
 
 ```toml
 [providers.kimi]

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -43,6 +43,38 @@ Print a Claude subscription OAuth token to **stdout** (logs go to stderr), desig
 
 See [Connect Claude Code](/guides/connect-claude-code/#2-choose-the-anthropic-credential) for when you need this.
 
+## `shunt add provider`
+
+Print a ready-to-paste `[providers.<name>]` block for a known backend — the built-in providers (`openai`, `codex`, `xai`, `grok`, `anthropic`) plus the Anthropic-compatible gateways from the [Providers](/guides/providers/) table (`kimi`, `deepseek`, `glm`, `minimax`, `mimo`, `openrouter`, `vercel`). It fills in the right `kind`, `base_url`, `auth`, and `api_key_env`, and adds a commented example route.
+
+```bash
+shunt add provider kimi
+```
+
+```toml
+[providers.kimi]
+kind = "anthropic"
+base_url = "https://api.moonshot.ai/anthropic"
+auth = "api_key"
+api_key_env = "KIMI_API_KEY"
+
+# Set the API key in your environment:
+#   export KIMI_API_KEY=...
+
+# Example route — map a model ID to this provider:
+# [[routes]]
+# model = "kimi-k2.7-code"
+# provider = "kimi"
+```
+
+The command **never writes files** — the whole output is valid TOML (setup hints ride along as `#` comments), so append it yourself:
+
+```bash
+shunt add provider kimi >> shunt.toml
+```
+
+Names are case-insensitive and accept aliases (e.g. `zai`/`z.ai` → `glm`, `moonshot` → `kimi`, `chatgpt` → `codex`). Run `shunt add provider` with no name to list the known providers; an unknown name errors and lists them.
+
 ## Environment variables
 
 | Variable | Effect |

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,0 +1,402 @@
+//! Built-in provider catalog for `shunt add provider`.
+//!
+//! `add provider <name>` prints a ready-to-paste `[providers.<name>]` TOML
+//! block for a known backend — the built-in providers plus the Anthropic-
+//! compatible gateways shunt documents. The output is valid TOML (the
+//! setup guidance rides along as comments), so it pipes straight into a config
+//! file: `shunt add provider kimi >> shunt.toml`. It never writes files itself,
+//! mirroring `flue add`'s print-only philosophy.
+//!
+//! The catalog is a static table (AGENTS.md's table-driven rule): a new backend
+//! is one [`CatalogEntry`], no branching logic. Rendering maps the typed config
+//! enums to their wire tokens via exhaustive `match`, so a new [`AuthMode`] /
+//! [`ProviderKind`] / [`ApiKeyHeader`] variant forces this file to be updated,
+//! and `catalog_entries_render_to_valid_config` round-trips every entry through
+//! the real config loader so a bad `base_url`/`auth` can't ship.
+
+use std::fmt::Write as _;
+
+use crate::config::{ApiKeyHeader, AuthMode, ProviderKind};
+
+/// One known upstream: the fields needed to scaffold a `[providers.<name>]`
+/// block, plus optional setup guidance rendered as comments.
+pub struct CatalogEntry {
+    /// Canonical provider name (the config table key).
+    pub name: &'static str,
+    /// Extra names that resolve to this entry (e.g. `zai` → `glm`).
+    pub aliases: &'static [&'static str],
+    pub kind: ProviderKind,
+    pub base_url: &'static str,
+    pub auth: AuthMode,
+    /// Env var holding the API key, for `auth = "api_key"` entries.
+    pub api_key_env: Option<&'static str>,
+    /// Non-default header for the injected key. `None` ⇒ the `bearer` default,
+    /// so the line is omitted.
+    pub api_key_header: Option<ApiKeyHeader>,
+    /// Example model ID for the commented route (`None` ⇒ a `<model-id>`
+    /// placeholder).
+    pub example_model: Option<&'static str>,
+    /// One-line setup hint (e.g. an OAuth login step) rendered as a comment.
+    pub note: Option<&'static str>,
+}
+
+/// The known providers: the built-ins that ship as config defaults, then the
+/// Anthropic-compatible gateways shunt documents. Order is the listing
+/// order for `shunt add provider` with no name.
+pub const CATALOG: &[CatalogEntry] = &[
+    CatalogEntry {
+        name: "anthropic",
+        aliases: &[],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.anthropic.com",
+        auth: AuthMode::Passthrough,
+        api_key_env: None,
+        api_key_header: None,
+        example_model: None,
+        note: Some("Passthrough forwards Claude Code's own Anthropic credential unchanged."),
+    },
+    CatalogEntry {
+        name: "openai",
+        aliases: &[],
+        kind: ProviderKind::Responses,
+        base_url: "https://api.openai.com/v1",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("OPENAI_API_KEY"),
+        api_key_header: None,
+        example_model: None,
+        note: None,
+    },
+    CatalogEntry {
+        name: "codex",
+        aliases: &["chatgpt"],
+        kind: ProviderKind::Responses,
+        base_url: "https://chatgpt.com/backend-api",
+        auth: AuthMode::ChatgptOauth,
+        api_key_env: None,
+        api_key_header: None,
+        example_model: None,
+        note: Some("Reuse your ChatGPT/Codex subscription — run `codex login` first."),
+    },
+    CatalogEntry {
+        name: "xai",
+        aliases: &[],
+        kind: ProviderKind::Responses,
+        base_url: "https://api.x.ai/v1",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("XAI_API_KEY"),
+        api_key_header: None,
+        example_model: Some("grok-code-fast-1"),
+        note: Some("Developer API, billed per token. For a SuperGrok / X Premium+ subscription use `grok`."),
+    },
+    CatalogEntry {
+        name: "grok",
+        aliases: &[],
+        kind: ProviderKind::Responses,
+        base_url: "https://cli-chat-proxy.grok.com/v1",
+        auth: AuthMode::XaiOauth,
+        api_key_env: None,
+        api_key_header: None,
+        example_model: Some("grok-code-fast-1"),
+        note: Some(
+            "Reuse your SuperGrok / X Premium+ subscription — run `shunt login xai` first.",
+        ),
+    },
+    CatalogEntry {
+        name: "kimi",
+        aliases: &["moonshot"],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.moonshot.ai/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("KIMI_API_KEY"),
+        api_key_header: None,
+        example_model: Some("kimi-k2.7-code"),
+        note: None,
+    },
+    CatalogEntry {
+        name: "deepseek",
+        aliases: &[],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.deepseek.com/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("DEEPSEEK_API_KEY"),
+        api_key_header: None,
+        example_model: Some("deepseek-v4-pro"),
+        note: None,
+    },
+    CatalogEntry {
+        name: "glm",
+        aliases: &["zai", "z.ai"],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.z.ai/api/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("ZAI_API_KEY"),
+        api_key_header: None,
+        example_model: Some("glm-5.2"),
+        note: None,
+    },
+    CatalogEntry {
+        name: "minimax",
+        aliases: &[],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.minimax.io/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("MINIMAX_API_KEY"),
+        api_key_header: None,
+        example_model: None,
+        note: Some("See https://platform.minimax.io/docs/token-plan/claude-code for model IDs."),
+    },
+    CatalogEntry {
+        name: "mimo",
+        aliases: &["xiaomi"],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.xiaomimimo.com/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("MIMO_API_KEY"),
+        api_key_header: None,
+        example_model: Some("mimo-v2.5-pro"),
+        note: Some(
+            "See https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode for model IDs.",
+        ),
+    },
+    CatalogEntry {
+        name: "openrouter",
+        aliases: &[],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://openrouter.ai/api",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("OPENROUTER_API_KEY"),
+        api_key_header: None,
+        example_model: Some("anthropic/claude-opus-4.8"),
+        note: None,
+    },
+    CatalogEntry {
+        name: "vercel",
+        aliases: &["vercel-ai-gateway"],
+        kind: ProviderKind::Anthropic,
+        base_url: "https://ai-gateway.vercel.sh",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("AI_GATEWAY_API_KEY"),
+        // Vercel AI Gateway expects the Anthropic-native `x-api-key` header.
+        api_key_header: Some(ApiKeyHeader::XApiKey),
+        example_model: Some("anthropic/claude-opus-4.8"),
+        note: None,
+    },
+];
+
+/// Resolve a provider name (case-insensitive) against the catalog, including
+/// aliases.
+pub fn find(name: &str) -> Option<&'static CatalogEntry> {
+    let name = name.trim().to_ascii_lowercase();
+    CATALOG
+        .iter()
+        .find(|entry| entry.name == name || entry.aliases.iter().any(|alias| *alias == name))
+}
+
+fn wire_kind(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Anthropic => "anthropic",
+        ProviderKind::Responses => "responses",
+    }
+}
+
+fn wire_auth(auth: AuthMode) -> &'static str {
+    match auth {
+        AuthMode::Passthrough => "passthrough",
+        AuthMode::ApiKey => "api_key",
+        AuthMode::ChatgptOauth => "chatgpt_oauth",
+        AuthMode::XaiOauth => "xai_oauth",
+    }
+}
+
+fn wire_header(header: ApiKeyHeader) -> &'static str {
+    match header {
+        ApiKeyHeader::Bearer => "bearer",
+        ApiKeyHeader::XApiKey => "x_api_key",
+    }
+}
+
+/// Render a paste-ready `[providers.<name>]` block. The whole string is valid
+/// TOML — every hint is a `#` comment — so it can be appended to a config file
+/// verbatim.
+pub fn render(entry: &CatalogEntry) -> String {
+    let name = entry.name;
+    let mut out = String::new();
+    writeln!(out, "[providers.{name}]").unwrap();
+    writeln!(out, "kind = \"{}\"", wire_kind(entry.kind)).unwrap();
+    writeln!(out, "base_url = \"{}\"", entry.base_url).unwrap();
+    writeln!(out, "auth = \"{}\"", wire_auth(entry.auth)).unwrap();
+    if let Some(env) = entry.api_key_env {
+        writeln!(out, "api_key_env = \"{env}\"").unwrap();
+    }
+    if let Some(header) = entry.api_key_header {
+        writeln!(out, "api_key_header = \"{}\"", wire_header(header)).unwrap();
+    }
+    if let Some(note) = entry.note {
+        writeln!(out, "\n# {note}").unwrap();
+    }
+    if let Some(env) = entry.api_key_env {
+        writeln!(out, "\n# Set the API key in your environment:").unwrap();
+        writeln!(out, "#   export {env}=...").unwrap();
+    }
+    let model = entry.example_model.unwrap_or("<model-id>");
+    writeln!(out, "\n# Example route — map a model ID to this provider:").unwrap();
+    writeln!(out, "# [[routes]]").unwrap();
+    writeln!(out, "# model = \"{model}\"").unwrap();
+    writeln!(out, "# provider = \"{name}\"").unwrap();
+    out
+}
+
+/// Render the list of known providers (for `shunt add provider` with no name),
+/// as TOML comments so the output is still safe to redirect into a file.
+pub fn list_text() -> String {
+    let mut out = String::new();
+    writeln!(out, "# Known providers — `shunt add provider <name>`:").unwrap();
+    for entry in CATALOG {
+        writeln!(out, "#   {:<11} {}", entry.name, entry.base_url).unwrap();
+    }
+    out
+}
+
+/// Handle `shunt add provider [name]`: print a block for a known provider, or
+/// the catalog listing when no name is given. An unknown name is an error that
+/// names the known providers.
+pub fn add_provider(name: Option<&str>) -> anyhow::Result<()> {
+    match name {
+        None => {
+            print!("{}", list_text());
+            Ok(())
+        }
+        Some(name) => match find(name) {
+            Some(entry) => {
+                print!("{}", render(entry));
+                Ok(())
+            }
+            None => {
+                let known = CATALOG
+                    .iter()
+                    .map(|entry| entry.name)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                anyhow::bail!("unknown provider '{name}'. Known providers: {known}")
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use figment::{
+        providers::{Format, Serialized, Toml},
+        Figment,
+    };
+
+    #[test]
+    fn find_resolves_names_and_aliases_case_insensitively() {
+        assert_eq!(find("openai").unwrap().name, "openai");
+        assert_eq!(find("OpenAI").unwrap().name, "openai");
+        // Aliases resolve to the canonical entry.
+        assert_eq!(find("zai").unwrap().name, "glm");
+        assert_eq!(find("z.ai").unwrap().name, "glm");
+        assert_eq!(find("moonshot").unwrap().name, "kimi");
+        assert_eq!(find("chatgpt").unwrap().name, "codex");
+        assert!(find("nope").is_none());
+    }
+
+    #[test]
+    fn render_openai_block_has_expected_fields() {
+        let block = render(find("openai").unwrap());
+        assert!(block.contains("[providers.openai]"));
+        assert!(block.contains("kind = \"responses\""));
+        assert!(block.contains("base_url = \"https://api.openai.com/v1\""));
+        assert!(block.contains("auth = \"api_key\""));
+        assert!(block.contains("api_key_env = \"OPENAI_API_KEY\""));
+        assert!(block.contains("export OPENAI_API_KEY=..."));
+        // The example route is commented so the block stays paste-safe.
+        assert!(block.contains("# [[routes]]"));
+        assert!(block.contains("# provider = \"openai\""));
+    }
+
+    #[test]
+    fn render_vercel_emits_non_default_api_key_header() {
+        let block = render(find("vercel").unwrap());
+        assert!(block.contains("api_key_header = \"x_api_key\""));
+    }
+
+    #[test]
+    fn render_omits_api_key_lines_for_oauth_and_passthrough() {
+        // OAuth/passthrough entries have no key to set, so no api_key_env line.
+        for name in ["anthropic", "codex", "grok"] {
+            let block = render(find(name).unwrap());
+            assert!(
+                !block.contains("api_key_env"),
+                "{name} should not render api_key_env"
+            );
+        }
+    }
+
+    #[test]
+    fn list_text_names_every_catalog_entry() {
+        let list = list_text();
+        for entry in CATALOG {
+            assert!(list.contains(entry.name), "list missing {}", entry.name);
+        }
+    }
+
+    #[test]
+    fn add_provider_rejects_unknown_name() {
+        let error = add_provider(Some("does-not-exist")).unwrap_err();
+        assert!(error.to_string().contains("unknown provider"));
+        // The error lists real providers so the user can recover.
+        assert!(error.to_string().contains("openai"));
+    }
+
+    #[test]
+    fn render_pins_literal_auth_token_per_mode() {
+        // The round-trip test below only proves each block parses and passes
+        // Config::validate(), which adds no semantic check for Passthrough or
+        // ChatgptOauth — so a wire_auth swap between them would ship silently.
+        // Pin the literal token: codex rendered as `passthrough` would forward
+        // the caller's own Anthropic credential to the ChatGPT backend.
+        assert!(render(find("anthropic").unwrap()).contains("auth = \"passthrough\""));
+        assert!(render(find("codex").unwrap()).contains("auth = \"chatgpt_oauth\""));
+        assert!(render(find("grok").unwrap()).contains("auth = \"xai_oauth\""));
+    }
+
+    #[test]
+    fn catalog_names_and_aliases_are_unique() {
+        // find() returns the first match, so a duplicate name/alias would
+        // silently shadow an earlier entry — guard every canonical name and
+        // alias being pairwise distinct.
+        let mut seen = std::collections::HashSet::new();
+        for entry in CATALOG {
+            assert!(
+                seen.insert(entry.name),
+                "duplicate catalog key: {}",
+                entry.name
+            );
+            for alias in entry.aliases {
+                assert!(seen.insert(*alias), "duplicate catalog key: {alias}");
+            }
+        }
+    }
+
+    /// Every rendered block must parse and pass the real config validation, so
+    /// the catalog can't ship a base_url/auth/kind combination the loader would
+    /// reject (e.g. an api_key provider with no env, or an xai_oauth host that
+    /// trips the bearer-leak guard).
+    #[test]
+    fn catalog_entries_render_to_valid_config() {
+        for entry in CATALOG {
+            let block = render(entry);
+            let config: Config = Figment::from(Serialized::defaults(Config::default()))
+                .merge(Toml::string(&block))
+                .extract()
+                .unwrap_or_else(|error| panic!("{} block failed to parse: {error}", entry.name));
+            config
+                .validate()
+                .unwrap_or_else(|error| panic!("{} block failed validation: {error}", entry.name));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 pub mod auth;
+pub mod catalog;
 pub mod config;
 pub mod count_tokens;
 pub mod discovery;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,24 @@ enum Command {
         /// Provider to log in to (currently: `xai`).
         provider: String,
     },
+    /// Scaffold config for a known backend. `shunt add provider <name>` prints a
+    /// ready-to-paste `[providers.<name>]` block (valid TOML, so it can be piped
+    /// into a config file); omit the name to list the known providers.
+    Add {
+        #[command(subcommand)]
+        target: AddTarget,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum AddTarget {
+    /// Print a `[providers.<name>]` block for a known provider (omit NAME to
+    /// list the catalog). Never writes files — redirect the output yourself:
+    /// `shunt add provider kimi >> shunt.toml`.
+    Provider {
+        /// Provider name or alias (e.g. `openai`, `kimi`, `zai`).
+        name: Option<String>,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -56,6 +74,9 @@ fn main() -> anyhow::Result<()> {
         Some(Command::Login { provider }) => {
             runtime()?.block_on(shunt::auth::xai_login::run(&provider))
         }
+        Some(Command::Add {
+            target: AddTarget::Provider { name },
+        }) => shunt::catalog::add_provider(name.as_deref()),
         None if cli.check => check(cli.config),
         None => run(cli.config),
     }


### PR DESCRIPTION
## Summary

Adds a new CLI subcommand, `shunt add provider <name>`, that prints a ready-to-paste `[providers.<name>]` TOML block for a known backend — the built-in providers (openai/codex/xai/grok/anthropic) plus the Anthropic-compatible gateways (kimi, deepseek, glm, minimax, mimo, openrouter, vercel). It is print-only and never writes files; the output is valid TOML so it can be piped straight into a config file (e.g. `shunt add provider kimi >> shunt.toml`). Modeled on Flue's `flue add` print-only philosophy.

## Milestone / spec

Not tied to a specific `docs/` milestone spec — this is a standalone CLI ergonomics feature (config scaffolding), not a protocol/translation change.

### Changes

- New static catalog table in `src/catalog.rs` (AGENTS.md table-driven rule); case-insensitive provider names plus aliases (`zai`/`z.ai`→`glm`, `moonshot`→`kimi`, `chatgpt`→`codex`, `xiaomi`→`mimo`).
- No name argument → lists the full catalog; unknown name → errors and lists known providers.
- Unit tests, including `catalog_entries_render_to_valid_config`, which round-trips every catalog entry through the real config loader + `Config::validate()` so a bad `base_url`/`auth`/`kind` can't ship; plus a test pinning the literal `auth=` token per mode, and a catalog name/alias uniqueness guard.
- Docs updated in the same PR (AGENTS.md docs-no-drift rule): README ×4 (en/ko/ja/zh-CN), site `reference/cli.md` (new `## shunt add provider` section), and `guides/providers.md`.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — 148 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A, no spec deviation
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes

## Notes for reviewers

- `catalog_entries_render_to_valid_config` is the key correctness guard here: it forces every catalog entry to round-trip through the real config loader and `Config::validate()`, so a typo'd `base_url`/`auth`/`kind` fails CI instead of shipping silently.
- This also passed a `/review:code-review-loop` pass locally before pushing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `shunt add provider <name>` to print a ready-to-paste `[providers.<name>]` TOML block for known backends. Output is print-only and can be piped into `shunt.toml` for quick setup.

- New Features
  - Supports built-ins (`openai`, `codex`, `xai`, `grok`, `anthropic`) and Anthropic-compatible gateways (`kimi`, `deepseek`, `glm`, `minimax`, `mimo`, `openrouter`, `vercel`); names are case-insensitive with aliases (e.g., `zai`/`z.ai` → `glm`, `moonshot` → `kimi`, `chatgpt` → `codex`).
  - Populates `kind`, `base_url`, `auth`, and `api_key_env`, and adds a commented example route; never writes files. Omit the name to list known providers; unknown names error and show the list.
  - Adds a static catalog in `src/catalog.rs` with tests that round-trip each entry through the real config loader and `Config::validate()`; docs updated (README ×4, CLI reference, providers guide).

<sup>Written for commit caa9b7efa564fd273b5fee139c06d3750241fc3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

