### PR TITLE
ci: add sccache compiler caching (CI + release) with opt-in local setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,19 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  # sccache wraps rustc to cache compilation artifacts in the GitHub Actions
-  # cache (SCCACHE_GHA_ENABLED). rust-cache still restores the cargo registry
-  # (cache-targets: false) so the two split roles without overlap. sccache
-  # does not support incremental compilation, so disable it.
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
-  CARGO_INCREMENTAL: 0
 
 jobs:
   test:
     name: fmt · clippy · test
     runs-on: ubuntu-latest
+    # sccache vars are scoped per-job (not top-level env): a future job that runs
+    # Cargo without installing sccache first would otherwise fail on a missing
+    # binary. rust-cache keeps cache-targets:false so the two split roles;
+    # sccache can't cache incremental builds, so disable it.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -62,6 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # sccache wraps rustc to cache compilation artifacts in the GitHub Actions
+  # cache (SCCACHE_GHA_ENABLED). rust-cache still restores the cargo registry
+  # (cache-targets: false) so the two split roles without overlap. sccache
+  # does not support incremental compilation, so disable it.
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   test:
@@ -29,8 +36,13 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: false
 
       - name: Format check
         run: cargo fmt --all --check
@@ -40,6 +52,10 @@ jobs:
 
       - name: Test
         run: cargo test --all-features --workspace
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
   coverage:
     name: coverage · codecov · sonarqube
@@ -58,8 +74,13 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: false
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2.83.0
@@ -68,6 +89,10 @@ jobs:
 
       - name: Generate coverage (lcov)
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
     name: build ${{ matrix.asset }}
     if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
+    # sccache is scoped to this job only: publish-crate runs `cargo publish`
+    # without a sccache binary on PATH, so a global RUSTC_WRAPPER would break it.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0
     strategy:
       matrix:
         include:
@@ -53,13 +59,21 @@ jobs:
         if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
+          cache-targets: false
 
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Stage asset
         run: cp target/${{ matrix.target }}/release/shunt ${{ matrix.asset }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@ site/.wrangler/
 .please/config.local.yml
 
 # Local sccache opt-in (per-developer rustc-wrapper); never shared upstream
+# Cargo reads both config.toml and the legacy extensionless config, so ignore both.
 /.cargo/config.toml
+/.cargo/config

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ site/.wrangler/
 
 # Per-developer config override (overlays .please/config.yml)
 .please/config.local.yml
+
+# Local sccache opt-in (per-developer rustc-wrapper); never shared upstream
+/.cargo/config.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,21 @@ backend). You can opt in locally — it's per-developer and nothing in the repo 
 missing `sccache` binary never breaks the build:
 
 ```bash
-brew install sccache          # or: cargo install sccache
-export RUSTC_WRAPPER=sccache  # add to your shell profile to persist it
+brew install sccache  # or: cargo install sccache
+```
+
+Then turn it on either globally via your shell profile:
+
+```bash
+export RUSTC_WRAPPER=sccache
+```
+
+…or scoped to just this repo with a gitignored `.cargo/config.toml` (keeps other Rust projects
+unaffected):
+
+```toml
+[build]
+rustc-wrapper = "sccache"
 ```
 
 sccache stores artifacts on disk by default (`~/Library/Caches/Mozilla.sccache` on macOS, 10 GB

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,22 @@ All four must pass before a PR is ready; CI enforces them.
 Use an Orca worktree rather than editing the main checkout in place. `orca.yaml` seeds local
 files (`.worktreeinclude`) and warms the Cargo cache on worktree creation.
 
+### Faster local builds (optional)
+
+CI compiles through [sccache](https://github.com/mozilla/sccache) (GitHub Actions cache
+backend). You can opt in locally — it's per-developer and nothing in the repo forces it, so a
+missing `sccache` binary never breaks the build:
+
+```bash
+brew install sccache          # or: cargo install sccache
+export RUSTC_WRAPPER=sccache  # add to your shell profile to persist it
+```
+
+sccache stores artifacts on disk by default (`~/Library/Caches/Mozilla.sccache` on macOS, 10 GB
+cap; tune with `SCCACHE_DIR` / `SCCACHE_CACHE_SIZE`). For the biggest win across `cargo clean` and
+branch switches, also set `CARGO_INCREMENTAL=0` — sccache can't cache incremental builds, though
+that trades away incremental rebuild speed. Check hits with `sccache --show-stats`.
+
 ## Pull requests
 
 - Keep changes scoped to a single milestone/concern; split unrelated work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,9 @@ unaffected):
 rustc-wrapper = "sccache"
 ```
 
-sccache stores artifacts on disk by default (`~/Library/Caches/Mozilla.sccache` on macOS, 10 GB
-cap; tune with `SCCACHE_DIR` / `SCCACHE_CACHE_SIZE`). For the biggest win across `cargo clean` and
+sccache stores artifacts on disk by default (10 GB cap; tune with `SCCACHE_DIR` /
+`SCCACHE_CACHE_SIZE`). The default cache location is `~/Library/Caches/Mozilla.sccache` on macOS,
+`~/.cache/sccache` on Linux, and `%LOCALAPPDATA%\Mozilla\sccache` on Windows. For the biggest win across `cargo clean` and
 branch switches, also disable incremental compilation, which sccache can't cache — either
 `export CARGO_INCREMENTAL=0`, or add `incremental = false` under `[build]` in the repo-local
 `.cargo/config.toml` to keep it scoped to this project instead of your global environment. It's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,11 @@ rustc-wrapper = "sccache"
 
 sccache stores artifacts on disk by default (`~/Library/Caches/Mozilla.sccache` on macOS, 10 GB
 cap; tune with `SCCACHE_DIR` / `SCCACHE_CACHE_SIZE`). For the biggest win across `cargo clean` and
-branch switches, also set `CARGO_INCREMENTAL=0` — sccache can't cache incremental builds, though
-that trades away incremental rebuild speed. Check hits with `sccache --show-stats`.
+branch switches, also disable incremental compilation, which sccache can't cache — either
+`export CARGO_INCREMENTAL=0`, or add `incremental = false` under `[build]` in the repo-local
+`.cargo/config.toml` to keep it scoped to this project instead of your global environment. It's
+optional: disabling incremental trades away fast small-edit rebuilds. Check hits with
+`sccache --show-stats`.
 
 ## Pull requests
 


### PR DESCRIPTION
## Summary

Adds mozilla/sccache compiler caching to speed up Rust compilation in CI and release builds, and documents an optional local setup for contributors.

- CI (`ci.yml` test/coverage jobs) and Release (`release.yml` build job) now run `mozilla-actions/sccache-action` (SHA-pinned `9e7fa8a...` = v0.0.10) with the GitHub Actions cache backend (`SCCACHE_GHA_ENABLED`).
- Splits roles with the existing `Swatinem/rust-cache`: rust-cache now uses `cache-targets: false` (registry/git deps only) so sccache owns compilation caching — avoids the overlap where rust-cache restoring `target/` leaves sccache no work.
- `RUSTC_WRAPPER=sccache` is scoped to the release **build** job only (a global var would break the `publish-crate` job's `cargo publish`, which has no sccache on PATH). `CARGO_INCREMENTAL=0` because sccache cannot cache incremental builds. Each job prints `sccache --show-stats`.
- Documents an **optional, opt-in** local setup in `CONTRIBUTING.md` ("Faster local builds"), and gitignores `/.cargo/config.toml` so per-developer local config is never committed. Nothing in the committed repo forces sccache on contributors.
- Distributed compilation (sccache-dist) was intentionally **not** adopted — out of proportion to this single-crate project's scale and operational cost.

## Milestone / spec

N/A — CI/tooling change, no frozen spec in `docs/` covers build caching.

## Checklist

- [ ] `cargo build` passes — N/A, no Rust source changed
- [ ] `cargo test` passes — N/A, no Rust source changed
- [ ] `cargo clippy --all-targets -- -D warnings` clean — N/A, no Rust source changed
- [ ] `cargo fmt --all --check` clean — N/A, no Rust source changed
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `CONTRIBUTING.md` updated for the optional local sccache setup
- [x] Any new GitHub Action is pinned to a full commit SHA — `mozilla-actions/sccache-action@9e7fa8a` (v0.0.10)

## Notes for reviewers

- Verified locally: YAML valid, `actionlint` passes on both workflows, and a local `cargo build` through sccache succeeded (699 compile requests, 0 cache errors), confirming the wrapper works with this codebase.
- Real CI cache hit rates will show up in the workflow's `sccache --show-stats` step once this runs/merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up Rust builds in CI and release with `sccache`, plus an opt-in local setup for contributors.

- **New Features**
  - CI (test, coverage) and the release build job use `mozilla-actions/sccache-action` with `SCCACHE_GHA_ENABLED`; set `RUSTC_WRAPPER=sccache` and `CARGO_INCREMENTAL=0` per job; print `sccache --show-stats`.
  - Split caches: `Swatinem/rust-cache` uses `cache-targets: false` so `sccache` owns compilation caching.
  - Docs: add “Faster local builds (optional)” with a repo-local `.cargo/config.toml` opt-in; document `incremental = false` under `[build]`; ignore `/.cargo/config.toml` and `/.cargo/config`; list default `sccache` cache paths for macOS, Linux, and Windows.

<sup>Written for commit 5c0d5a7f78403fd98b56381a0f806256594be204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

