### PR TITLE
fix(auth): cancellation-safe Claude OAuth refresh + off-thread store I/O (#73, #101)

### DIFF
--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -71,36 +71,10 @@ async fn forward(
             "upstream returned 429"
         );
     }
-    let response_headers = headers::filtered(upstream.headers());
-    let is_sse = upstream
-        .headers()
-        .get("content-type")
-        .and_then(|value| value.to_str().ok())
-        .map(|value| value.starts_with("text/event-stream"))
-        .unwrap_or(false);
-    let stream = upstream.bytes_stream();
-
-    let mut builder = Response::builder().status(status);
-    for (name, value) in response_headers {
-        if let Some(name) = name {
-            builder = builder.header(name, value);
-        }
-    }
-
-    // Keepalive pings apply only to SSE relays; JSON bodies pass untouched.
-    let body = if is_sse {
-        Body::from_stream(keepalive::with_pings(
-            stream,
-            Duration::from_secs(state.config.server.sse_keepalive_seconds),
-        ))
-    } else {
-        Body::from_stream(stream)
-    };
-    let response = builder
-        .body(body)
-        .expect("response builder uses valid upstream status and headers")
-        .into_response();
-    Ok((status, response))
+    // The non-pooled path builds its response exactly like the pooled path's
+    // relay_response (header filtering, SSE keepalive, status passthrough), so
+    // reuse it with no account attribution instead of duplicating that logic.
+    relay_response(&state, upstream, None)
 }
 
 async fn forward_claude_oauth(
@@ -246,30 +220,20 @@ async fn forward_claude_oauth(
                     .unwrap_or(Duration::from_secs(1))
                     .min(Duration::from_secs(300));
                 tokio::time::sleep(delay).await;
-                let retry =
-                    match post_upstream(&state.http_client, &url, request_headers, request_body)
-                        .await
-                    {
-                        Ok(response) => response,
-                        Err(error) => {
-                            state.accounts.cooldown(
-                                &route.provider,
-                                &account.name,
-                                Duration::from_secs(30),
-                            );
-                            tracing::warn!(
-                                provider = %route.provider,
-                                account = %account.name,
-                                error = %error,
-                                "Claude OAuth throttle retry failed"
-                            );
-                            last_response = Some(upstream);
-                            continue;
-                        }
-                    };
-                state
-                    .accounts
-                    .note_quota(&route.provider, &account.name, retry.headers());
+                let Some(retry) = retry_upstream(
+                    &state,
+                    &route,
+                    account,
+                    &url,
+                    request_headers,
+                    request_body,
+                    "Claude OAuth throttle retry failed",
+                )
+                .await
+                else {
+                    last_response = Some(upstream);
+                    continue;
+                };
                 let retry_status = retry.status();
                 if retry_status.is_success() {
                     state.accounts.mark_healthy(&route.provider, &account.name);
@@ -373,34 +337,20 @@ async fn forward_claude_oauth(
                     account_uuid: account.uuid.clone(),
                 };
                 let retry_headers = outbound_headers(headers, &refreshed);
-                let retry = match post_upstream(
-                    &state.http_client,
+                let Some(retry) = retry_upstream(
+                    &state,
+                    &route,
+                    account,
                     &url,
                     retry_headers,
                     request_body,
+                    "Claude OAuth refresh retry failed",
                 )
                 .await
-                {
-                    Ok(response) => response,
-                    Err(error) => {
-                        state.accounts.cooldown(
-                            &route.provider,
-                            &account.name,
-                            Duration::from_secs(30),
-                        );
-                        tracing::warn!(
-                            provider = %route.provider,
-                            account = %account.name,
-                            error = %error,
-                            "Claude OAuth refresh retry failed"
-                        );
-                        last_response = Some(upstream);
-                        continue;
-                    }
+                else {
+                    last_response = Some(upstream);
+                    continue;
                 };
-                state
-                    .accounts
-                    .note_quota(&route.provider, &account.name, retry.headers());
                 let retry_status = retry.status();
                 if retry_status == StatusCode::UNAUTHORIZED {
                     // Refresh succeeded but the credential is still rejected — the
@@ -498,6 +448,43 @@ async fn post_upstream(
     body: Vec<u8>,
 ) -> Result<reqwest::Response, reqwest::Error> {
     client.post(url).headers(headers).body(body).send().await
+}
+
+/// Send a per-account retry POST, noting quota headers on success. On a
+/// transport error it cools the account down for 30s, logs `fail_msg`, and
+/// returns `None` so the caller fails over to the next account. Shared by the
+/// throttle-retry and refresh-retry arms, whose transport-error handling is
+/// otherwise identical.
+async fn retry_upstream(
+    state: &AppState,
+    route: &Route,
+    account: &crate::config::AccountConfig,
+    url: &str,
+    headers: HeaderMap,
+    body: Vec<u8>,
+    fail_msg: &str,
+) -> Option<reqwest::Response> {
+    match post_upstream(&state.http_client, url, headers, body).await {
+        Ok(response) => {
+            state
+                .accounts
+                .note_quota(&route.provider, &account.name, response.headers());
+            Some(response)
+        }
+        Err(error) => {
+            state
+                .accounts
+                .cooldown(&route.provider, &account.name, Duration::from_secs(30));
+            tracing::warn!(
+                provider = %route.provider,
+                account = %account.name,
+                error = %error,
+                "{}",
+                fail_msg
+            );
+            None
+        }
+    }
 }
 
 fn relay_response(

--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -320,7 +320,20 @@ async fn forward_claude_oauth(
 
                 let failed_access_token = match &credential {
                     Credential::ClaudeOauth { access_token, .. } => access_token.as_str(),
-                    _ => unreachable!("claude_oauth account resolved a non-OAuth credential"),
+                    // resolve_claude_account only ever yields ClaudeOauth, so this
+                    // is unreachable today — but this is a request-handling path in
+                    // a failover proxy, so degrade gracefully (log loudly + fail
+                    // over to the next account) instead of panicking if a future
+                    // refactor ever breaks that invariant.
+                    _ => {
+                        tracing::error!(
+                            provider = %route.provider,
+                            account = %account.name,
+                            "claude_oauth account resolved a non-OAuth credential"
+                        );
+                        last_response = Some(upstream);
+                        continue;
+                    }
                 };
                 let credentials = account
                     .credentials

--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -758,6 +758,76 @@ mod tests {
         format!("{scheme} {token}")
     }
 
+    fn claude_route() -> super::Route {
+        super::Route {
+            provider: "claude".to_string(),
+            adapter: crate::routing::AdapterKind::Anthropic,
+            model: "claude-test".to_string(),
+            upstream_model: "claude-test".to_string(),
+            effort: None,
+        }
+    }
+
+    fn claude_account() -> crate::config::AccountConfig {
+        crate::config::AccountConfig {
+            name: "acct".to_string(),
+            credentials: None,
+            token_env: None,
+            uuid: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_upstream_returns_response_on_success() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let state =
+            super::AppState::new(crate::config::Config::default(), reqwest::Client::new()).unwrap();
+
+        let response = super::retry_upstream(
+            &state,
+            &claude_route(),
+            &claude_account(),
+            &server.uri(),
+            HeaderMap::new(),
+            Vec::new(),
+            "retry failed",
+        )
+        .await
+        .expect("a 200 upstream should be handed back to the caller");
+        assert!(response.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn retry_upstream_signals_failover_on_transport_error() {
+        let state =
+            super::AppState::new(crate::config::Config::default(), reqwest::Client::new()).unwrap();
+
+        // Port 1 refuses immediately, so post_upstream returns a transport error
+        // and the helper must cool the account down and return None (fail over).
+        let outcome = super::retry_upstream(
+            &state,
+            &claude_route(),
+            &claude_account(),
+            "http://127.0.0.1:1/v1/messages",
+            HeaderMap::new(),
+            Vec::new(),
+            "retry failed",
+        )
+        .await;
+        assert!(
+            outcome.is_none(),
+            "a transport error should signal fail-over"
+        );
+    }
+
     #[test]
     fn passthrough_forwards_client_credential_unchanged() {
         let out = outbound_headers(&client_headers(), &Credential::Passthrough);

--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -318,6 +318,10 @@ async fn forward_claude_oauth(
                     continue;
                 }
 
+                let failed_access_token = match &credential {
+                    Credential::ClaudeOauth { access_token, .. } => access_token.as_str(),
+                    _ => unreachable!("claude_oauth account resolved a non-OAuth credential"),
+                };
                 let credentials = account
                     .credentials
                     .as_deref()
@@ -329,7 +333,10 @@ async fn forward_claude_oauth(
                 // lock again before the retry POST below.
                 let access_token = {
                     let _guard = refresh_lock.lock().await;
-                    match store.force_refresh().await {
+                    match store
+                        .force_refresh_if_access_token(failed_access_token)
+                        .await
+                    {
                         Ok(token) => token,
                         Err(error) => {
                             state.accounts.cooldown(

--- a/src/auth/claude/auth.rs
+++ b/src/auth/claude/auth.rs
@@ -66,11 +66,18 @@ pub fn default_credentials_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".claude/.credentials.json"))
 }
 
+#[derive(Clone)]
 pub struct ClaudeAuthStore {
     path: PathBuf,
     client: reqwest::Client,
     token_url: String,
 }
+
+/// In-process single-flight for Claude OAuth refreshes. Stores are constructed
+/// per request, so the lock must be shared across independent instances. The
+/// refresh task owns the guard through atomic writeback, preventing a cancelled
+/// caller from exposing an already-consumed refresh token to another request.
+static REFRESH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 impl ClaudeAuthStore {
     pub fn new(path: PathBuf, client: reqwest::Client) -> Self {
@@ -98,36 +105,83 @@ impl ClaudeAuthStore {
     }
 
     pub async fn get_valid_access_token(&self) -> anyhow::Result<String> {
-        let tokens = self.read_tokens()?;
+        let tokens = self.read_tokens_off_thread().await?;
         if tokens.is_valid_at(SystemTime::now()) {
             return Ok(tokens.access_token);
         }
 
-        // Re-read: a concurrent Claude Code / helper run may have just refreshed.
-        let tokens = self.read_tokens()?;
+        // Single-flight the refresh. A waiter re-reads after acquiring the lock,
+        // so it uses the token persisted by the caller that refreshed first.
+        let refreshing = REFRESH_LOCK.lock().await;
+        let tokens = self.read_tokens_off_thread().await?;
         if tokens.is_valid_at(SystemTime::now()) {
             return Ok(tokens.access_token);
         }
 
-        self.refresh_and_write_back(tokens).await
+        self.refresh_and_write_back(tokens, refreshing).await
     }
 
     /// Refresh and persist the stored OAuth token regardless of its expiry.
     pub async fn force_refresh(&self) -> anyhow::Result<String> {
-        let tokens = self.read_tokens()?;
-        self.refresh_and_write_back(tokens).await
+        let refreshing = REFRESH_LOCK.lock().await;
+        let tokens = self.read_tokens_off_thread().await?;
+        self.refresh_and_write_back(tokens, refreshing).await
     }
 
-    async fn refresh_and_write_back(&self, tokens: Tokens) -> anyhow::Result<String> {
+    /// Refresh and persist the stored OAuth token if the file still contains the
+    /// access token rejected by the upstream. If another request has already
+    /// refreshed it, return that newer token without rotating again.
+    pub async fn force_refresh_if_access_token(
+        &self,
+        rejected_access_token: &str,
+    ) -> anyhow::Result<String> {
+        let refreshing = REFRESH_LOCK.lock().await;
+        let tokens = self.read_tokens_off_thread().await?;
+        if tokens.access_token != rejected_access_token {
+            return Ok(tokens.access_token);
+        }
+        self.refresh_and_write_back(tokens, refreshing).await
+    }
+
+    async fn refresh_and_write_back(
+        &self,
+        tokens: Tokens,
+        refreshing: tokio::sync::MutexGuard<'static, ()>,
+    ) -> anyhow::Result<String> {
         let refresh_token = tokens.refresh_token.ok_or_else(|| {
             anyhow::anyhow!(
                 "no refresh token in {}; run `claude` then /login",
                 self.path.display()
             )
         })?;
-        let refreshed = refresh(&self.client, &self.token_url, &refresh_token).await?;
-        write_back(&self.path, &refreshed)?;
-        Ok(refreshed.access_token)
+
+        // The detached task owns both the single-flight guard and the critical
+        // refresh + writeback sequence. Dropping the caller's future therefore
+        // cannot strand a rotated refresh token in memory after the provider has
+        // consumed the old one.
+        let client = self.client.clone();
+        let token_url = self.token_url.clone();
+        let path = self.path.clone();
+        tokio::spawn(async move {
+            let _refreshing = refreshing;
+            let refreshed = refresh(&client, &token_url, &refresh_token).await?;
+            let access_token = refreshed.access_token.clone();
+            write_back_off_thread(path, refreshed)
+                .await
+                .map_err(|error| anyhow::anyhow!("failed to update Claude auth file: {error}"))?;
+            Ok::<String, anyhow::Error>(access_token)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("Claude refresh task failed: {error}"))?
+    }
+
+    /// Read the credential file on Tokio's blocking pool so synchronous file I/O
+    /// never stalls an async runtime worker.
+    async fn read_tokens_off_thread(&self) -> anyhow::Result<Tokens> {
+        let this = self.clone();
+        tokio::task::spawn_blocking(move || this.read_tokens())
+            .await
+            .map_err(|error| anyhow::anyhow!("Claude auth read task failed: {error}"))?
     }
 
     fn read_tokens(&self) -> anyhow::Result<Tokens> {
@@ -247,142 +301,13 @@ fn write_back(path: &Path, refreshed: &Refreshed) -> io::Result<()> {
     write_auth_file_atomic(path, &value)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn force_refresh_refreshes_a_still_valid_token() {
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
-
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "new-access",
-                "refresh_token": "new-refresh",
-                "expires_in": 3600
-            })))
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let dir = std::env::temp_dir().join(format!(
-            "shunt-claude-force-refresh-{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(".credentials.json");
-        std::fs::write(
-            &path,
-            r#"{"claudeAiOauth":{"accessToken":"still-valid","refreshToken":"old-refresh","expiresAt":4000000000000}}"#,
-        )
-        .unwrap();
-        let store = ClaudeAuthStore::with_token_url(
-            path.clone(),
-            reqwest::Client::new(),
-            format!("{}/token", server.uri()),
-        );
-
-        let token = store.force_refresh().await.unwrap();
-
-        assert_eq!(token, "new-access");
-        let stored = read_file(&path).unwrap();
-        assert_eq!(stored["claudeAiOauth"]["accessToken"], "new-access");
-        assert_eq!(stored["claudeAiOauth"]["refreshToken"], "new-refresh");
-        server.verify().await;
-        let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn valid_when_beyond_expiry_buffer() {
-        let now = UNIX_EPOCH + Duration::from_secs(1_000);
-        let inside = Tokens {
-            access_token: "a".into(),
-            refresh_token: None,
-            expires_at_ms: (1_000 + 5 * 60 - 1) * 1000, // just inside the 5-min buffer
-        };
-        let outside = Tokens {
-            access_token: "a".into(),
-            refresh_token: None,
-            expires_at_ms: (1_000 + 5 * 60 + 1) * 1000, // just outside
-        };
-        assert!(!inside.is_valid_at(now));
-        assert!(outside.is_valid_at(now));
-    }
-
-    #[test]
-    fn parses_credentials_tokens() {
-        let value = json!({
-            "claudeAiOauth": {
-                "accessToken": "sk-ant-oat-access",
-                "refreshToken": "sk-ant-ort-refresh",
-                "expiresAt": 2_000_000_000_000i64,
-                "subscriptionType": "max"
-            }
-        });
-        let tokens = Tokens::from_value(&value).unwrap();
-        assert_eq!(tokens.access_token, "sk-ant-oat-access");
-        assert_eq!(tokens.refresh_token.as_deref(), Some("sk-ant-ort-refresh"));
-        assert_eq!(tokens.expires_at_ms, 2_000_000_000_000);
-    }
-
-    #[test]
-    fn refresh_reuses_prior_refresh_token_when_omitted() {
-        let now = UNIX_EPOCH + Duration::from_secs(1_000);
-        let value = json!({"access_token": "new-access", "expires_in": 3600});
-        let refreshed = parse_refresh(&value, "old-refresh", now).unwrap();
-        assert_eq!(refreshed.access_token, "new-access");
-        assert_eq!(refreshed.refresh_token, "old-refresh");
-        assert_eq!(refreshed.expires_at_ms, 1_000 * 1000 + 3600 * 1000);
-    }
-
-    #[test]
-    fn refresh_rejects_response_without_access_token() {
-        // A malformed refresh response (no access_token) yields None, which the
-        // caller surfaces as an "invalid refresh response" error rather than
-        // persisting a broken token.
-        let now = UNIX_EPOCH + Duration::from_secs(1_000);
-        assert!(parse_refresh(&json!({"expires_in": 3600}), "old-refresh", now).is_none());
-    }
-
-    #[test]
-    fn write_back_updates_tokens_and_preserves_other_fields() {
-        let dir = std::env::temp_dir().join(format!(
-            "shunt-claude-auth-{}",
-            std::time::SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(".credentials.json");
-        std::fs::write(
-            &path,
-            r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"old-r","expiresAt":1,"subscriptionType":"max"},"mcpOAuth":{"keep":true}}"#,
-        )
-        .unwrap();
-
-        write_back(
-            &path,
-            &Refreshed {
-                access_token: "new".into(),
-                refresh_token: "new-r".into(),
-                expires_at_ms: 999,
-            },
-        )
-        .unwrap();
-
-        let value: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(value["claudeAiOauth"]["accessToken"], "new");
-        assert_eq!(value["claudeAiOauth"]["refreshToken"], "new-r");
-        assert_eq!(value["claudeAiOauth"]["expiresAt"], 999);
-        assert_eq!(value["claudeAiOauth"]["subscriptionType"], "max"); // preserved
-        assert_eq!(value["mcpOAuth"]["keep"], true); // preserved
-        let _ = std::fs::remove_dir_all(dir);
-    }
+/// Persist the refreshed credential on Tokio's blocking pool. The on-disk
+/// content and atomic write semantics remain those of [`write_back`].
+async fn write_back_off_thread(path: PathBuf, refreshed: Refreshed) -> io::Result<()> {
+    tokio::task::spawn_blocking(move || write_back(&path, &refreshed))
+        .await
+        .map_err(|error| io::Error::other(format!("Claude auth write task failed: {error}")))?
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/auth/claude/auth.rs
+++ b/src/auth/claude/auth.rs
@@ -166,9 +166,18 @@ impl ClaudeAuthStore {
             let _refreshing = refreshing;
             let refreshed = refresh(&client, &token_url, &refresh_token).await?;
             let access_token = refreshed.access_token.clone();
-            write_back_off_thread(path, refreshed)
-                .await
-                .map_err(|error| anyhow::anyhow!("failed to update Claude auth file: {error}"))?;
+            if let Err(error) = write_back_off_thread(path, refreshed).await {
+                // The upstream refresh already consumed the old refresh token, so a
+                // failed writeback leaves the file holding a now-invalid token. Log
+                // here (not only via the returned Err) so the failure stays visible
+                // even when the caller's future was dropped and the JoinHandle —
+                // carrying this Err — is discarded with it.
+                tracing::warn!(
+                    %error,
+                    "Claude OAuth token refreshed upstream but writeback failed; stored refresh token is now stale until re-login"
+                );
+                return Err(anyhow::anyhow!("failed to update Claude auth file: {error}"));
+            }
             Ok::<String, anyhow::Error>(access_token)
         })
         .await

--- a/src/auth/claude/auth/tests.rs
+++ b/src/auth/claude/auth/tests.rs
@@ -1,0 +1,276 @@
+use super::*;
+
+fn temp_credentials_path(tag: &str) -> PathBuf {
+    std::env::temp_dir()
+        .join(format!(
+            "shunt-claude-{tag}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .join(".credentials.json")
+}
+
+fn write_credentials(path: &Path, access_token: &str, refresh_token: &str, expires_at: i64) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        path,
+        json!({
+            "claudeAiOauth": {
+                "accessToken": access_token,
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn cancelled_refresh_still_persists_rotated_token() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(200))
+                .set_body_json(json!({
+                    "access_token": "new-access",
+                    "refresh_token": "rotated-refresh",
+                    "expires_in": 3600
+                })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = temp_credentials_path("cancelled-refresh");
+    write_credentials(&path, "expired-access", "old-refresh", 0);
+    let store = ClaudeAuthStore::with_token_url(
+        path.clone(),
+        reqwest::Client::new(),
+        format!("{}/token", server.uri()),
+    );
+
+    let caller = tokio::spawn(async move { store.get_valid_access_token().await });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let requests = server
+                .received_requests()
+                .await
+                .expect("mock records requests");
+            if requests
+                .iter()
+                .any(|request| request.method.as_str() == "POST" && request.url.path() == "/token")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("refresh request did not reach the OAuth provider");
+    caller.abort();
+    let error = caller.await.unwrap_err();
+    assert!(error.is_cancelled());
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let stored = read_file(&path).unwrap();
+            if stored["claudeAiOauth"]["refreshToken"] == "rotated-refresh" {
+                assert_eq!(stored["claudeAiOauth"]["accessToken"], "new-access");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("detached refresh did not persist the rotated token");
+
+    server.verify().await;
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn concurrent_get_valid_single_flights_refresh() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access",
+            "refresh_token": "rotated-refresh",
+            "expires_in": 3600
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = temp_credentials_path("single-flight");
+    write_credentials(&path, "expired-access", "old-refresh", 0);
+    let first_store = ClaudeAuthStore::with_token_url(
+        path.clone(),
+        reqwest::Client::new(),
+        format!("{}/token", server.uri()),
+    );
+    let second_store = ClaudeAuthStore::with_token_url(
+        path.clone(),
+        reqwest::Client::new(),
+        format!("{}/token", server.uri()),
+    );
+
+    let (first, second) = tokio::join!(
+        first_store.get_valid_access_token(),
+        second_store.get_valid_access_token()
+    );
+    assert_eq!(first.unwrap(), "new-access");
+    assert_eq!(second.unwrap(), "new-access");
+    assert_eq!(
+        read_file(&path).unwrap()["claudeAiOauth"]["refreshToken"],
+        "rotated-refresh"
+    );
+
+    server.verify().await;
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn force_refresh_skips_when_rejected_token_was_already_replaced() {
+    let path = temp_credentials_path("force-refresh-already-replaced");
+    write_credentials(&path, "new-access", "rotated-refresh", 4_000_000_000_000);
+    let store = ClaudeAuthStore::with_token_url(
+        path.clone(),
+        reqwest::Client::new(),
+        "http://127.0.0.1:9/token".to_string(),
+    );
+
+    let token = store
+        .force_refresh_if_access_token("rejected-access")
+        .await
+        .unwrap();
+
+    assert_eq!(token, "new-access");
+    let stored = read_file(&path).unwrap();
+    assert_eq!(stored["claudeAiOauth"]["refreshToken"], "rotated-refresh");
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn force_refresh_refreshes_a_still_valid_token() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = temp_credentials_path("force-refresh");
+    write_credentials(&path, "still-valid", "old-refresh", 4_000_000_000_000);
+    let store = ClaudeAuthStore::with_token_url(
+        path.clone(),
+        reqwest::Client::new(),
+        format!("{}/token", server.uri()),
+    );
+
+    let token = store.force_refresh().await.unwrap();
+
+    assert_eq!(token, "new-access");
+    let stored = read_file(&path).unwrap();
+    assert_eq!(stored["claudeAiOauth"]["accessToken"], "new-access");
+    assert_eq!(stored["claudeAiOauth"]["refreshToken"], "new-refresh");
+    server.verify().await;
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
+fn valid_when_beyond_expiry_buffer() {
+    let now = UNIX_EPOCH + Duration::from_secs(1_000);
+    let inside = Tokens {
+        access_token: "a".into(),
+        refresh_token: None,
+        expires_at_ms: (1_000 + 5 * 60 - 1) * 1000,
+    };
+    let outside = Tokens {
+        access_token: "a".into(),
+        refresh_token: None,
+        expires_at_ms: (1_000 + 5 * 60 + 1) * 1000,
+    };
+    assert!(!inside.is_valid_at(now));
+    assert!(outside.is_valid_at(now));
+}
+
+#[test]
+fn parses_credentials_tokens() {
+    let value = json!({
+        "claudeAiOauth": {
+            "accessToken": "sk-ant-oat-access",
+            "refreshToken": "sk-ant-ort-refresh",
+            "expiresAt": 2_000_000_000_000i64,
+            "subscriptionType": "max"
+        }
+    });
+    let tokens = Tokens::from_value(&value).unwrap();
+    assert_eq!(tokens.access_token, "sk-ant-oat-access");
+    assert_eq!(tokens.refresh_token.as_deref(), Some("sk-ant-ort-refresh"));
+    assert_eq!(tokens.expires_at_ms, 2_000_000_000_000);
+}
+
+#[test]
+fn refresh_reuses_prior_refresh_token_when_omitted() {
+    let now = UNIX_EPOCH + Duration::from_secs(1_000);
+    let value = json!({"access_token": "new-access", "expires_in": 3600});
+    let refreshed = parse_refresh(&value, "old-refresh", now).unwrap();
+    assert_eq!(refreshed.access_token, "new-access");
+    assert_eq!(refreshed.refresh_token, "old-refresh");
+    assert_eq!(refreshed.expires_at_ms, 1_000 * 1000 + 3600 * 1000);
+}
+
+#[test]
+fn refresh_rejects_response_without_access_token() {
+    let now = UNIX_EPOCH + Duration::from_secs(1_000);
+    assert!(parse_refresh(&json!({"expires_in": 3600}), "old-refresh", now).is_none());
+}
+
+#[test]
+fn write_back_updates_tokens_and_preserves_other_fields() {
+    let path = temp_credentials_path("write-back");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &path,
+        r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"old-r","expiresAt":1,"subscriptionType":"max"},"mcpOAuth":{"keep":true}}"#,
+    )
+    .unwrap();
+
+    write_back(
+        &path,
+        &Refreshed {
+            access_token: "new".into(),
+            refresh_token: "new-r".into(),
+            expires_at_ms: 999,
+        },
+    )
+    .unwrap();
+
+    let value: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(value["claudeAiOauth"]["accessToken"], "new");
+    assert_eq!(value["claudeAiOauth"]["refreshToken"], "new-r");
+    assert_eq!(value["claudeAiOauth"]["expiresAt"], 999);
+    assert_eq!(value["claudeAiOauth"]["subscriptionType"], "max");
+    assert_eq!(value["mcpOAuth"]["keep"], true);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}

--- a/src/auth/claude/auth/tests.rs
+++ b/src/auth/claude/auth/tests.rs
@@ -12,6 +12,27 @@ fn temp_credentials_path(tag: &str) -> PathBuf {
         .join(".credentials.json")
 }
 
+/// Start a wiremock server that answers a single `POST /token` with a 200
+/// carrying `new-access` and the given `refresh_token`. Shared by the token
+/// tests whose mock setup is otherwise identical.
+async fn mock_token_server(refresh_token: &str) -> wiremock::MockServer {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access",
+            "refresh_token": refresh_token,
+            "expires_in": 3600
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    server
+}
+
 fn write_credentials(path: &Path, access_token: &str, refresh_token: &str, expires_at: i64) {
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(
@@ -98,20 +119,7 @@ async fn cancelled_refresh_still_persists_rotated_token() {
 
 #[tokio::test]
 async fn concurrent_get_valid_single_flights_refresh() {
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/token"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "access_token": "new-access",
-            "refresh_token": "rotated-refresh",
-            "expires_in": 3600
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
+    let server = mock_token_server("rotated-refresh").await;
 
     let path = temp_credentials_path("single-flight");
     write_credentials(&path, "expired-access", "old-refresh", 0);
@@ -164,20 +172,7 @@ async fn force_refresh_skips_when_rejected_token_was_already_replaced() {
 
 #[tokio::test]
 async fn force_refresh_refreshes_a_still_valid_token() {
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    let server = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/token"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "access_token": "new-access",
-            "refresh_token": "new-refresh",
-            "expires_in": 3600
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
+    let server = mock_token_server("new-refresh").await;
 
     let path = temp_credentials_path("force-refresh");
     write_credentials(&path, "still-valid", "old-refresh", 4_000_000_000_000);


### PR DESCRIPTION
## Summary

Hardens the single-account `ClaudeAuthStore` OAuth path (the helper backing `shunt token` / apiKeyHelper), bringing it in line with the already-hardened xAI/Cursor stores. Fixes two tracked issues in one pass since they touch the same functions:

- **#73 — cancellation-safe refresh:** the refresh HTTP request and the credential write-back are now detached (`tokio::spawn`) behind a **process-wide single-flight lock**, so a caller future cancelled mid-refresh (client disconnect) can no longer drop a freshly *rotated* refresh token before it is persisted. Concurrent 401 retries also compare the rejected access token before rotating, so parallel failures don't repeatedly re-refresh.
- **#101 — off-thread file I/O:** synchronous credential reads and atomic write-backs now run on `tokio::task::spawn_blocking` (with explicit `JoinError` mapping), instead of blocking the async runtime.

## Milestone / spec

M8 auth hardening — mirrors the cancellation-safe pattern established in `src/auth/xai/auth.rs` and `src/auth/cursor/auth.rs`.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (9 new/updated auth tests; run without network)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines (auth tests split into `auth/tests.rs` to keep files under limit)
- [x] English only; matches surrounding style
- [x] No user-facing behavior/config/endpoint change (internal correctness + perf)
- [x] No new GitHub Action

## Notes for reviewers

- Core changes in `src/auth/claude/auth.rs`; tests in the new `src/auth/claude/auth/tests.rs`.
- `src/adapters/anthropic/mod.rs` (9 lines) touched for the rejected-access-token comparison on the shared refresh path — please confirm the single-flight serialization interaction with the M8 `AccountPool.refresh_lock` is acceptable.
- The process-wide lock deliberately serializes Claude refreshes across independently-constructed store instances, matching the xAI/Cursor convention.
- New tests cover: persistence after caller cancellation, single-flight across separate store instances, and skipping a redundant 401 refresh once another request replaced the token.

Closes #73
Closes #101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude OAuth refresh cancellation-safe and serialize refreshes across the process, fixing #73. Move credential file I/O to Tokio’s blocking pool and refactor the Anthropic adapter to de-duplicate relay/retry logic, fixing #101; add tests for the new retry helper.

- **Bug Fixes**
  - Detached refresh + write-back holds a process‑wide single‑flight lock and logs write‑back failures, so cancellation can’t drop a rotated refresh token.
  - Avoid redundant 401 refreshes by checking the rejected access token; Anthropic now calls `force_refresh_if_access_token`.
  - Credential reads and atomic write‑backs run via `tokio::task::spawn_blocking`, preventing async runtime stalls.
  - Gracefully fail over (log and continue) if a non‑OAuth Claude credential is resolved, instead of panicking.

- **Refactors**
  - Extracted `retry_upstream` to unify throttle/refresh retry handling and added tests for success and fail‑over.
  - Reused `relay_response` to remove duplicated response-building in the non‑pooled path.

<sup>Written for commit 183eb48c03ff65769e73ba5fbe55fa018eebce15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

