### PR TITLE
feat(xai): enable hosted web search for Grok OAuth

### DIFF
--- a/docs/m6-xai-provider.md
+++ b/docs/m6-xai-provider.md
@@ -26,7 +26,15 @@
     is not subject to API billing. Sends the Grok-CLI identity headers (§6).
 - A `shunt login xai` subcommand that runs the device-code flow and writes a shunt-owned
   credential file, refreshed automatically on expiry.
-- xAI-flavored request translation (a third [`ResponsesFlavor`] beside OpenAI and ChatGPT/Codex).
+- xAI-flavored request translation, with a distinct Grok CLI flavor for capabilities such as
+  hosted web search that are verified only on the subscription proxy.
+
+The Grok CLI proxy supports the Responses hosted `web_search` tool end-to-end. shunt forwards it
+only for the `grok` subscription provider and translates the resulting search call, results, and URL
+citations back into Anthropic `server_tool_use`, `web_search_tool_result`, and citation blocks. The
+same tool remains disabled for the API-key `xai` provider because `api.x.ai` support has not been
+verified. **Hosted search is billed separately by xAI (approximately $5 per 1,000 calls), even when
+the request uses a Grok subscription.**
 
 Out of scope: any change to the M1 response translation / SSE state machine.
 
@@ -117,9 +125,10 @@ All gateway-owned errors use the Anthropic error envelope via the `auth_error` h
 ## 6. Request shaping — the `xai` [`ResponsesFlavor`]
 
 Detected table-driven, not by provider name: `auth = chatgpt_oauth` → ChatGPT; `auth = xai_oauth`
-→ xAI (the OAuth `grok` provider, whose `grok.com` host isn't an `x.ai` host); a base_url host of
-`x.ai`/`*.x.ai` → xAI (the API-key `xai` provider); else OpenAI. The xai flavor differs from the
-stock OpenAI translation in three ways (learned from 400s in the reference impls):
+→ Grok CLI (the OAuth `grok` provider, whose `grok.com` host isn't an `x.ai` host); a base_url host
+of `x.ai`/`*.x.ai` → xAI (the API-key `xai` provider); else OpenAI. The Grok CLI flavor inherits
+the xAI request-shaping rules below and additionally enables hosted `web_search`, which is verified
+only on the subscription proxy.
 
 **Grok-CLI identity headers.** The subscription OAuth path (`Credential::XaiOauth`) additionally
 sends `x-xai-token-auth: xai-grok-cli`, `x-grok-client-identifier: grok-shell`,
@@ -176,6 +185,9 @@ stays as the safe choice for the families that still reject it.
 
 ## 10. Open questions
 
+- **Developer API hosted tools.** The Grok CLI proxy is verified to accept hosted `web_search`;
+  `api.x.ai` is not, so the API-key `xai` flavor continues to drop it pending a live probe with an
+  `XAI_API_KEY`. Related hosted tools such as `x_search` remain out of scope.
 - **`text.verbosity`.** Dropped for xai because Hermes never sends it and xAI is reported to
   reject the `text` object. If a future grok build accepts it, this is a safe place to re-enable.
 - **Refresh skew.** shunt uses the shared 5-minute buffer. Hermes uses an adaptive skew (up to

--- a/src/adapters/responses.rs
+++ b/src/adapters/responses.rs
@@ -685,7 +685,10 @@ fn request_builder(
         .header("content-type", "application/json");
     // `OpenAI-Beta: responses=experimental` is an OpenAI/ChatGPT header; xAI's
     // Responses API doesn't expect it and the reference clients don't send it.
-    if state.config.responses_flavor(&route.provider) != crate::config::ResponsesFlavor::Xai {
+    if !matches!(
+        state.config.responses_flavor(&route.provider),
+        crate::config::ResponsesFlavor::Xai | crate::config::ResponsesFlavor::Grok
+    ) {
         request = request.header("OpenAI-Beta", "responses=experimental");
     }
     match credential {

--- a/src/config.rs
+++ b/src/config.rs
@@ -830,16 +830,17 @@ impl Config {
         if provider.auth == AuthMode::ChatgptOauth {
             return ResponsesFlavor::Chatgpt;
         }
-        // The subscription OAuth path targets the Grok CLI proxy. It mostly
-        // speaks the xAI dialect, but supports hosted tools the developer API
-        // has not been verified to accept, so keep it as a distinct flavor.
-        if provider.auth == AuthMode::XaiOauth {
-            return ResponsesFlavor::Grok;
-        }
         let host = reqwest::Url::parse(&provider.base_url)
             .ok()
             .and_then(|url| url.host_str().map(ToOwned::to_owned))
             .unwrap_or_default();
+        // Hosted tools are a Grok CLI-proxy capability, not an OAuth capability:
+        // an xai_oauth provider may still target the developer API at api.x.ai.
+        if provider.auth == AuthMode::XaiOauth
+            && (host == "grok.com" || host.ends_with(".grok.com"))
+        {
+            return ResponsesFlavor::Grok;
+        }
         if host_is_xai(&host) {
             ResponsesFlavor::Xai
         } else {
@@ -1013,7 +1014,7 @@ mod tests {
         config.providers.get_mut("xai").unwrap().auth = AuthMode::XaiOauth;
         config.providers.get_mut("xai").unwrap().api_key_env = None;
         let config = config.validate().unwrap();
-        assert_eq!(config.responses_flavor("xai"), ResponsesFlavor::Grok);
+        assert_eq!(config.responses_flavor("xai"), ResponsesFlavor::Xai);
 
         // Pointing an xai_oauth provider off-origin is refused (bearer-leak guard).
         let mut config = Config::default();
@@ -1071,8 +1072,8 @@ mod tests {
         assert_eq!(grok.base_url, "https://cli-chat-proxy.grok.com/v1");
         assert_eq!(grok.auth, AuthMode::XaiOauth);
         assert!(grok.api_key_env.is_none());
-        // The grok.com host isn't an x.ai host, so the flavor keys on the
-        // auth mode and enables CLI-proxy-only capabilities.
+        // The Grok flavor keys on the CLI proxy host and enables
+        // proxy-only capabilities.
         assert_eq!(config.responses_flavor("grok"), ResponsesFlavor::Grok);
         // The default config validates: the bearer-leak guard allows grok.com.
         assert!(config.validate().is_ok());

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,9 +292,12 @@ pub enum ResponsesFlavor {
     /// ChatGPT/Codex backend under /codex/responses — rejects parameters codex
     /// never sends (e.g. `max_output_tokens`).
     Chatgpt,
-    /// xAI Grok Responses API — rejects `service_tier`/`text`, and 400s on
+    /// xAI developer Responses API — rejects `service_tier`/`text`, and 400s on
     /// `reasoning.effort` for several grok models, so reasoning stays opt-in.
     Xai,
+    /// Grok CLI subscription proxy. It otherwise speaks the xAI dialect, but
+    /// additionally accepts the hosted `web_search` tool.
+    Grok,
 }
 
 /// Whether `host` belongs to xAI (`x.ai` or any subdomain). Used both to gate
@@ -827,11 +830,11 @@ impl Config {
         if provider.auth == AuthMode::ChatgptOauth {
             return ResponsesFlavor::Chatgpt;
         }
-        // The subscription OAuth path (Grok CLI proxy on grok.com) speaks the
-        // same xAI dialect as api.x.ai but its host isn't an x.ai host, so key
-        // the flavor on the auth mode as well as the host.
+        // The subscription OAuth path targets the Grok CLI proxy. It mostly
+        // speaks the xAI dialect, but supports hosted tools the developer API
+        // has not been verified to accept, so keep it as a distinct flavor.
         if provider.auth == AuthMode::XaiOauth {
-            return ResponsesFlavor::Xai;
+            return ResponsesFlavor::Grok;
         }
         let host = reqwest::Url::parse(&provider.base_url)
             .ok()
@@ -1010,7 +1013,7 @@ mod tests {
         config.providers.get_mut("xai").unwrap().auth = AuthMode::XaiOauth;
         config.providers.get_mut("xai").unwrap().api_key_env = None;
         let config = config.validate().unwrap();
-        assert_eq!(config.responses_flavor("xai"), ResponsesFlavor::Xai);
+        assert_eq!(config.responses_flavor("xai"), ResponsesFlavor::Grok);
 
         // Pointing an xai_oauth provider off-origin is refused (bearer-leak guard).
         let mut config = Config::default();
@@ -1069,8 +1072,8 @@ mod tests {
         assert_eq!(grok.auth, AuthMode::XaiOauth);
         assert!(grok.api_key_env.is_none());
         // The grok.com host isn't an x.ai host, so the flavor keys on the
-        // auth mode — it still speaks the xai Responses dialect.
-        assert_eq!(config.responses_flavor("grok"), ResponsesFlavor::Xai);
+        // auth mode and enables CLI-proxy-only capabilities.
+        assert_eq!(config.responses_flavor("grok"), ResponsesFlavor::Grok);
         // The default config validates: the bearer-leak guard allows grok.com.
         assert!(config.validate().is_ok());
     }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -39,6 +39,7 @@ pub struct AnthropicSseMachine {
     output_tokens: u64,
     content: Vec<Value>,
     text_buffer: String,
+    text_citations: Vec<Value>,
     tool_buffer: Option<ToolBuffer>,
     reasoning: Option<ReasoningBuffer>,
     web_search_indexes: HashMap<String, String>,
@@ -78,6 +79,7 @@ impl AnthropicSseMachine {
             output_tokens: 0,
             content: Vec::new(),
             text_buffer: String::new(),
+            text_citations: Vec::new(),
             tool_buffer: None,
             reasoning: None,
             web_search_indexes: HashMap::new(),
@@ -317,6 +319,7 @@ impl AnthropicSseMachine {
             kind: BlockKind::Text,
         });
         self.text_buffer.clear();
+        self.text_citations.clear();
         out.push(sse(
             "content_block_start",
             &json!({
@@ -382,13 +385,18 @@ impl AnthropicSseMachine {
         if annotation.get("type").and_then(Value::as_str) != Some("url_citation") {
             return Vec::new();
         }
+        let mut out = Vec::new();
+        if self.open.as_ref().map(|block| block.kind) != Some(BlockKind::Text) {
+            out.extend(self.open_text());
+        }
         let url = annotation.get("url").and_then(Value::as_str).unwrap_or("");
         let encrypted_index = annotation
             .get("encrypted_index")
             .and_then(Value::as_str)
             .map(str::to_string)
             .or_else(|| self.web_search_indexes.get(url).cloned())
-            .unwrap_or_default();
+            .map(Value::String)
+            .unwrap_or(Value::Null);
         let mut citation = json!({
             "type": "web_search_result_location",
             "url": url,
@@ -400,14 +408,16 @@ impl AnthropicSseMachine {
             .as_object_mut()
             .expect("citation is an object")
             .retain(|_, value| !value.is_null());
-        vec![sse(
+        self.text_citations.push(citation.clone());
+        out.push(sse(
             "content_block_delta",
             &json!({
                 "type": "content_block_delta",
                 "index": self.open_index(),
                 "delta": {"type": "citations_delta", "citation": citation}
             }),
-        )]
+        ));
+        out
     }
 
     fn web_search_done(&mut self, item: &Value) -> Vec<String> {
@@ -502,9 +512,13 @@ impl AnthropicSseMachine {
         };
         match open.kind {
             BlockKind::Text => {
-                self.content
-                    .push(json!({"type": "text", "text": self.text_buffer}));
+                let mut block = json!({"type": "text", "text": self.text_buffer});
+                if !self.text_citations.is_empty() {
+                    block["citations"] = json!(self.text_citations);
+                }
+                self.content.push(block);
                 self.text_buffer.clear();
+                self.text_citations.clear();
             }
             BlockKind::Tool => {
                 if let Some(tool) = self.tool_buffer.take() {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -397,11 +397,19 @@ impl AnthropicSseMachine {
             .or_else(|| self.web_search_indexes.get(url).cloned())
             .map(Value::String)
             .unwrap_or(Value::Null);
+        let title = annotation
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let cited_text = annotation
+            .get("cited_text")
+            .and_then(Value::as_str)
+            .unwrap_or("");
         let mut citation = json!({
             "type": "web_search_result_location",
             "url": url,
-            "title": annotation.get("title").cloned().unwrap_or(Value::Null),
-            "cited_text": annotation.get("cited_text").cloned().unwrap_or_else(|| json!("")),
+            "title": title,
+            "cited_text": cited_text,
             "encrypted_index": encrypted_index,
         });
         citation
@@ -452,6 +460,7 @@ impl AnthropicSseMachine {
         let results = item
             .get("results")
             .or_else(|| item.get("output"))
+            .filter(|results| results.is_array())
             .cloned()
             .unwrap_or_else(|| json!([]));
         if let Some(results) = results.as_array() {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use axum::http::StatusCode;
 use serde_json::{json, Value};
 
@@ -39,6 +41,7 @@ pub struct AnthropicSseMachine {
     text_buffer: String,
     tool_buffer: Option<ToolBuffer>,
     reasoning: Option<ReasoningBuffer>,
+    web_search_indexes: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +80,7 @@ impl AnthropicSseMachine {
             text_buffer: String::new(),
             tool_buffer: None,
             reasoning: None,
+            web_search_indexes: HashMap::new(),
         }
     }
 
@@ -89,6 +93,7 @@ impl AnthropicSseMachine {
             "response.created" | "response.in_progress" => self.start(&event.data),
             "response.output_item.added" => self.output_item_added(&event.data),
             "response.output_text.delta" => self.text_delta(&event.data),
+            "response.output_text.annotation.added" => self.annotation_added(&event.data),
             "response.output_text.done" | "response.content_part.done" => {
                 self.close_current(BlockKind::Text)
             }
@@ -181,6 +186,9 @@ impl AnthropicSseMachine {
         let item = data.get("item").unwrap_or(data);
         if item.get("type").and_then(Value::as_str) == Some("reasoning") {
             return self.reasoning_done(item);
+        }
+        if item.get("type").and_then(Value::as_str) == Some("web_search_call") {
+            return self.web_search_done(item);
         }
         self.close_any()
     }
@@ -367,6 +375,103 @@ impl AnthropicSseMachine {
                 "delta": {"type": "text_delta", "text": delta}
             }),
         )]
+    }
+
+    fn annotation_added(&mut self, data: &Value) -> Vec<String> {
+        let annotation = data.get("annotation").unwrap_or(data);
+        if annotation.get("type").and_then(Value::as_str) != Some("url_citation") {
+            return Vec::new();
+        }
+        let url = annotation.get("url").and_then(Value::as_str).unwrap_or("");
+        let encrypted_index = annotation
+            .get("encrypted_index")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| self.web_search_indexes.get(url).cloned())
+            .unwrap_or_default();
+        let mut citation = json!({
+            "type": "web_search_result_location",
+            "url": url,
+            "title": annotation.get("title").cloned().unwrap_or(Value::Null),
+            "cited_text": annotation.get("cited_text").cloned().unwrap_or_else(|| json!("")),
+            "encrypted_index": encrypted_index,
+        });
+        citation
+            .as_object_mut()
+            .expect("citation is an object")
+            .retain(|_, value| !value.is_null());
+        vec![sse(
+            "content_block_delta",
+            &json!({
+                "type": "content_block_delta",
+                "index": self.open_index(),
+                "delta": {"type": "citations_delta", "citation": citation}
+            }),
+        )]
+    }
+
+    fn web_search_done(&mut self, item: &Value) -> Vec<String> {
+        let mut out = self.close_any();
+        let id = item
+            .get("id")
+            .or_else(|| item.get("call_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let input = item
+            .get("action")
+            .cloned()
+            .or_else(|| item.get("input").cloned())
+            .unwrap_or_else(|| json!({}));
+        out.push(sse(
+            "content_block_start",
+            &json!({
+                "type": "content_block_start",
+                "index": self.index,
+                "content_block": {"type": "server_tool_use", "id": id, "name": "web_search", "input": input}
+            }),
+        ));
+        self.content.push(json!({
+            "type": "server_tool_use", "id": id, "name": "web_search", "input": input
+        }));
+        out.push(sse(
+            "content_block_stop",
+            &json!({"type": "content_block_stop", "index": self.index}),
+        ));
+        self.index += 1;
+
+        let results = item
+            .get("results")
+            .or_else(|| item.get("output"))
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        if let Some(results) = results.as_array() {
+            for result in results {
+                if let (Some(url), Some(encrypted_content)) = (
+                    result.get("url").and_then(Value::as_str),
+                    result.get("encrypted_content").and_then(Value::as_str),
+                ) {
+                    self.web_search_indexes
+                        .insert(url.to_string(), encrypted_content.to_string());
+                }
+            }
+        }
+        out.push(sse(
+            "content_block_start",
+            &json!({
+                "type": "content_block_start",
+                "index": self.index,
+                "content_block": {"type": "web_search_tool_result", "tool_use_id": id, "content": results}
+            }),
+        ));
+        self.content.push(json!({
+            "type": "web_search_tool_result", "tool_use_id": id, "content": results
+        }));
+        out.push(sse(
+            "content_block_stop",
+            &json!({"type": "content_block_stop", "index": self.index}),
+        ));
+        self.index += 1;
+        out
     }
 
     fn arguments_delta(&mut self, data: &Value) -> Vec<String> {

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -113,7 +113,7 @@ pub fn translate_request(
     // xAI also rejects the `summary` key, so it is omitted there. Other
     // flavors always request a reasoning summary, as before.
     match flavor {
-        ResponsesFlavor::Xai => {
+        ResponsesFlavor::Xai | ResponsesFlavor::Grok => {
             let client_effort = request
                 .pointer("/output_config/effort")
                 .and_then(Value::as_str)
@@ -134,7 +134,7 @@ pub fn translate_request(
     }
     // `text.verbosity` is a gpt-family knob; xAI's Responses API rejects the
     // `text` object, and Hermes never sends it there, so skip it for xai.
-    if flavor != ResponsesFlavor::Xai {
+    if !matches!(flavor, ResponsesFlavor::Xai | ResponsesFlavor::Grok) {
         out.insert("text".to_string(), json!({"verbosity": "medium"}));
     }
     // With store:false the Responses backend forgets each turn's reasoning, so ask
@@ -640,10 +640,9 @@ fn tools(request: &Value, flavor: ResponsesFlavor, context: &ToolSearchContext) 
             })
             .filter_map(|tool| {
                 if is_web_search_tool(tool) {
-                    // xAI's Responses API only accepts function tools and 400s
-                    // on the hosted web-search shape, so drop it there rather
-                    // than fail the whole request. The tool_choice below then
-                    // downgrades any web_search choice to `auto`.
+                    // Only the Grok CLI subscription proxy is verified to accept
+                    // hosted web search. Keep dropping it on the xAI developer
+                    // API until that surface is verified separately.
                     match flavor {
                         ResponsesFlavor::Xai => None,
                         _ => Some(web_search_tool(tool)),
@@ -705,11 +704,10 @@ fn tool_choice(
             Some("tool") => {
                 let name = choice.get("name").and_then(Value::as_str).unwrap_or("");
                 if names_web_search(request, name) {
-                    // xAI drops the hosted web-search tool (see `tools`), so a
-                    // `web_search` choice there would force a tool that was
-                    // never registered — the backend 502s on that. Downgrade to
-                    // `auto`. Elsewhere the tool is selected with a bare
-                    // `{"type":"web_search"}`, not a named function choice.
+                    // The xAI developer API drops the hosted tool (see `tools`),
+                    // so a `web_search` choice there would force a tool that was
+                    // never registered. The Grok CLI flavor keeps the hosted
+                    // selector because that surface supports it.
                     match flavor {
                         ResponsesFlavor::Xai => Some(json!("auto")),
                         _ => Some(json!({"type": "web_search"})),

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -823,7 +823,54 @@ fn translates_grok_web_search_results_and_citations_to_anthropic_blocks() {
     assert_eq!(final_json["content"][0]["type"], "server_tool_use");
     assert_eq!(final_json["content"][1]["type"], "web_search_tool_result");
     assert_eq!(final_json["content"][2]["type"], "text");
+    assert_eq!(
+        final_json["content"][2]["citations"][0]["encrypted_index"],
+        "enc"
+    );
     assert_eq!(final_json["stop_reason"], "end_turn");
+}
+
+#[test]
+fn citation_without_open_text_block_opens_one_and_omits_missing_encrypted_index() {
+    let fixture = concat!(
+        "event: response.created\n",
+        "data: {\"response\":{\"id\":\"resp_search\"}}\n\n",
+        "event: response.output_text.annotation.added\n",
+        "data: {\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://example.com/\",\"title\":\"Example\",\"cited_text\":\"Example text\"}}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{}}\n\n"
+    );
+    let mut machine = AnthropicSseMachine::new("grok-4.5", false);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+
+    let names = event_names(&emitted);
+    assert_eq!(
+        names,
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop"
+        ]
+    );
+    assert!(!emitted.contains("encrypted_index"));
+
+    let final_json = machine.final_json();
+    assert_eq!(final_json["content"][0]["type"], "text");
+    assert_eq!(final_json["content"][0]["text"], "");
+    assert_eq!(
+        final_json["content"][0]["citations"][0]["url"],
+        "https://example.com/"
+    );
+    assert!(final_json["content"][0]["citations"][0]
+        .get("encrypted_index")
+        .is_none());
 }
 
 #[test]

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -574,6 +574,39 @@ fn forced_web_search_tool_choice_uses_web_search_selector() {
 }
 
 #[test]
+fn grok_forwards_web_search_tool_and_forced_choice() {
+    let out = translate_with_flavor(
+        json!({
+            "model": "grok-4.5",
+            "messages": [{"role": "user", "content": "find it"}],
+            "tools": [
+                {"name": "Bash", "input_schema": {}},
+                {"type": "web_search_20250305", "name": "web_search"}
+            ],
+            "tool_choice": {"type": "tool", "name": "web_search"}
+        }),
+        ResponsesFlavor::Grok,
+    );
+    assert_eq!(
+        out["tools"],
+        json!([
+            {
+                "type": "function",
+                "name": "Bash",
+                "description": "",
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": true}
+            },
+            {
+                "type": "web_search",
+                "external_web_access": false,
+                "search_content_types": ["text", "image"]
+            }
+        ])
+    );
+    assert_eq!(out["tool_choice"], json!({"type": "web_search"}));
+}
+
+#[test]
 fn xai_drops_web_search_tool_and_downgrades_forced_choice() {
     // xAI's Responses API only accepts function tools, so the hosted
     // web-search tool is dropped and a forced choice for it falls back to
@@ -749,6 +782,48 @@ fn xai_includes_encrypted_reasoning_when_thinking_enabled() {
     let actual = translate_request(&body, &xai_route("grok-4.5"), ResponsesFlavor::Xai).unwrap();
 
     assert_eq!(actual["include"], json!(["reasoning.encrypted_content"]));
+}
+
+#[test]
+fn translates_grok_web_search_results_and_citations_to_anthropic_blocks() {
+    let fixture = concat!(
+        "event: response.created\n",
+        "data: {\"response\":{\"id\":\"resp_search\"}}\n\n",
+        "event: response.output_item.added\n",
+        "data: {\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"status\":\"in_progress\"}}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"query\":\"Rust language\"},\"results\":[{\"type\":\"web_search_result\",\"url\":\"https://www.rust-lang.org/\",\"title\":\"Rust\",\"encrypted_content\":\"enc\"}]}}\n\n",
+        "event: response.output_item.added\n",
+        "data: {\"item\":{\"type\":\"message\"}}\n\n",
+        "event: response.output_text.delta\n",
+        "data: {\"delta\":\"Rust is a systems language.\"}\n\n",
+        "event: response.output_text.annotation.added\n",
+        "data: {\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://www.rust-lang.org/\",\"title\":\"Rust\",\"cited_text\":\"Rust is a systems language.\"}}\n\n",
+        "event: response.output_text.done\n",
+        "data: {}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n"
+    );
+    let mut machine = AnthropicSseMachine::new("grok-4.5", false);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+
+    assert!(emitted.contains("\"type\":\"server_tool_use\""));
+    assert!(emitted.contains("\"id\":\"ws_1\""));
+    assert!(emitted.contains("\"type\":\"web_search_tool_result\""));
+    assert!(emitted.contains("\"tool_use_id\":\"ws_1\""));
+    assert!(emitted.contains("\"type\":\"citations_delta\""));
+    assert!(emitted.contains("\"type\":\"web_search_result_location\""));
+    assert!(emitted.contains("\"encrypted_index\":\"enc\""));
+    assert!(emitted.contains("https://www.rust-lang.org/"));
+
+    let final_json = machine.final_json();
+    assert_eq!(final_json["content"][0]["type"], "server_tool_use");
+    assert_eq!(final_json["content"][1]["type"], "web_search_tool_result");
+    assert_eq!(final_json["content"][2]["type"], "text");
+    assert_eq!(final_json["stop_reason"], "end_turn");
 }
 
 #[test]

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -836,7 +836,7 @@ fn citation_without_open_text_block_opens_one_and_omits_missing_encrypted_index(
         "event: response.created\n",
         "data: {\"response\":{\"id\":\"resp_search\"}}\n\n",
         "event: response.output_text.annotation.added\n",
-        "data: {\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://example.com/\",\"title\":\"Example\",\"cited_text\":\"Example text\"}}\n\n",
+        "data: {\"annotation\":{\"type\":\"url_citation\",\"url\":\"https://example.com/\",\"title\":null,\"cited_text\":null}}\n\n",
         "event: response.completed\n",
         "data: {\"response\":{}}\n\n"
     );
@@ -868,9 +868,33 @@ fn citation_without_open_text_block_opens_one_and_omits_missing_encrypted_index(
         final_json["content"][0]["citations"][0]["url"],
         "https://example.com/"
     );
+    assert_eq!(final_json["content"][0]["citations"][0]["title"], "");
+    assert_eq!(final_json["content"][0]["citations"][0]["cited_text"], "");
     assert!(final_json["content"][0]["citations"][0]
         .get("encrypted_index")
         .is_none());
+}
+
+#[test]
+fn non_array_web_search_results_become_an_empty_result_array() {
+    let fixture = concat!(
+        "event: response.created\n",
+        "data: {\"response\":{\"id\":\"resp_search\"}}\n\n",
+        "event: response.output_item.done\n",
+        "data: {\"item\":{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"results\":null}}\n\n",
+        "event: response.completed\n",
+        "data: {\"response\":{}}\n\n"
+    );
+    let mut machine = AnthropicSseMachine::new("grok-4.5", false);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+
+    assert!(emitted.contains("\"type\":\"web_search_tool_result\""));
+    assert!(emitted.contains("\"content\":[]"));
+    let final_json = machine.final_json();
+    assert_eq!(final_json["content"][1]["content"], json!([]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- distinguish the Grok CLI subscription proxy from the xAI developer API at the Responses flavor boundary
- forward hosted `web_search` tools and forced choices only for the verified Grok OAuth surface
- translate Grok `web_search_call` output, results, and URL annotations into Anthropic server-tool, result, and citation events
- document the separate hosted-search charge and the unverified `api.x.ai` behavior

## Testing

- `cargo test --all-features --workspace`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Live validation

A local live probe was not run because neither `XAI_API_KEY` nor a Grok OAuth credential is available in this worktree. The request and response wire behavior is covered by focused fixtures based on the live event sequence recorded in the issue.

Closes #61

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables hosted `web_search` for Grok OAuth (Grok CLI proxy) and translates Grok search calls, results, and URL citations into Anthropic tool and citation events. Keeps the `api.x.ai` developer API unchanged and documents separate hosted-search billing; also hardens the streaming mapper for web search edge cases. Addresses #61.

- **New Features**
  - Added `ResponsesFlavor::Grok` (detected when `auth = xai_oauth` targets `grok.com`); kept `Xai` for `api.x.ai`.
  - Forward hosted `web_search` tool and forced choice only for `grok`; drop on `xai` and downgrade choice to `auto`.
  - Translate `web_search_call` into `server_tool_use` and `web_search_tool_result`; map `response.output_text.annotation.added` `url_citation` to Anthropic citation deltas, propagating `encrypted_index` from results and opening a text block if needed.
  - Skip `OpenAI-Beta: responses=experimental` for both `Xai` and `Grok`.
  - Updated docs to clarify proxy-only capability and separate billing; added tests for search, citations, and header behavior.

- **Bug Fixes**
  - Hardened web search blocks: treat non-array `results` as `[]`; support `id`/`call_id` and `action`/`input`.
  - Preserve `encrypted_content`→`encrypted_index` mapping per-URL; omit `encrypted_index` when missing.
  - Emit citations even if no text block is open.

<sup>Written for commit 4bf9df664d9ccbf1b904d00637f4c706873dcc52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

