### PR TITLE
feat(codex-ws): live-probe continuation normalization and add hit/fallback metric

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -189,11 +189,16 @@ toward being a fleet gateway and warrant a conscious decision first.
   off by default pending a live probe of backend acceptance, so the shim (and the zero-savings
   gap for xAI/Grok and older models) remains the baseline until operators opt in.
 
-- **B. Codex WS: live-probe the continuation normalization (already tracked: [#45]).** Reasoning/`function_call`
-  normalization is schema-validated against 3 sources but not yet live-probed
-  (`docs/m7-codex-websocket.md:250-270`). Any unaccounted field silently falls back to the
-  safe full-input fallback — correctness-safe, but a *latent missed optimization*. A
-  probe pass would confirm continuation fires as often as it should.
+- **B. Codex WS: live-probe the continuation normalization (already tracked: [#45]).** **Done (2026-07-13).**
+  Reasoning/`function_call` normalization was schema-validated against 3 sources; a live probe over the
+  WebSocket transport then captured real `message`/`reasoning`/`function_call` output items and diffed
+  them against `normalize_item` — **no unaccounted field**. The probe corrected two assumptions: the
+  backend omits reasoning `status` and returns an empty plaintext `content` array under `store:false`
+  (both already stripped, so the match is unaffected). End-to-end, all three item kinds continued from
+  `previous_response_id` on a warm pool (delta-only turns, zero `previous_response_not_found` rejects).
+  A new `shunt.codex_continuation` counter (hit vs full-input fallback) makes future drift visible. The
+  one residual is namespaced/MCP tool calls (need a live MCP server to trigger); their `namespace` strip
+  stays schema-grounded until probed.
 
 - **C. Codex WS: mid-stream failure resumption (already tracked: [#46]).** A WS failure *before* streaming
   falls back to HTTP transparently, but a *mid-stream* failure surfaces as an error

--- a/docs/m7-codex-websocket.md
+++ b/docs/m7-codex-websocket.md
@@ -169,10 +169,10 @@ own reconstruction code:
 
 | Item type | Backend `output_item.done` extras | Canonicalization | Source |
 | :-- | :-- | :-- | :-- |
-| all | `id`, `phase`, `status` | strip | live probe (text turn), 2026-07-12 `gpt-5.6-sol` |
+| all | `id`, `phase`, `status` | strip | live probe (message/reasoning/function_call), 2026-07-13 `gpt-5.6-sol` |
 | `message` content part | `annotations`, `logprobs` | strip | live probe |
-| `function_call` | `id`, `status`, `namespace`; `arguments` as raw model string | strip keys; **parse `arguments`** to a value | code + `openai/codex` `ResponseItem::FunctionCall` / openai-python `ResponseFunctionToolCall` (`arguments: str`) |
-| `reasoning` | `id`, `status`, plaintext `content` array; `summary` parts | strip keys; normalize `summary` parts; `encrypted_content`/`id` round-trip verbatim | code + `openai/codex` `ResponseItem::Reasoning` / openai-python `ResponseReasoningItem` (`content: Optional[List[reasoning_text]]`) |
+| `function_call` | `id`, `status`, `namespace`; `arguments` as raw model string | strip keys; **parse `arguments`** to a value | live probe (plain tool) + `openai/codex` `ResponseItem::FunctionCall` / openai-python `ResponseFunctionToolCall` (`arguments: str`); `namespace` schema-grounded (MCP not yet probed) |
+| `reasoning` | `id`; `summary` parts; (`status` and plaintext `content` absent under `store:false`) | strip `id`/`status`; normalize `summary` parts; drop plaintext `content`; `encrypted_content` round-trips verbatim | live probe 2026-07-13 + `openai/codex` `ResponseItem::Reasoning` / openai-python `ResponseReasoningItem` (`content: Optional[List[reasoning_text]]`) |
 
 For the text/message case the reconstruction is a strict **subset**, so stripping
 suffices. For `function_call` the `arguments` string is *not* a subset — the backend
@@ -279,19 +279,18 @@ websocket = true   # opt-in; effective only on the ChatGPT/Codex backend
 
 ## 11. Open questions / follow-ups
 
-- **Reasoning / function_call normalization is schema-validated (three sources),
-  not yet live-probed.** The text/message rules were live-probed. The `reasoning`
-  and `function_call` rules (§6) are derived from shunt's own reconstruction code
-  and cross-checked against three independent authoritative sources that agree:
-  `openai/codex` `ResponseItem` (the type codex round-trips as input under
-  `store:false`), openai-python `ResponseReasoningItem` / `ResponseFunctionToolCall`,
-  and LiteLLM's Responses transformation. That cross-check confirmed and closed the
-  two gaps the earlier draft flagged — a reasoning item's optional plaintext
-  `content` array and a `function_call.namespace` are now stripped — and surfaced no
-  field shunt fails to handle. A live thinking/tool turn would still be the final
-  confirmation (the probe account is `prolite` and usage-capped), but any
-  unaccounted field only causes the **safe** full-input fallback — correct, just
-  unoptimized.
+- **Reasoning / function_call normalization — live-probed (issue #45, 2026-07-13).**
+  The text/message rules were live-probed earlier; the `reasoning` and `function_call`
+  rules are now confirmed too. A probe over the WebSocket transport captured real
+  `message`, `reasoning`, and `function_call` output items and diffed them against
+  `normalize_item`: **no unaccounted field**. It corrected two assumptions — the backend
+  omits reasoning `status` entirely and returns an empty plaintext `content` array under
+  `store:false` (both already stripped, so the append-only match is unaffected). All
+  three item kinds then continued from `previous_response_id` end-to-end on a warm pool
+  (delta-only turns, zero `previous_response_not_found` rejects). The remaining gap is
+  namespaced/MCP tool calls, which need a live MCP server to trigger; the `namespace`
+  strip stays schema-grounded until then. A `shunt.codex_continuation` counter (hit vs
+  full-input fallback, per provider) now surfaces any future drift.
 - **Payoff measurement.** Correctness is proven; the actual per-turn byte savings on
   long real conversations should be measured before the flag is recommended broadly.
 - **Multi-process pools.** The pool is process-local; a multi-replica deployment

--- a/src/adapters/responses/codex_continuation.rs
+++ b/src/adapters/responses/codex_continuation.rs
@@ -27,7 +27,9 @@
 //!
 //! - **All items** shed the additive backend-only keys `id`/`phase`/`status`. Both
 //!   schemas mark `status`/`id` as "populated when returned via API"; a live probe
-//!   (text turn) confirmed the reconstruction is otherwise a strict subset.
+//!   over the WebSocket transport (issue #45, 2026-07-13) captured real
+//!   `message`/`reasoning`/`function_call` items and confirmed the reconstruction
+//!   is otherwise a strict subset, with no unaccounted field.
 //! - **`message`** content parts shed `annotations`/`logprobs` (probe-confirmed).
 //! - **`function_call`** items parse their `arguments` JSON *string* into a value
 //!   and drop `namespace`. The backend sends the model's raw argument string
@@ -41,10 +43,13 @@
 //!   normalization; shunt is the outlier because Anthropic's `tool_use.input` is a
 //!   parsed object. `namespace` appears only for namespaced/MCP tools and is not
 //!   reconstructed; `call_id` already identifies the call.
-//! - **`reasoning`** items round-trip `encrypted_content` and `id` verbatim (via
-//!   the thinking-block signature) and shed `status` and the plaintext `content`
-//!   array (`Optional[List[reasoning_text]]`, which shunt does not reconstruct);
-//!   their `summary` array is normalized part-by-part like `content`.
+//! - **`reasoning`** items round-trip `encrypted_content` verbatim (via the
+//!   thinking-block signature) and shed the plaintext `content` array
+//!   (`Optional[List[reasoning_text]]`, which shunt does not reconstruct) along
+//!   with `id`/`status` like every item; their `summary` array is normalized
+//!   part-by-part like `content`. The live probe found the backend actually omits
+//!   `status` entirely and sends an empty `content` array under `store:false`, so
+//!   the strip rules hold whether or not either field is present.
 //!
 //! [`translate_request`]: crate::model::responses::translate_request
 
@@ -246,8 +251,9 @@ mod tests {
         json!({"type": "message", "role": "user", "content": [{"type": "input_text", "text": text}]})
     }
 
-    /// The backend's assistant message item, as captured live from the ChatGPT
-    /// backend (extra id/phase/status + content annotations/logprobs).
+    /// The backend's assistant message item, as captured live over the Codex
+    /// WebSocket (issue #45, 2026-07-13): keys `content`/`id`/`phase`/`role`/
+    /// `status`/`type`, with each content part carrying `annotations`/`logprobs`.
     fn backend_assistant(text: &str) -> Value {
         json!({
             "type": "message",
@@ -279,8 +285,11 @@ mod tests {
         })
     }
 
-    /// The backend's `function_call` output item: extra `id`/`status`, and an
-    /// `arguments` string in the model's own formatting (spaces, source key order).
+    /// The backend's `function_call` output item, as captured live over the Codex
+    /// WebSocket (issue #45, 2026-07-13): keys `arguments`/`call_id`/`id`/`name`/
+    /// `status`/`type`, with `arguments` a JSON string in the model's own
+    /// formatting (here spaced/reordered to exercise the structural comparison).
+    /// A plain function tool carries no `namespace` (that appears only for MCP).
     fn backend_function_call() -> Value {
         json!({
             "type": "function_call",
@@ -304,16 +313,19 @@ mod tests {
         })
     }
 
-    /// The backend's `reasoning` output item: extra `id`/`status` and a plaintext
-    /// `content` array; `summary` and `encrypted_content` round-trip verbatim
-    /// through the thinking-block signature.
+    /// The backend's `reasoning` output item, as captured live over the Codex
+    /// WebSocket (issue #45, 2026-07-13): keys `content`/`encrypted_content`/`id`/
+    /// `summary`/`type`. Under `store:false` the backend omits `status` and sends
+    /// an empty `content` array (the plaintext chain of thought is not returned);
+    /// `summary` and `encrypted_content` round-trip through the thinking-block
+    /// signature. The `content`/`status` strip is exercised defensively in
+    /// [`normalize_reasoning_matches_reconstruction`].
     fn backend_reasoning() -> Value {
         json!({
             "type": "reasoning",
             "id": "rs_1",
-            "status": "completed",
             "summary": [{"type": "summary_text", "text": "think about it"}],
-            "content": [{"type": "reasoning_text", "text": "long private chain of thought"}],
+            "content": [],
             "encrypted_content": "ENC"
         })
     }
@@ -372,10 +384,21 @@ mod tests {
 
     #[test]
     fn normalize_reasoning_matches_reconstruction() {
-        // The backend item carries `status` and a plaintext `content` array the
-        // reconstruction never produces; both are shed for the comparison.
+        // The live-captured item (empty `content`, no `status`) matches the
+        // reconstruction once normalized.
         assert_eq!(
             normalize_item(&backend_reasoning()),
+            normalize_item(&reconstructed_reasoning())
+        );
+        // Defensive: even if the backend ever returns `status` and a populated
+        // plaintext `content` array (the API-returned shape), both are shed so the
+        // append-only match still holds.
+        let mut verbose = backend_reasoning();
+        verbose["status"] = json!("completed");
+        verbose["content"] =
+            json!([{"type": "reasoning_text", "text": "long private chain of thought"}]);
+        assert_eq!(
+            normalize_item(&verbose),
             normalize_item(&reconstructed_reasoning())
         );
     }

--- a/src/adapters/responses/mod.rs
+++ b/src/adapters/responses/mod.rs
@@ -283,6 +283,7 @@ async fn forward_websocket(
     let ctx = WsTurnContext {
         ws_url,
         pool_key,
+        provider: &route.provider,
         credential,
         auth,
         signature: codex_continuation::signature(&upstream_body),
@@ -328,6 +329,7 @@ async fn forward_websocket(
 struct WsTurnContext<'a> {
     ws_url: String,
     pool_key: Option<&'a str>,
+    provider: &'a str,
     credential: Credential,
     auth: AuthMode,
     signature: String,
@@ -379,32 +381,55 @@ async fn start_ws_turn(
     let mut frame_body = ctx.upstream_body.clone();
     let mut used_continuation = false;
     if allow_continuation {
+        // Only a reused connection carries stored continuation state; a fresh
+        // connection has no chance to continue and is not counted, so the hit/
+        // fallback series stay directly comparable (issue #45).
         if let Some(stored) = turn.stored_continuation() {
-            if let Some(decision) = codex_continuation::decide(&stored, &ctx.upstream_body) {
-                if let Some(object) = frame_body.as_object_mut() {
-                    object.insert("input".to_string(), json!(decision.input_delta));
-                    object.insert(
-                        "previous_response_id".to_string(),
-                        json!(decision.previous_response_id),
-                    );
-                    if let Some(turn_state) = stored
-                        .turn_state
-                        .clone()
-                        .or_else(|| turn.handshake_turn_state().map(str::to_string))
-                    {
-                        let metadata = object
-                            .entry("client_metadata".to_string())
-                            .or_insert_with(|| json!({}));
-                        if let Some(metadata) = metadata.as_object_mut() {
-                            metadata.insert("x-codex-turn-state".to_string(), json!(turn_state));
+            match codex_continuation::decide(&stored, &ctx.upstream_body) {
+                Some(decision) => {
+                    if let Some(object) = frame_body.as_object_mut() {
+                        object.insert("input".to_string(), json!(decision.input_delta));
+                        object.insert(
+                            "previous_response_id".to_string(),
+                            json!(decision.previous_response_id),
+                        );
+                        if let Some(turn_state) = stored
+                            .turn_state
+                            .clone()
+                            .or_else(|| turn.handshake_turn_state().map(str::to_string))
+                        {
+                            let metadata = object
+                                .entry("client_metadata".to_string())
+                                .or_insert_with(|| json!({}));
+                            if let Some(metadata) = metadata.as_object_mut() {
+                                metadata
+                                    .insert("x-codex-turn-state".to_string(), json!(turn_state));
+                            }
                         }
                     }
+                    used_continuation = true;
+                    tracing::debug!(
+                        delta_items = decision.input_delta.len(),
+                        "codex websocket continuing with previous_response_id"
+                    );
+                    crate::metrics::record_continuation_outcome(
+                        ctx.provider,
+                        crate::metrics::ContinuationOutcome::Hit,
+                    );
                 }
-                used_continuation = true;
-                tracing::debug!(
-                    delta_items = decision.input_delta.len(),
-                    "codex websocket continuing with previous_response_id"
-                );
+                None => {
+                    // The reused connection's stored transcript was not an
+                    // append-only prefix of this input (history rewrite, a changed
+                    // non-input field, or normalization drift), so re-send the full
+                    // input. Correct, but the payload-trim was missed.
+                    tracing::debug!(
+                        "codex websocket reused connection but input diverged; re-sending full input"
+                    );
+                    crate::metrics::record_continuation_outcome(
+                        ctx.provider,
+                        crate::metrics::ContinuationOutcome::Fallback,
+                    );
+                }
             }
         }
     }

--- a/src/adapters/responses/mod.rs
+++ b/src/adapters/responses/mod.rs
@@ -364,6 +364,34 @@ async fn open_ws_turn(
     }
 }
 
+/// Rewrite `frame_body` in place for a continuation turn: replace `input` with the
+/// decision's delta, set `previous_response_id`, and — when a turn-state token is
+/// present — echo it into `client_metadata` as `x-codex-turn-state`. Returns the
+/// delta item count (for logging). Pure and unit-tested; the async turn setup that
+/// produces the inputs stays in [`start_ws_turn`].
+fn apply_continuation(
+    frame_body: &mut Value,
+    decision: &codex_continuation::Decision,
+    turn_state: Option<&str>,
+) -> usize {
+    if let Some(object) = frame_body.as_object_mut() {
+        object.insert("input".to_string(), json!(decision.input_delta));
+        object.insert(
+            "previous_response_id".to_string(),
+            json!(decision.previous_response_id),
+        );
+        if let Some(turn_state) = turn_state {
+            let metadata = object
+                .entry("client_metadata".to_string())
+                .or_insert_with(|| json!({}));
+            if let Some(metadata) = metadata.as_object_mut() {
+                metadata.insert("x-codex-turn-state".to_string(), json!(turn_state));
+            }
+        }
+    }
+    decision.input_delta.len()
+}
+
 /// Begin a turn on the session's connection and send its frame. When
 /// `allow_continuation` and the reused connection's stored state make the input an
 /// append-only extension, send only the delta with `previous_response_id`;
@@ -387,29 +415,14 @@ async fn start_ws_turn(
         if let Some(stored) = turn.stored_continuation() {
             match codex_continuation::decide(&stored, &ctx.upstream_body) {
                 Some(decision) => {
-                    if let Some(object) = frame_body.as_object_mut() {
-                        object.insert("input".to_string(), json!(decision.input_delta));
-                        object.insert(
-                            "previous_response_id".to_string(),
-                            json!(decision.previous_response_id),
-                        );
-                        if let Some(turn_state) = stored
-                            .turn_state
-                            .clone()
-                            .or_else(|| turn.handshake_turn_state().map(str::to_string))
-                        {
-                            let metadata = object
-                                .entry("client_metadata".to_string())
-                                .or_insert_with(|| json!({}));
-                            if let Some(metadata) = metadata.as_object_mut() {
-                                metadata
-                                    .insert("x-codex-turn-state".to_string(), json!(turn_state));
-                            }
-                        }
-                    }
+                    let turn_state = stored
+                        .turn_state
+                        .as_deref()
+                        .or_else(|| turn.handshake_turn_state());
+                    let delta_items = apply_continuation(&mut frame_body, &decision, turn_state);
                     used_continuation = true;
                     tracing::debug!(
-                        delta_items = decision.input_delta.len(),
+                        delta_items,
                         "codex websocket continuing with previous_response_id"
                     );
                     crate::metrics::record_continuation_outcome(
@@ -843,7 +856,7 @@ impl SseParser {
 mod tests {
     use axum::body::to_bytes;
     use axum::http::StatusCode;
-    use serde_json::Value;
+    use serde_json::{json, Value};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -854,7 +867,8 @@ mod tests {
         server::AppState,
     };
 
-    use super::{build_test_request, mapped_upstream_error, responses_url};
+    use super::codex_continuation::Decision;
+    use super::{apply_continuation, build_test_request, mapped_upstream_error, responses_url};
 
     /// Serves `body` at `status` from a mock server and returns the resulting
     /// `reqwest::Response`, mirroring the shape `mapped_upstream_error` sees in
@@ -896,6 +910,54 @@ mod tests {
             upstream_model: "gpt-5.2-codex".to_string(),
             effort: None,
         }
+    }
+
+    #[test]
+    fn apply_continuation_sets_delta_previous_id_and_turn_state() {
+        // A continuation turn replaces `input` with the delta, sets
+        // `previous_response_id`, and echoes the turn-state token.
+        let mut frame = json!({"model": "m", "input": ["FULL_INPUT"]});
+        let decision = Decision {
+            previous_response_id: "resp_1".to_string(),
+            input_delta: vec![json!({"type": "message", "role": "user"})],
+        };
+        let delta_items = apply_continuation(&mut frame, &decision, Some("ts_1"));
+        assert_eq!(delta_items, 1);
+        assert_eq!(frame["input"], json!([{"type": "message", "role": "user"}]));
+        assert_eq!(frame["previous_response_id"], json!("resp_1"));
+        assert_eq!(
+            frame["client_metadata"]["x-codex-turn-state"],
+            json!("ts_1")
+        );
+    }
+
+    #[test]
+    fn apply_continuation_without_turn_state_omits_metadata() {
+        // No turn-state token ⇒ no `client_metadata` is synthesized.
+        let mut frame = json!({"input": ["FULL_INPUT"]});
+        let decision = Decision {
+            previous_response_id: "r".to_string(),
+            input_delta: vec![json!("a"), json!("b")],
+        };
+        let delta_items = apply_continuation(&mut frame, &decision, None);
+        assert_eq!(delta_items, 2);
+        assert_eq!(frame["input"], json!(["a", "b"]));
+        assert_eq!(frame["previous_response_id"], json!("r"));
+        assert!(frame.get("client_metadata").is_none());
+    }
+
+    #[test]
+    fn apply_continuation_merges_into_existing_client_metadata() {
+        // The turn-state token is inserted alongside pre-existing metadata keys,
+        // not clobbering them (the `or_insert_with` existing-object path).
+        let mut frame = json!({"input": [], "client_metadata": {"existing": "keep"}});
+        let decision = Decision {
+            previous_response_id: "r".to_string(),
+            input_delta: vec![json!("x")],
+        };
+        apply_continuation(&mut frame, &decision, Some("ts"));
+        assert_eq!(frame["client_metadata"]["existing"], json!("keep"));
+        assert_eq!(frame["client_metadata"]["x-codex-turn-state"], json!("ts"));
     }
 
     #[test]

--- a/src/adapters/responses/mod.rs
+++ b/src/adapters/responses/mod.rs
@@ -384,6 +384,12 @@ fn apply_continuation(
             let metadata = object
                 .entry("client_metadata".to_string())
                 .or_insert_with(|| json!({}));
+            // Defensive: a pre-existing non-object `client_metadata` would make
+            // `as_object_mut()` return None and silently drop the turn-state token;
+            // reset it to an object so the token is always recorded.
+            if !metadata.is_object() {
+                *metadata = json!({});
+            }
             if let Some(metadata) = metadata.as_object_mut() {
                 metadata.insert("x-codex-turn-state".to_string(), json!(turn_state));
             }
@@ -944,6 +950,19 @@ mod tests {
         assert_eq!(frame["input"], json!(["a", "b"]));
         assert_eq!(frame["previous_response_id"], json!("r"));
         assert!(frame.get("client_metadata").is_none());
+    }
+
+    #[test]
+    fn apply_continuation_overwrites_non_object_client_metadata() {
+        // A pre-existing non-object `client_metadata` is reset to an object so the
+        // turn-state token is recorded rather than silently dropped.
+        let mut frame = json!({"input": [], "client_metadata": "not-an-object"});
+        let decision = Decision {
+            previous_response_id: "r".to_string(),
+            input_delta: vec![json!("x")],
+        };
+        apply_continuation(&mut frame, &decision, Some("ts"));
+        assert_eq!(frame["client_metadata"]["x-codex-turn-state"], json!("ts"));
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,6 +27,7 @@ use sentry::protocol::Unit;
 struct OtelInstruments {
     requests: Counter<u64>,
     latency: Histogram<f64>,
+    continuation: Counter<u64>,
 }
 
 fn otel_instruments() -> &'static OtelInstruments {
@@ -43,8 +44,35 @@ fn otel_instruments() -> &'static OtelInstruments {
                 .with_unit("ms")
                 .with_description("Proxied inference request latency")
                 .build(),
+            continuation: meter
+                .u64_counter("shunt.codex_continuation")
+                .with_description(
+                    "Codex WebSocket continuation decisions (hit vs full-input fallback)",
+                )
+                .build(),
         }
     })
+}
+
+/// The outcome of a Codex WebSocket continuation decision on a *reused*
+/// connection (one that carried stored `previous_response_id` state).
+#[derive(Clone, Copy, Debug)]
+pub enum ContinuationOutcome {
+    /// The input was an append-only extension, so only the delta was sent with
+    /// `previous_response_id` — the payload-trimming win.
+    Hit,
+    /// The input was not an append-only extension of the stored transcript, so
+    /// the full input was re-sent. Correctness-safe, but a missed optimization.
+    Fallback,
+}
+
+impl ContinuationOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Fallback => "fallback",
+        }
+    }
 }
 
 /// Record one proxied inference request: a `shunt.requests` count and a
@@ -74,9 +102,32 @@ pub fn record_proxied_request(provider: &str, model: &str, status: u16, latency_
     instruments.latency.record(latency_ms, &attributes);
 }
 
+/// Record a Codex WebSocket continuation decision on a reused connection: a
+/// `hit` (continued from `previous_response_id`, delta only) or a `fallback`
+/// (input was not an append-only extension, full input re-sent). Emitted only
+/// when the pooled connection actually held continuation state, so the two
+/// series are directly comparable — a fresh connection (no stored state) is not
+/// counted. A rising `fallback` share on a warm pool is the signal that the
+/// append-only normalization has drifted from the backend's item shapes (issue
+/// #45): correctness-safe, but a latent lost optimization. Emitted to Sentry and
+/// OpenTelemetry; each sink is inert unless configured.
+pub fn record_continuation_outcome(provider: &str, outcome: ContinuationOutcome) {
+    let outcome = outcome.as_str();
+    sentry::metrics::counter("shunt.codex_continuation", 1)
+        .attribute("provider", provider.to_owned())
+        .attribute("outcome", outcome.to_owned())
+        .capture();
+
+    let attributes = [
+        KeyValue::new("provider", provider.to_owned()),
+        KeyValue::new("outcome", outcome),
+    ];
+    otel_instruments().continuation.add(1, &attributes);
+}
+
 #[cfg(test)]
 mod tests {
-    use super::record_proxied_request;
+    use super::{record_continuation_outcome, record_proxied_request, ContinuationOutcome};
 
     /// The core opt-in contract: recording a proxied request must never panic,
     /// whatever the sink state — the default (no Sentry client, no OTel meter
@@ -87,5 +138,12 @@ mod tests {
     fn record_is_noop_without_sinks() {
         record_proxied_request("openai", "gpt-5.2", 200, 123.4);
         record_proxied_request("anthropic", "claude-opus-4-8", 502, 0.0);
+    }
+
+    /// The continuation counter honors the same opt-in no-op contract.
+    #[test]
+    fn record_continuation_is_noop_without_sinks() {
+        record_continuation_outcome("codex", ContinuationOutcome::Hit);
+        record_continuation_outcome("codex", ContinuationOutcome::Fallback);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -112,14 +112,15 @@ pub fn record_proxied_request(provider: &str, model: &str, status: u16, latency_
 /// #45): correctness-safe, but a latent lost optimization. Emitted to Sentry and
 /// OpenTelemetry; each sink is inert unless configured.
 pub fn record_continuation_outcome(provider: &str, outcome: ContinuationOutcome) {
+    let provider = provider.to_owned();
     let outcome = outcome.as_str();
     sentry::metrics::counter("shunt.codex_continuation", 1)
-        .attribute("provider", provider.to_owned())
+        .attribute("provider", provider.clone())
         .attribute("outcome", outcome.to_owned())
         .capture();
 
     let attributes = [
-        KeyValue::new("provider", provider.to_owned()),
+        KeyValue::new("provider", provider),
         KeyValue::new("outcome", outcome),
     ];
     otel_instruments().continuation.add(1, &attributes);


### PR DESCRIPTION
## Summary

Live-probed the real ChatGPT/Codex backend over the WebSocket transport to validate the continuation-normalization logic for issue #45, and added observability for future normalization drift.

## Milestone / spec

M7 — `docs/m7-codex-websocket.md` normalization table and open questions

## Changes

- Captured real `message`/`reasoning`/`function_call` `output_item` shapes over the live WebSocket transport and diffed them against `normalize_item` — no unaccounted field.
- Corrected two assumptions: the backend omits reasoning `status`, and returns empty plaintext `content` under `store:false` (both were already stripped correctly).
- Verified all three item kinds continue from `previous_response_id` end-to-end on a warm pool (delta-only turns, zero `previous_response_not_found` rejects).
- Updated the reasoning test fixture to the real captured shape, with module/doc provenance.
- Added a `shunt.codex_continuation` hit-vs-fallback observability counter (Sentry + OTel, per provider) in `src/metrics.rs`, emitted at the `decide()` call site.
- Updated `docs/comparison.md` §6.B and `docs/m7-codex-websocket.md` to reflect the completed live-probe.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

Live-probe verification against the real Codex backend; no protocol surprises found beyond the two corrected assumptions noted above (both harmless, already stripped fields). `cargo test --all-features --workspace`: 63 passed, 0 failed.

## Related Issues

Closes #45

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Live-probed the Codex WebSocket backend to confirm continuation normalization for `message`, `reasoning`, and `function_call` (no unaccounted fields), and added a `shunt.codex_continuation` metric for hit vs fallback on reused connections. Extracted and hardened `apply_continuation` (resets non-object `client_metadata` so turn-state is preserved) with tests. Completes #45.

- **New Features**
  - Added `shunt.codex_continuation` (Sentry + OTel, per provider). Emits only on reused WS connections at the continuation decision; counts "hit" (delta + `previous_response_id`) vs "fallback" (full input).

- **Refactors**
  - Extracted pure `apply_continuation` with unit tests; also resets non-object `client_metadata` to ensure `x-codex-turn-state` is recorded.

<sup>Written for commit 3e3b1e416a1be1ea4df0d67a1978a92fe3f2ee86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

