### PR TITLE
docs(codex): point Codex CLI base URL via config.toml, not OPENAI_BASE_URL env

### DIFF
--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -649,10 +649,7 @@ wire_api = "responses"
 If shunt has `[server.auth]` configured (recommended for anything beyond loopback), present the
 client token **either** way — shunt accepts both (`InboundAuth::authenticate_bearer`):
 
-# A. OpenAI-style Bearer key (the LiteLLM/llmgateway idiom), on the built-in openai provider.
-#    Set the base URL in ~/.codex/config.toml — NOT via the OPENAI_BASE_URL env var, which does
-#    not redirect the CLI's Responses WebSocket transport (the CLI keeps hitting
-#    wss://api.openai.com and bypasses shunt):
+**Option A:** OpenAI-style Bearer key (the LiteLLM/llmgateway idiom), on the built-in openai provider. Set the base URL in `~/.codex/config.toml` — **NOT** via the `OPENAI_BASE_URL` env var, which does not redirect the CLI's Responses WebSocket transport (the CLI keeps hitting `wss://api.openai.com` and bypasses shunt):
 
 ```toml
 # ~/.codex/config.toml
@@ -664,13 +661,14 @@ openai_base_url = "http://127.0.0.1:3001/v1"
 export OPENAI_API_KEY="<shunt-token>"
 ```
 
+**Option B:** the `x-shunt-token` header — only a custom provider can attach one:
+
 ```toml
-# B. The x-shunt-token header — only a custom provider can attach one:
 [model_providers.shunt]
 base_url = "http://127.0.0.1:3001/v1"
 wire_api = "responses"
-env_key = "SHUNT_TOKEN"                            # A, on a custom provider: Bearer from $SHUNT_TOKEN
-# http_headers = { "x-shunt-token" = "<token>" }   # B: the header form
+env_key = "SHUNT_TOKEN"                            # option A on a custom provider: Bearer from $SHUNT_TOKEN
+# http_headers = { "x-shunt-token" = "<token>" }   # option B: the header form
 ```
 
 The Codex CLI's own local `~/.codex/auth.json` login is irrelevant once pointed at shunt this

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -649,13 +649,19 @@ wire_api = "responses"
 If shunt has `[server.auth]` configured (recommended for anything beyond loopback), present the
 client token **either** way — shunt accepts both (`InboundAuth::authenticate_bearer`):
 
+# A. OpenAI-style Bearer key (the LiteLLM/llmgateway idiom), on the built-in openai provider.
+#    Set the base URL in ~/.codex/config.toml — NOT via the OPENAI_BASE_URL env var, which does
+#    not redirect the CLI's Responses WebSocket transport (the CLI keeps hitting
+#    wss://api.openai.com and bypasses shunt):
+
+```toml
+# ~/.codex/config.toml
+openai_base_url = "http://127.0.0.1:3001/v1"
+```
+
 ```bash
-# A. OpenAI-style Bearer key (the LiteLLM/llmgateway idiom) — works with the built-in
-#    openai provider. Set the base URL in ~/.codex/config.toml (openai_base_url = ".../v1"),
-#    NOT via the OPENAI_BASE_URL env var — the env var does not redirect the CLI's Responses
-#    WebSocket transport, so the CLI keeps hitting wss://api.openai.com and bypasses shunt.
-#    Then present only the token via env:
-export OPENAI_API_KEY="<shunt-token>"      # Codex sends it as Authorization: Bearer
+# then present only the token via env — Codex sends it as Authorization: Bearer
+export OPENAI_API_KEY="<shunt-token>"
 ```
 
 ```toml

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -651,7 +651,10 @@ client token **either** way — shunt accepts both (`InboundAuth::authenticate_b
 
 ```bash
 # A. OpenAI-style Bearer key (the LiteLLM/llmgateway idiom) — works with the built-in
-#    openai provider (openai_base_url = ".../v1"), no config block required:
+#    openai provider. Set the base URL in ~/.codex/config.toml (openai_base_url = ".../v1"),
+#    NOT via the OPENAI_BASE_URL env var — the env var does not redirect the CLI's Responses
+#    WebSocket transport, so the CLI keeps hitting wss://api.openai.com and bypasses shunt.
+#    Then present only the token via env:
 export OPENAI_API_KEY="<shunt-token>"      # Codex sends it as Authorization: Bearer
 ```
 

--- a/site/src/content/docs/guides/connect-codex-cli.md
+++ b/site/src/content/docs/guides/connect-codex-cli.md
@@ -85,6 +85,20 @@ token, which shunt can't accept as a client token — use it **only on an ungate
 Both run the CLI in its own OpenAI/ChatGPT auth mode, so both need a local `codex login`; the custom
 provider above avoids even that.
 
+:::caution[Set the base URL in config.toml, not via the OPENAI_BASE_URL env var]
+Put `openai_base_url` in `~/.codex/config.toml` (user-level). The `OPENAI_BASE_URL`
+**environment variable** does not redirect the Codex CLI's Responses **WebSocket**
+transport — the CLI keeps opening `wss://api.openai.com/v1/responses` and bypasses shunt
+entirely, failing with `Incorrect API key` because it presents your shunt token to OpenAI
+directly. Only the config key redirects both the HTTP and WebSocket paths. (The same applies
+to `chatgpt_base_url`, `model_provider`, and `experimental_realtime_ws_base_url`: these are
+user-level `~/.codex/config.toml` keys — the CLI ignores them in a project-local
+`.codex/config.toml`, and there is no environment-variable equivalent.) With `openai_base_url`
+the CLI still *tries* a WebSocket first; shunt has no `wss` route, so the CLI falls back to
+HTTP on its own. The custom `model_provider` above avoids even that round-trip —
+`supports_websockets` defaults off, so it goes straight to HTTP.
+:::
+
 The CLI's own local `~/.codex/auth.json` login is **irrelevant to which account answers** — every
 request draws an account from shunt's pool. A loopback `base_url` may stay plain `http://`; use
 `https://` for anything remote. Do **not** set `supports_websockets = true` on the shunt provider —
@@ -104,9 +118,14 @@ loopback — present the shunt client token one of **two** ways; shunt accepts e
 **A. As an OpenAI-style Bearer key** — the LiteLLM/llmgateway idiom. Set the shunt token as the API
 key and the CLI sends it as `Authorization: Bearer <shunt-token>`:
 
+```toml
+# ~/.codex/config.toml — built-in openai provider (no provider block needed).
+# Set the base URL here, NOT via the OPENAI_BASE_URL env var (see the caution in step 2).
+openai_base_url = "http://127.0.0.1:3001/v1"
+```
+
 ```bash
-# built-in openai provider (no config block needed)
-export OPENAI_BASE_URL="http://127.0.0.1:3001/v1"
+# then present only the token via env — the CLI sends it as Authorization: Bearer
 export OPENAI_API_KEY="<shunt-token>"
 ```
 

--- a/site/src/content/docs/guides/inbound-codex-endpoint.md
+++ b/site/src/content/docs/guides/inbound-codex-endpoint.md
@@ -49,9 +49,15 @@ With the custom provider (add `requires_openai_auth = false` so the CLI needs no
 
 If shunt has [`[server.auth]`](/guides/shared-gateway/) configured — recommended for anything beyond loopback — present the client token **either** as an OpenAI-style Bearer key (`OPENAI_API_KEY` / a custom provider's `env_key`, the LiteLLM/llmgateway idiom) **or** as the `x-shunt-token` header:
 
+```toml
+# A. Bearer — built-in openai provider. Set the base URL in ~/.codex/config.toml,
+#    NOT via the OPENAI_BASE_URL env var: the env var leaves the CLI's Responses
+#    WebSocket pointed at wss://api.openai.com, so it bypasses shunt. See
+#    "Point the Codex CLI at shunt" in the connect guide.
+openai_base_url = "http://127.0.0.1:3001/v1"
+```
+
 ```bash
-# A. Bearer — works with the built-in openai provider, no config block:
-export OPENAI_BASE_URL="http://127.0.0.1:3001/v1"
 export OPENAI_API_KEY="<shunt-token>"      # sent as Authorization: Bearer
 ```
 


### PR DESCRIPTION
## Summary

Docs-only fix: the OpenAI Codex CLI, when pointed at shunt's inbound Codex
endpoint, must set its base URL via the `openai_base_url` key in
`~/.codex/config.toml` (or a custom `model_provider` base_url) — **not** via
the `OPENAI_BASE_URL` environment variable. The env var does not redirect the
CLI's Responses WebSocket transport, so the CLI keeps opening
`wss://api.openai.com/v1/responses` and bypasses shunt entirely, failing with
`Incorrect API key`. Confirmed in live troubleshooting and matches OpenAI's
own Codex config docs (`openai_base_url`, `chatgpt_base_url`,
`model_provider`, `experimental_realtime_ws_base_url` are user-level
`config.toml` keys with no env-var equivalent).

No code or behavior change.

## Milestone / spec

N/A — documentation correction, no implementation spec affected.

## Changes

- `site/src/content/docs/guides/connect-codex-cli.md` — added a `:::caution`
  in step 2 (env var does not redirect the WebSocket; `config.toml` is
  required; a custom `model_provider` avoids the WS round-trip via
  `supports_websockets = off`) and replaced the step-3
  `export OPENAI_BASE_URL=...` example with the `config.toml` form.
- `site/src/content/docs/guides/inbound-codex-endpoint.md` — replaced the
  client-auth `export OPENAI_BASE_URL=...` example with the `config.toml`
  form + caveat.
- `docs/codex-configuration.md` — strengthened the §16.2 comment (base URL
  belongs in `config.toml`, not the env var).

i18n (ko/ja/zh-cn) needs no change: these two guides have no translation yet,
so `OPENAI_BASE_URL` only ever lived in the English files.

## Checklist

- [x] `cargo build` passes (no code changed)
- [x] `cargo test` passes (no code changed)
- [x] `cargo clippy --all-targets -- -D warnings` clean (no code changed)
- [x] `cargo fmt --all --check` clean (no code changed)
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it — N/A, no spec deviation
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes
- [ ] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes

## Notes for reviewers

Pure documentation correction based on live troubleshooting of the Codex CLI
against shunt's inbound Codex endpoint; no `src/` changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Codex CLI setup: set the OpenAI base URL in `~/.codex/config.toml` via `openai_base_url` (or a custom provider `base_url`), not the `OPENAI_BASE_URL` env var. This redirects both HTTP and WebSocket and prevents `Incorrect API key` errors when routing through shunt.

- **Bug Fixes**
  - Replaced `export OPENAI_BASE_URL=...` examples with `openai_base_url` in user `config.toml` (or a custom `model_provider`), and added a runnable `~/.codex/config.toml` block in §16.2.
  - Documented that `OPENAI_BASE_URL` does not redirect the Responses WebSocket; only `config.toml` updates both HTTP and WS. Clarified auth and provider settings (`OPENAI_API_KEY`, `model_provider`, `chatgpt_base_url`, `experimental_realtime_ws_base_url`) and to keep `supports_websockets` off.
  - Fixed §16.2 option labels rendering: converted to bold “Option A/B” prose to avoid unintended H1 headings.

<sup>Written for commit 0fded21f04e94df966f74d56134f51ffcb1888b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

