### PR TITLE
refactor(responses): unify error type + client status into one table

### DIFF
--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -801,47 +801,51 @@ pub fn map_error_value(value: &Value, status: StatusCode) -> Value {
 // of failing the turn, so it must reach the client as its own status rather
 // than folding into a generic `api_error`.
 
-/// Map an upstream HTTP status to the Anthropic error envelope's
-/// `error.type`, per the table in `docs/gateway-protocol.md#error-envelopes`.
-/// Shared by every translated backend (Responses/Codex, xAI, Cursor) so they
-/// surface the same vocabulary the Anthropic-direct path streams verbatim.
-pub fn anthropic_error_type(status: StatusCode) -> &'static str {
+/// Single source of truth mapping an upstream HTTP status to both the Anthropic
+/// error envelope's `error.type` and the client-facing HTTP status.
+///
+/// Deriving both from one table makes their shared invariant unbreakable: a
+/// status can never be given a specific `error.type` (e.g. `permission_error`)
+/// while its client-facing status silently falls back to `502`, which would
+/// ship a self-contradictory envelope. `anthropic_error_type` and
+/// `client_facing_status` are thin projections of this table.
+///
+/// The standard error statuses (400/401/403/413/429/500/501/502/503/504 and the
+/// non-registry 529 overload) reach the client unchanged so status-based client
+/// behavior (the `529` overload backoff, distinguishing `503`/`500` from a
+/// generic gateway failure) sees the real upstream signal. Anything outside that
+/// set collapses to `(api_error, 502)` rather than leaking an unexpected
+/// upstream status verbatim. See `docs/gateway-protocol.md#error-envelopes`.
+fn mapped_error(status: StatusCode) -> (&'static str, StatusCode) {
     match status {
-        StatusCode::BAD_REQUEST => "invalid_request_error",
-        StatusCode::UNAUTHORIZED => "authentication_error",
-        StatusCode::FORBIDDEN => "permission_error",
-        StatusCode::PAYLOAD_TOO_LARGE => "request_too_large",
-        StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
-        StatusCode::NOT_IMPLEMENTED => "not_supported",
-        _ if status.as_u16() == 529 => "overloaded_error",
-        _ => "api_error",
+        StatusCode::BAD_REQUEST => ("invalid_request_error", StatusCode::BAD_REQUEST),
+        StatusCode::UNAUTHORIZED => ("authentication_error", StatusCode::UNAUTHORIZED),
+        StatusCode::FORBIDDEN => ("permission_error", StatusCode::FORBIDDEN),
+        StatusCode::PAYLOAD_TOO_LARGE => ("request_too_large", StatusCode::PAYLOAD_TOO_LARGE),
+        StatusCode::TOO_MANY_REQUESTS => ("rate_limit_error", StatusCode::TOO_MANY_REQUESTS),
+        StatusCode::INTERNAL_SERVER_ERROR => ("api_error", StatusCode::INTERNAL_SERVER_ERROR),
+        StatusCode::NOT_IMPLEMENTED => ("not_supported", StatusCode::NOT_IMPLEMENTED),
+        StatusCode::BAD_GATEWAY => ("api_error", StatusCode::BAD_GATEWAY),
+        StatusCode::SERVICE_UNAVAILABLE => ("api_error", StatusCode::SERVICE_UNAVAILABLE),
+        StatusCode::GATEWAY_TIMEOUT => ("api_error", StatusCode::GATEWAY_TIMEOUT),
+        _ if status.as_u16() == 529 => ("overloaded_error", status),
+        _ => ("api_error", StatusCode::BAD_GATEWAY),
     }
 }
 
-/// Client-facing HTTP status for a mapped upstream error. The standard error
-/// statuses reach the client unchanged so status-based client behavior (the
-/// `529` overload backoff, distinguishing `503`/`500` from a generic gateway
-/// failure) sees the real upstream signal; anything outside that set
-/// collapses to `502` rather than leaking an unexpected upstream status
-/// verbatim.
+/// Map an upstream HTTP status to the Anthropic error envelope's `error.type`,
+/// per the table in `docs/gateway-protocol.md#error-envelopes`. Shared by every
+/// translated backend (Responses/Codex, xAI, Cursor) so they surface the same
+/// vocabulary the Anthropic-direct path streams verbatim. Projection of
+/// `mapped_error`.
+pub fn anthropic_error_type(status: StatusCode) -> &'static str {
+    mapped_error(status).0
+}
+
+/// Client-facing HTTP status for a mapped upstream error. Projection of
+/// `mapped_error`; see its docs for the preserved-vs-collapsed rule.
 pub fn client_facing_status(status: StatusCode) -> StatusCode {
-    const PRESERVED: &[StatusCode] = &[
-        StatusCode::BAD_REQUEST,
-        StatusCode::UNAUTHORIZED,
-        StatusCode::FORBIDDEN,
-        StatusCode::PAYLOAD_TOO_LARGE,
-        StatusCode::TOO_MANY_REQUESTS,
-        StatusCode::INTERNAL_SERVER_ERROR,
-        StatusCode::NOT_IMPLEMENTED,
-        StatusCode::BAD_GATEWAY,
-        StatusCode::SERVICE_UNAVAILABLE,
-        StatusCode::GATEWAY_TIMEOUT,
-    ];
-    if PRESERVED.contains(&status) || status.as_u16() == 529 {
-        status
-    } else {
-        StatusCode::BAD_GATEWAY
-    }
+    mapped_error(status).1
 }
 
 fn error_message(value: &Value) -> String {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -816,20 +816,24 @@ pub fn map_error_value(value: &Value, status: StatusCode) -> Value {
 /// generic gateway failure) sees the real upstream signal. Anything outside that
 /// set collapses to `(api_error, 502)` rather than leaking an unexpected
 /// upstream status verbatim. See `docs/gateway-protocol.md#error-envelopes`.
-fn mapped_error(status: StatusCode) -> (&'static str, StatusCode) {
+/// The second tuple element is whether the upstream `status` reaches the client
+/// unchanged (`true`) or collapses to `502` (`false`); `client_facing_status`
+/// projects it. Encoding it as a flag rather than repeating the `StatusCode` in
+/// both the pattern and the return keeps each row's status listed once.
+fn mapped_error(status: StatusCode) -> (&'static str, bool) {
     match status {
-        StatusCode::BAD_REQUEST => ("invalid_request_error", StatusCode::BAD_REQUEST),
-        StatusCode::UNAUTHORIZED => ("authentication_error", StatusCode::UNAUTHORIZED),
-        StatusCode::FORBIDDEN => ("permission_error", StatusCode::FORBIDDEN),
-        StatusCode::PAYLOAD_TOO_LARGE => ("request_too_large", StatusCode::PAYLOAD_TOO_LARGE),
-        StatusCode::TOO_MANY_REQUESTS => ("rate_limit_error", StatusCode::TOO_MANY_REQUESTS),
-        StatusCode::INTERNAL_SERVER_ERROR => ("api_error", StatusCode::INTERNAL_SERVER_ERROR),
-        StatusCode::NOT_IMPLEMENTED => ("not_supported", StatusCode::NOT_IMPLEMENTED),
-        StatusCode::BAD_GATEWAY => ("api_error", StatusCode::BAD_GATEWAY),
-        StatusCode::SERVICE_UNAVAILABLE => ("api_error", StatusCode::SERVICE_UNAVAILABLE),
-        StatusCode::GATEWAY_TIMEOUT => ("api_error", StatusCode::GATEWAY_TIMEOUT),
-        _ if status.as_u16() == 529 => ("overloaded_error", status),
-        _ => ("api_error", StatusCode::BAD_GATEWAY),
+        StatusCode::BAD_REQUEST => ("invalid_request_error", true),
+        StatusCode::UNAUTHORIZED => ("authentication_error", true),
+        StatusCode::FORBIDDEN => ("permission_error", true),
+        StatusCode::PAYLOAD_TOO_LARGE => ("request_too_large", true),
+        StatusCode::TOO_MANY_REQUESTS => ("rate_limit_error", true),
+        StatusCode::INTERNAL_SERVER_ERROR => ("api_error", true),
+        StatusCode::NOT_IMPLEMENTED => ("not_supported", true),
+        StatusCode::BAD_GATEWAY => ("api_error", true),
+        StatusCode::SERVICE_UNAVAILABLE => ("api_error", true),
+        StatusCode::GATEWAY_TIMEOUT => ("api_error", true),
+        _ if status.as_u16() == 529 => ("overloaded_error", true),
+        _ => ("api_error", false),
     }
 }
 
@@ -848,7 +852,11 @@ pub fn anthropic_error_type(status: StatusCode) -> &'static str {
 /// rather than leaking an unexpected upstream status verbatim. Projection of
 /// `mapped_error`, the shared source of truth this and `error.type` derive from.
 pub fn client_facing_status(status: StatusCode) -> StatusCode {
-    mapped_error(status).1
+    if mapped_error(status).1 {
+        status
+    } else {
+        StatusCode::BAD_GATEWAY
+    }
 }
 
 fn error_message(value: &Value) -> String {

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -842,8 +842,11 @@ pub fn anthropic_error_type(status: StatusCode) -> &'static str {
     mapped_error(status).0
 }
 
-/// Client-facing HTTP status for a mapped upstream error. Projection of
-/// `mapped_error`; see its docs for the preserved-vs-collapsed rule.
+/// Client-facing HTTP status for a mapped upstream error. The standard error
+/// statuses (400/401/403/413/429/500/501/502/503/504 and the non-registry 529
+/// overload) reach the client unchanged; anything else collapses to `502`
+/// rather than leaking an unexpected upstream status verbatim. Projection of
+/// `mapped_error`, the shared source of truth this and `error.type` derive from.
 pub fn client_facing_status(status: StatusCode) -> StatusCode {
     mapped_error(status).1
 }

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -1207,6 +1207,26 @@ fn preserves_client_facing_status_for_standard_error_statuses_only() {
 }
 
 #[test]
+fn error_type_and_client_status_never_contradict() {
+    // Both projections come from one table, so a status can never carry a
+    // specific (non-`api_error`) `error.type` while its client-facing status
+    // silently collapses to 502 — that pairing would ship a self-contradictory
+    // envelope (e.g. `permission_error` with HTTP 502). Sweep every 4xx/5xx and
+    // lock the invariant against a future re-split of the two mappings.
+    for code in 400u16..=599 {
+        let status = StatusCode::from_u16(code).unwrap();
+        let kind = anthropic_error_type(status);
+        if kind != "api_error" {
+            assert_eq!(
+                client_facing_status(status),
+                status,
+                "status {code} has specific type {kind:?} but its client status is not preserved"
+            );
+        }
+    }
+}
+
+#[test]
 fn surfaces_upstream_error_detail_and_message() {
     // ChatGPT Codex backend shape: {"detail": "..."}
     let codex = map_error_value(


### PR DESCRIPTION
## Summary

The two error-mapping functions in `src/model/responses.rs` — `anthropic_error_type` and `client_facing_status` — shared an unenforced invariant: every HTTP status given a non-`api_error` type must also appear in `client_facing_status`'s PRESERVED list, otherwise the client receives a self-contradictory envelope (e.g. `error.type: permission_error` with HTTP 502). This collapses both into a single private `mapped_error(status) -> (&'static str, StatusCode)` table so the two properties can never diverge again.

## Milestone / spec

Maintainability hardening per AGENTS.md's table-driven mapping preference; no milestone/spec deviation.

## Changes

- Collapsed `anthropic_error_type` and `client_facing_status` into thin projections (`.0` / `.1`) over a new private `mapped_error(status)` table. Public signatures are unchanged, so no call-site churn.
- Behavior is identical: 500/502/503/504 keep `api_error` type but preserve their own status via explicit table entries; 529 → `overloaded_error` preserved; everything else falls back to `(api_error, 502)`.
- Added an invariant regression test, `error_type_and_client_status_never_contradict`, in `tests/responses_translate.rs`, sweeping HTTP 400–599 to lock the invariant against a future re-split.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A, no observable behavior change
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — N/A, pure internal refactor, no behavior change
- [x] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes

## Notes for reviewers

Pure maintainability refactor with no observable behavior change — the new test asserts type/status can never contradict across the full 400-599 range.

## Related Issues

Closes #97

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies error mapping so `error.type` and client HTTP status come from one source of truth, preventing contradictory envelopes. No behavior or public API changes.

- **Refactors**
  - Introduced private `mapped_error(status)` and made `anthropic_error_type`/`client_facing_status` thin projections; public signatures unchanged.
  - Encoded the client-status projection as a preserve flag instead of repeating `StatusCode`; `client_facing_status` projects it.
  - Preserved statuses: 400/401/403/413/429/500/501/502/503/504 and 529 (`overloaded_error`); all others collapse to `(api_error, 502)`.
  - Added a regression test sweeping 400–599 to lock type/status alignment; documented the preserved-vs-collapsed rule on `client_facing_status`.

<sup>Written for commit ebdb30cdeae2a69b1ae0955a6d67dfd09f1203da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

