### PR TITLE
docs(comparison): sync with recent PRs and refactors

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@ shunt is a **spec-compliant Claude Code LLM gateway**: it implements Claude Code
 official `ANTHROPIC_BASE_URL` gateway contract (`/v1/messages`, `/v1/models`
 discovery, attribution/header pass-through) and does **selective, per-`model`-id**
 diversion — keep the main session on Claude, divert only the models you name onto
-another provider (ChatGPT/Codex, OpenAI, Cursor, xAI). It translates Anthropic Messages ⇄
+another provider (ChatGPT/Codex, OpenAI, Cursor, xAI, Grok). It translates Anthropic Messages ⇄
 the OpenAI Responses API for mapped models, and passes everything else through to
 Anthropic unchanged. Routing is purely by the request's `model` id — no
 prompt-shape fingerprinting (`README.md:104-131`).
@@ -50,7 +50,7 @@ Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
 | tool-search / `defer_loading` / `tool_reference` handling | ◐ (shim: works, no ctx savings; native opt-in⁸) | ○⁵ | ◐ (upstream) / ● (fork) | ○ | ○ |
 | Reasoning round-trip to Claude Code `thinking` | ● (encrypted) | ◐ (Kimi/Grok; **Codex dropped**) | ◐ | ○ | ◐ |
 | Multi-account load balancing / failover | ◐⁷ | ○ | ● | some | ● |
-| Backend breadth | 5 providers¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
+| Backend breadth | 6 providers¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
 | Management API / dashboard | ◐⁹ | ◐ (monitor TUI) | ● | some | ● |
 | Usage / quota / cost tracking | ◐⁹ (pool quota state; no usage/cost) | ○ | ● | some | ● |
 | Plugin / interceptor system | ○ | ○ | ● | some | ● |
@@ -58,9 +58,10 @@ Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
 | Config model | TOML + env, hot-reload | env + config file | YAML + mgmt API | varies | YAML/UI |
 
 ¹ shunt: three adapter *kinds* (`anthropic` passthrough, `responses` translation, and
-`cursor` ConnectRPC/protobuf translation — `src/config.rs:395-408`) with 5 built-in providers
-seeded by default (Anthropic, OpenAI, ChatGPT/Codex, Cursor, xAI — `src/config.rs:654-693`);
-any other Anthropic-Messages or OpenAI-Responses endpoint is config-only.
+`cursor` ConnectRPC/protobuf translation — `src/config.rs:395-408`) with 6 built-in providers
+seeded by default (Anthropic, OpenAI, ChatGPT/Codex, Cursor, and xAI Grok on two surfaces —
+`xai` API-key and `grok` subscription-OAuth — `src/config.rs:652-716`); any other
+Anthropic-Messages or OpenAI-Responses endpoint is config-only.
 ² CLIProxyAPI: aistudio, antigravity, claude, codex, codex-ws, gemini, gemini-vertex,
 kimi, openai-compat, xai, xai-ws.
 ³ raine/ccp routes by `ANTHROPIC_MODEL` per-model like shunt, but has **no

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -101,7 +101,7 @@ the #43 shim regardless of the flag.
 `[server.admin]` table is present (`src/server.rs:117-118`, `src/admin/mod.rs:87-101`). It
 provisions Anthropic `claude_oauth` accounts (add/list/replace/remove) through the existing
 `claude_login` flow and renders a **read-only account-pool dashboard** — per-account 5h/7d
-quota utilization, reset times, cooldown, and near-quota flags (`src/accounts.rs:46-78`).
+quota utilization, cooldown, and near-quota flags (`src/accounts.rs:46-78`).
 Deliberately narrow: Anthropic accounts only (no ChatGPT/Codex), and no request/token usage
 or cost accounting — well short of CLIProxyAPI's full management API + quota/usage manager.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -98,10 +98,10 @@ given backend accepts the shapes shunt emits. xAI/Grok routes and gpt-5.2-and-be
 the #43 shim regardless of the flag.
 
 ⁹ **[#77]** adds an opt-in `[server.admin]` browser surface, registered only when the
-`[server.admin]` table is present (`src/server.rs:117-118`, `src/admin/mod.rs:87-101`). It
+`[server.admin]` table is present (`src/server.rs:117-118`, `src/admin/mod.rs:87-103`). It
 provisions Anthropic `claude_oauth` accounts (add/list/replace/remove) through the existing
 `claude_login` flow and renders a **read-only account-pool dashboard** — per-account 5h/7d
-quota utilization, cooldown, and near-quota flags (`src/accounts.rs:46-78`).
+quota utilization, cooldown, and near-quota flags (`src/accounts.rs:46-63`).
 Deliberately narrow: Anthropic accounts only (no ChatGPT/Codex), and no request/token usage
 or cost accounting — well short of CLIProxyAPI's full management API + quota/usage manager.
 
@@ -166,7 +166,7 @@ possible backends*, not the same product.
   endpoints are just `/`, `/health`, `/protocol`, `/v1/models`, `/routes`,
   `/v1/messages`, `/v1/messages/count_tokens` (`src/server.rs:106-112`). An opt-in
   `[server.admin]` surface ([#77]) adds browser-based Anthropic-account provisioning
-  and a **read-only account-pool dashboard** (`src/admin/mod.rs:87-101`), but there is
+  and a **read-only account-pool dashboard** (`src/admin/mod.rs:87-103`), but there is
   still no request/token usage or cost accounting; observability beyond that is opt-in
   Sentry metrics only (`src/metrics.rs`). CLIProxyAPI ships a full management API +
   quota/usage manager and a third-party dashboard ecosystem; raine/claude-code-proxy
@@ -236,7 +236,7 @@ toward being a fleet gateway and warrant a conscious decision first.
 
 - **H. Per-account quota/usage visibility.** Follows G. For Anthropic accounts the
   opt-in admin dashboard ([#77]) already surfaces each account's 5h/7d window and
-  cooldown state (`src/accounts.rs:46-78`); extending the same per-account view to
+  cooldown state (`src/accounts.rs:46-63`); extending the same per-account view to
   ChatGPT/Codex subscription accounts (as CLIProxyAPI's ecosystem does) is the part
   still missing. Ties to the observability gap.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@ shunt is a **spec-compliant Claude Code LLM gateway**: it implements Claude Code
 official `ANTHROPIC_BASE_URL` gateway contract (`/v1/messages`, `/v1/models`
 discovery, attribution/header pass-through) and does **selective, per-`model`-id**
 diversion — keep the main session on Claude, divert only the models you name onto
-another provider (ChatGPT/Codex, OpenAI, xAI). It translates Anthropic Messages ⇄
+another provider (ChatGPT/Codex, OpenAI, Cursor, xAI). It translates Anthropic Messages ⇄
 the OpenAI Responses API for mapped models, and passes everything else through to
 Anthropic unchanged. Routing is purely by the request's `model` id — no
 prompt-shape fingerprinting (`README.md:104-131`).
@@ -50,16 +50,17 @@ Legend: ● full · ◐ partial / workaround · ○ none · — n/a by design
 | tool-search / `defer_loading` / `tool_reference` handling | ◐ (shim: works, no ctx savings; native opt-in⁸) | ○⁵ | ◐ (upstream) / ● (fork) | ○ | ○ |
 | Reasoning round-trip to Claude Code `thinking` | ● (encrypted) | ◐ (Kimi/Grok; **Codex dropped**) | ◐ | ○ | ◐ |
 | Multi-account load balancing / failover | ◐⁷ | ○ | ● | some | ● |
-| Backend breadth | 4 providers¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
-| Management API / dashboard | ○ | ◐ (monitor TUI) | ● | some | ● |
-| Usage / quota / cost tracking | ○ (Sentry metrics only) | ○ | ● | some | ● |
+| Backend breadth | 5 providers¹ | 4 subs⁶ | 11 backends² | varies | 100–1600+ |
+| Management API / dashboard | ◐⁹ | ◐ (monitor TUI) | ● | some | ● |
+| Usage / quota / cost tracking | ◐⁹ (pool quota state; no usage/cost) | ○ | ● | some | ● |
 | Plugin / interceptor system | ○ | ○ | ● | some | ● |
 | Language / footprint | Rust, 1 binary | Rust, 1 binary | Go | Node/Python | Go/Node/Python |
 | Config model | TOML + env, hot-reload | env + config file | YAML + mgmt API | varies | YAML/UI |
 
-¹ shunt: two adapter *kinds* (`anthropic` passthrough, `responses` translation) with
-4 built-in providers (Anthropic, OpenAI, ChatGPT/Codex, xAI) — any Anthropic-Messages
-or OpenAI-Responses endpoint is config-only (`src/config.rs:180-190,316-363`).
+¹ shunt: three adapter *kinds* (`anthropic` passthrough, `responses` translation, and
+`cursor` ConnectRPC/protobuf translation — `src/config.rs:395-408`) with 5 built-in providers
+seeded by default (Anthropic, OpenAI, ChatGPT/Codex, Cursor, xAI — `src/config.rs:654-693`);
+any other Anthropic-Messages or OpenAI-Responses endpoint is config-only.
 ² CLIProxyAPI: aistudio, antigravity, claude, codex, codex-ws, gemini, gemini-vertex,
 kimi, openai-compat, xai, xai-ws.
 ³ raine/ccp routes by `ANTHROPIC_MODEL` per-model like shunt, but has **no
@@ -67,7 +68,7 @@ Anthropic-passthrough adapter** — an unknown model id returns 400, so you cann
 the main session on Claude while diverting only the models you name.
 ⁴ raine/ccp implements its **own** ChatGPT OAuth (PKCE browser + device-code login);
 shunt reuses the Codex CLI login (`~/.codex/auth.json`) and its own PKCE flow is an
-open TODO (`src/auth/mod.rs:18-19`).
+open TODO (`src/auth/mod.rs:19-20`).
 ⁵ **Confirmed by reading raine/ccp source** (`fe80a6b`, 2026-07-11): no tool-search
 handling exists (zero matches for `defer_loading` / `tool_reference` / `tool_search` /
 `advanced-tool-use`). Tools are whitelist-rebuilt to `{name, description, parameters}`
@@ -85,7 +86,7 @@ selection, per-provider round-robin, model-aware proactive rotation from per-acc
 5h/7d quota headers, cooldowns, forced refresh after 401, and reactive failover on
 quota-rejected 429s and 5xx responses. ChatGPT/Codex remains single-account;
 per-account usage reporting is not implemented.
-⁸ **[#82]** adds an opt-in, per-provider `tool_search` flag (`src/config.rs:250-261,1041-1049`)
+⁸ **[#82]** adds an opt-in, per-provider `tool_search` flag (`src/config.rs:324-335,1153-1161`)
 that maps Claude Code's tool search onto the OpenAI Responses API's own native,
 client-executed `tool_search` protocol — `ToolSearch` → `tool_search`, its `tool_use` →
 `tool_search_call`, and `tool_reference` → a `tool_search_output` item carrying the loaded
@@ -94,6 +95,14 @@ schema into text. Off by default: it only applies for a stock OpenAI or ChatGPT/
 flavor routing to a gpt-5.4+ model, and is gated behind the flag until a live probe confirms a
 given backend accepts the shapes shunt emits. xAI/Grok routes and gpt-5.2-and-below models keep
 the #43 shim regardless of the flag.
+
+⁹ **[#77]** adds an opt-in `[server.admin]` browser surface, registered only when the
+`[server.admin]` table is present (`src/server.rs:117-118`, `src/admin/mod.rs:87-101`). It
+provisions Anthropic `claude_oauth` accounts (add/list/replace/remove) through the existing
+`claude_login` flow and renders a **read-only account-pool dashboard** — per-account 5h/7d
+quota utilization, reset times, cooldown, and near-quota flags (`src/accounts.rs:46-78`).
+Deliberately narrow: Anthropic accounts only (no ChatGPT/Codex), and no request/token usage
+or cost accounting — well short of CLIProxyAPI's full management API + quota/usage manager.
 
 > "raine/ccp" = [raine/claude-code-proxy](https://github.com/raine/claude-code-proxy).
 
@@ -111,7 +120,7 @@ the #43 shim regardless of the flag.
   *synthesizes* continuation: it stores the transcript on the pooled connection,
   diffs the next request against it with type-aware normalization, and injects
   `previous_response_id` + input-delta — real upload trimming on the Claude→Codex
-  path (`src/adapters/codex_continuation.rs:79-114`). This is **not** unique:
+  path (`src/adapters/responses/codex_continuation.rs:79-114`). This is **not** unique:
   **raine/claude-code-proxy does the same class of thing** (opt-in
   `CCP_CODEX_PREVIOUS_RESPONSE_ID`, session-keyed, append-only). The two Rust
   subscription proxies share it — the real contrast is with **passthrough** proxies
@@ -125,7 +134,7 @@ the #43 shim regardless of the flag.
   axes: (1) its continuation normalization parses `function_call.arguments` and
   round-trips reasoning `encrypted_content`/signature, so continuation keeps firing
   across tool turns where a shape-only comparison would drop it
-  (`src/adapters/codex_continuation.rs:11-48`); and (2) it **forwards Codex reasoning
+  (`src/adapters/responses/codex_continuation.rs:11-48`); and (2) it **forwards Codex reasoning
   to Claude Code as `thinking`**, whereas raine/claude-code-proxy **drops Codex
   reasoning blocks entirely** (its README lists this as a limitation). Any unforeseen
   shape still falls back to full input — never wrong context, only a missed
@@ -152,20 +161,23 @@ possible backends*, not the same product.
 - **Narrow backend breadth.** Only Anthropic-Messages passthrough or OpenAI-Responses
   translation; no native Gemini/Bedrock/Azure/Ollama unless they expose one of those
   two protocols.
-- **No management API / dashboard / usage-quota / cost tracking.** Endpoints are just
-  `/`, `/health`, `/v1/models`, `/routes`, `/v1/messages`, `/v1/messages/count_tokens`
-  (`src/server.rs:69-75`); observability is opt-in Sentry metrics only
-  (`src/metrics.rs`). CLIProxyAPI ships a full management API + quota/usage manager
-  and a third-party dashboard ecosystem; even the same-class peer
-  raine/claude-code-proxy ships a built-in **monitor TUI** (live sessions, active /
-  recent requests, error events) that shunt has no equivalent of.
+- **Narrow, opt-in management surface; no usage/cost tracking.** The always-on
+  endpoints are just `/`, `/health`, `/protocol`, `/v1/models`, `/routes`,
+  `/v1/messages`, `/v1/messages/count_tokens` (`src/server.rs:106-112`). An opt-in
+  `[server.admin]` surface ([#77]) adds browser-based Anthropic-account provisioning
+  and a **read-only account-pool dashboard** (`src/admin/mod.rs:87-101`), but there is
+  still no request/token usage or cost accounting; observability beyond that is opt-in
+  Sentry metrics only (`src/metrics.rs`). CLIProxyAPI ships a full management API +
+  quota/usage manager and a third-party dashboard ecosystem; raine/claude-code-proxy
+  ships a built-in **monitor TUI** (live sessions, active / recent requests, error
+  events) — a live-traffic view shunt's account-oriented dashboard doesn't replace.
 - **No own ChatGPT OAuth login.** shunt reuses the Codex CLI login
   (`~/.codex/auth.json`); a first-party PKCE flow is an open TODO
-  (`src/auth/mod.rs:18-19`). raine/claude-code-proxy is prior art here — it ships its
+  (`src/auth/mod.rs:19-20`). raine/claude-code-proxy is prior art here — it ships its
   own `codex auth login` (PKCE) **and** `codex auth device` (device-code), so it works
   without the Codex CLI installed.
-- **No plugin / interceptor system.** The adapter set is a fixed two-variant `match`
-  (`src/proxy.rs:152-163`); CLIProxyAPI has a full plugin host (RPC ABI, auth
+- **No plugin / interceptor system.** The adapter set is a fixed three-variant `match`
+  (`src/proxy.rs:170-186`); CLIProxyAPI has a full plugin host (RPC ABI, auth
   providers, executor routing, request/response translators).
 - **Plain HTTP only** (TLS out of scope, `docs/m4-inbound-auth.md:13`).
 
@@ -197,8 +209,12 @@ toward being a fleet gateway and warrant a conscious decision first.
 
 - **C. Codex WS: mid-stream failure resumption (already tracked: [#46]).** A WS failure *before* streaming
   falls back to HTTP transparently, but a *mid-stream* failure surfaces as an error
-  SSE event, not a fallback (`src/adapters/responses.rs:92-135`). Consider
-  resuming/replaying so a dropped socket mid-turn degrades to HTTP instead of erroring.
+  SSE event, not a fallback (`src/adapters/responses/mod.rs:97-134`). **[#93]** removed
+  one major *cause* — a half-open pooled socket now fails the reuse liveness probe
+  (a timely `Pong` is required, not just a local write) and is replaced with a fresh
+  handshake before the turn's frame is sent, so a stale connection can no longer break
+  mid-stream. The residual gap stands: a socket that genuinely drops *during* a turn
+  still errors rather than resuming/replaying over HTTP.
 
 - **D. Codex WS: speculative prewarm (`generate:false`) (already tracked: [#47]).** Explicitly out of scope
   today (`docs/m7-codex-websocket.md:53-58`), but it is a real Codex latency
@@ -209,10 +225,6 @@ toward being a fleet gateway and warrant a conscious decision first.
   implemented (`docs/implementation-plan.md:247`); transient upstream 429/5xx errors surface
   directly. A small, idempotent retry would improve resilience without adding scope.
 
-- **F. Doc drift: `GET /protocol` (already tracked: [#49]).** README advertises a machine-readable spec at
-  `GET /protocol` (`README.md:110`) but no such route exists in `src/server.rs`.
-  Implement it (cheap, and it's part of the gateway-protocol story) or correct the docs.
-
 ### Scope-boundary (decide before doing)
 
 - **G. Minimal multi-account for ChatGPT/Codex.** Full LB is out of scope, but heavy
@@ -221,9 +233,11 @@ toward being a fleet gateway and warrant a conscious decision first.
   moving to the next) is disproportionately valuable. This is the single biggest
   feature gap vs CLIProxyAPI and the one most worth a design discussion.
 
-- **H. Per-account quota/usage visibility.** Follows G — if multiple subscription
-  accounts are in play, surfacing each account's 5h/7d window (as CLIProxyAPI's
-  ecosystem does) becomes useful. Ties to the observability gap.
+- **H. Per-account quota/usage visibility.** Follows G. For Anthropic accounts the
+  opt-in admin dashboard ([#77]) already surfaces each account's 5h/7d window and
+  cooldown state (`src/accounts.rs:46-78`); extending the same per-account view to
+  ChatGPT/Codex subscription accounts (as CLIProxyAPI's ecosystem does) is the part
+  still missing. Ties to the observability gap.
 
 - **I. Native Gemini (and other) backends.** Only relevant if shunt broadens past the
   Anthropic-Messages / OpenAI-Responses duality. Not currently in scope.
@@ -236,7 +250,7 @@ subscription OAuth, per-`model` routing, Codex WS + `previous_response_id`
 continuation) — against which shunt's edge is deeper continuation normalization,
 Codex reasoning fidelity (raine drops it), an Anthropic-passthrough path (keep the
 main session on Claude), and xAI OAuth; raine's edge is a built-in monitor TUI, a
-first-party ChatGPT OAuth login, and Kimi/Cursor breadth. Against **CLIProxyAPI**,
+first-party ChatGPT OAuth login, and Kimi breadth. Against **CLIProxyAPI**,
 shunt wins on translation-path upload trimming (CLIProxyAPI's WS is a passthrough)
 and trades away most fleet features (broad multi-account LB, management, plugins,
 backend breadth) by design. It now provides a narrow Anthropic OAuth account
@@ -254,4 +268,5 @@ multi-account for ChatGPT/Codex.
 [#46]: https://github.com/pleaseai/shunt/issues/46
 [#47]: https://github.com/pleaseai/shunt/issues/47
 [#48]: https://github.com/pleaseai/shunt/issues/48
-[#49]: https://github.com/pleaseai/shunt/issues/49
+[#77]: https://github.com/pleaseai/shunt/issues/77
+[#93]: https://github.com/pleaseai/shunt/issues/93


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Syncs docs/comparison.md with recent features and refactors.

Adds Cursor and the `cursor` adapter, counts `xai` and `grok` separately (6 total), documents the opt‑in `[server.admin]` web surface and clarifies the Anthropic account dashboard shows utilization/state/cooldown only (no reset times), notes the Codex WS mid‑stream stability fix, removes the resolved `/protocol` gap, corrects a raine/ccp attribution, tightens `admin_router` and `AccountSnapshot` citation ranges, and updates footnotes.

<sup>Written for commit 78262e4888f151c423fdfdfeb29541b70ac7d323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

