### PR TITLE
chore(review): configure cubic + greptile review plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ site/.wrangler/
 
 # Machine-local review/apply-loop state (regenerated per run; not shared)
 .please/state/
+
+# Per-developer config override (overlays .please/config.yml)
+.please/config.local.yml

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -1,0 +1,12 @@
+review:
+  cubic:
+    enabled: true
+    default-flags: "--json -b"
+  agy:
+    enabled: false
+  coderabbit:
+    enabled: false
+  greptile:
+    enabled: true
+  gemini:
+    enabled: false


### PR DESCRIPTION
## Summary

Adds the `review` plugin configuration for this repo (`.please/config.yml`, team-shared):

- **cubic** — enabled, default flags `--json -b` (JSON output + base-branch comparison).
- **greptile** — enabled (reviews committed changes on the branch vs base).
- **agy / coderabbit / gemini** — disabled.
- `pre-pr-check` left at the default (`warn`).

Also ignores the per-developer `.please/config.local.yml` override in `.gitignore` so a
developer can locally enable different reviewers without leaking the file upstream.

## Milestone / spec

N/A — tooling/config only (review plugin setup).

## Checklist

- [x] Config only; no source changes, no build/test impact
- [x] English only
- [x] No new GitHub Action

## Notes for reviewers

- Generated by `/review:setup`. `.please/config.yml` is the tracking marker consumed by the review
  plugin; the greptile/coderabbit reviewers delegate to their respective plugin skills at run time.
- Greptile CLI is installed locally but the `greptile@pleaseai` plugin skill must be installed
  (`/plugin install greptile@pleaseai`) + `greptile login` before its reviewer runs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `cubic` and `greptile` review plugins via `.please/config.yml` (others disabled). Set `cubic` default flags to `--json -b` and add `.please/config.local.yml` to `.gitignore` so devs can keep local overrides untracked.

<sup>Written for commit 9b004c1600d33979cd2d6ce47b51d1eb966010a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

