### PR TITLE
fix(responses): drop empty text blocks on Codex to Claude switch

### DIFF
--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -636,9 +636,14 @@ impl AnthropicSseMachine {
         let Some(open) = self.open.take() else {
             return Vec::new();
         };
-        let empty_text = open.kind == BlockKind::Text && self.text_buffer.trim().is_empty();
         match open.kind {
             BlockKind::Text => {
+                // Drop a whitespace-only text block from the reconstructed
+                // `content` (Anthropic rejects empty text blocks), but still
+                // emit the matching `content_block_stop` below and advance the
+                // index: `open_text` already streamed a `content_block_start`
+                // for this block, so suppressing the stop would leave an
+                // unbalanced block and make the next block reuse this index.
                 if !self.text_buffer.trim().is_empty() {
                     let mut block = json!({"type": "text", "text": self.text_buffer});
                     if !self.text_citations.is_empty() {
@@ -670,12 +675,7 @@ impl AnthropicSseMachine {
                 }
             }
         }
-        if !empty_text {
-            self.index += 1;
-        }
-        if empty_text {
-            return Vec::new();
-        }
+        self.index += 1;
         vec![sse(
             "content_block_stop",
             &json!({"type": "content_block_stop", "index": open.index}),
@@ -1042,5 +1042,74 @@ mod tests {
             final_json["content"][0],
             json!({"type": "text", "text": "Hello"})
         );
+    }
+
+    #[test]
+    fn whitespace_only_text_keeps_the_sse_stream_balanced() {
+        // A whitespace-only delta still opens a text block (open_text streams a
+        // content_block_start), so closing it must emit the matching
+        // content_block_stop and advance the index. Otherwise the following
+        // tool block reuses the same index and the first block is never closed.
+        let mut machine = AnthropicSseMachine::new("test", false, false);
+        let mut output = machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "message"}}),
+        ));
+        output.extend(machine.apply(event("response.output_text.delta", json!({"delta": "  "}))));
+        output.extend(machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "function_call", "call_id": "call_1", "name": "do_work"}}),
+        )));
+        output.extend(machine.apply(event(
+            "response.function_call_arguments.delta",
+            json!({"delta": "{}"}),
+        )));
+        output.extend(machine.apply(event("response.function_call_arguments.done", json!({}))));
+        output.extend(machine.apply(event(
+            "response.output_item.done",
+            json!({"item": {"type": "function_call"}}),
+        )));
+        output.extend(machine.finish());
+        let final_json = machine.final_json();
+
+        let starts = output
+            .iter()
+            .filter(|frame| frame.contains("event: content_block_start"))
+            .count();
+        let stops = output
+            .iter()
+            .filter(|frame| frame.contains("event: content_block_stop"))
+            .count();
+        assert_eq!(starts, stops, "every content_block_start needs a stop");
+
+        // No two content_block_start frames may share an index.
+        let start_indexes: Vec<&str> = output
+            .iter()
+            .filter(|frame| frame.contains("event: content_block_start"))
+            .map(|frame| {
+                let marker = "\"index\":";
+                let start = frame.find(marker).unwrap() + marker.len();
+                let rest = &frame[start..];
+                let end = rest
+                    .find(|c: char| !c.is_ascii_digit())
+                    .unwrap_or(rest.len());
+                &rest[..end]
+            })
+            .collect();
+        let mut unique = start_indexes.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            start_indexes.len(),
+            unique.len(),
+            "content_block_start indexes must be distinct"
+        );
+
+        // The whitespace-only text block is still dropped from `content`.
+        assert!(final_json["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|block| block["type"] != "text"));
     }
 }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -231,7 +231,7 @@ impl AnthropicSseMachine {
     fn output_item_added(&mut self, data: &Value) -> Vec<String> {
         let item = data.get("item").unwrap_or(data);
         match item.get("type").and_then(Value::as_str) {
-            Some("message") => self.open_text(),
+            Some("message") => Vec::new(),
             Some("function_call") => self.open_tool(item),
             Some("reasoning") => self.reasoning_added(item),
             _ => Vec::new(),
@@ -481,15 +481,20 @@ impl AnthropicSseMachine {
         if delta.is_empty() {
             return Vec::new();
         }
+        let mut out = Vec::new();
+        if self.open.as_ref().map(|block| block.kind) != Some(BlockKind::Text) {
+            out.extend(self.open_text());
+        }
         self.text_buffer.push_str(delta);
-        vec![sse(
+        out.push(sse(
             "content_block_delta",
             &json!({
                 "type": "content_block_delta",
                 "index": self.open_index(),
                 "delta": {"type": "text_delta", "text": delta}
             }),
-        )]
+        ));
+        out
     }
 
     fn annotation_added(&mut self, data: &Value) -> Vec<String> {
@@ -498,9 +503,6 @@ impl AnthropicSseMachine {
             return Vec::new();
         }
         let mut out = Vec::new();
-        if self.open.as_ref().map(|block| block.kind) != Some(BlockKind::Text) {
-            out.extend(self.open_text());
-        }
         let url = annotation.get("url").and_then(Value::as_str).unwrap_or("");
         let encrypted_index = annotation
             .get("encrypted_index")
@@ -529,6 +531,9 @@ impl AnthropicSseMachine {
             .expect("citation is an object")
             .retain(|_, value| !value.is_null());
         self.text_citations.push(citation.clone());
+        if self.open.as_ref().map(|block| block.kind) != Some(BlockKind::Text) {
+            return out;
+        }
         out.push(sse(
             "content_block_delta",
             &json!({
@@ -631,13 +636,16 @@ impl AnthropicSseMachine {
         let Some(open) = self.open.take() else {
             return Vec::new();
         };
+        let empty_text = open.kind == BlockKind::Text && self.text_buffer.trim().is_empty();
         match open.kind {
             BlockKind::Text => {
-                let mut block = json!({"type": "text", "text": self.text_buffer});
-                if !self.text_citations.is_empty() {
-                    block["citations"] = json!(self.text_citations);
+                if !self.text_buffer.trim().is_empty() {
+                    let mut block = json!({"type": "text", "text": self.text_buffer});
+                    if !self.text_citations.is_empty() {
+                        block["citations"] = json!(self.text_citations);
+                    }
+                    self.content.push(block);
                 }
-                self.content.push(block);
                 self.text_buffer.clear();
                 self.text_citations.clear();
             }
@@ -662,7 +670,12 @@ impl AnthropicSseMachine {
                 }
             }
         }
-        self.index += 1;
+        if !empty_text {
+            self.index += 1;
+        }
+        if empty_text {
+            return Vec::new();
+        }
         vec![sse(
             "content_block_stop",
             &json!({"type": "content_block_stop", "index": open.index}),
@@ -938,4 +951,96 @@ pub fn context_overflow_message(value: &Value, message: &str) -> Option<String> 
 
 fn sse(event: &str, data: &Value) -> String {
     format!("event: {event}\ndata: {data}\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(name: &str, data: Value) -> ResponseEvent {
+        ResponseEvent {
+            event: Some(name.to_string()),
+            data,
+        }
+    }
+
+    #[test]
+    fn tool_only_turn_does_not_emit_empty_text_block() {
+        let mut machine = AnthropicSseMachine::new("test", false, false);
+        let mut output = Vec::new();
+        output.extend(machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "function_call", "call_id": "call_1", "name": "do_work"}}),
+        )));
+        output.extend(machine.apply(event(
+            "response.function_call_arguments.delta",
+            json!({"delta": "{}"}),
+        )));
+        output.extend(machine.apply(event("response.function_call_arguments.done", json!({}))));
+        output.extend(machine.apply(event(
+            "response.output_item.done",
+            json!({"item": {"type": "function_call"}}),
+        )));
+        output.extend(machine.finish());
+        let final_json = machine.final_json();
+
+        assert!(output.iter().all(|frame| {
+            !frame.contains("\"type\":\"text\"") && !frame.contains("\"text\":\"\"")
+        }));
+        assert!(final_json["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|block| block["type"] != "text"));
+    }
+
+    #[test]
+    fn reasoning_only_turn_does_not_emit_empty_text_block() {
+        let mut machine = AnthropicSseMachine::new("test", true, false);
+        let mut output = machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "reasoning", "id": "reason_1"}}),
+        ));
+        output.extend(machine.apply(event(
+            "response.reasoning_summary_text.delta",
+            json!({"delta": "Thinking"}),
+        )));
+        output.extend(machine.apply(event(
+            "response.output_item.done",
+            json!({"item": {"type": "reasoning", "id": "reason_1"}}),
+        )));
+        output.extend(machine.finish());
+        let final_json = machine.final_json();
+
+        assert!(output.iter().all(|frame| {
+            !frame.contains("\"type\":\"text\"") && !frame.contains("\"text\":\"\"")
+        }));
+        assert!(final_json["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|block| block["type"] != "text"));
+    }
+
+    #[test]
+    fn text_turn_still_streams_text_content() {
+        let mut machine = AnthropicSseMachine::new("test", false, false);
+        let mut output = machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "message"}}),
+        ));
+        output.extend(machine.apply(event(
+            "response.output_text.delta",
+            json!({"delta": "Hello"}),
+        )));
+        output.extend(machine.apply(event("response.output_text.done", json!({}))));
+        output.extend(machine.finish());
+        let final_json = machine.final_json();
+
+        assert!(output.iter().any(|frame| frame.contains("text_delta")));
+        assert_eq!(
+            final_json["content"][0],
+            json!({"type": "text", "text": "Hello"})
+        );
+    }
 }

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -430,8 +430,11 @@ impl AnthropicSseMachine {
             index: self.index,
             kind: BlockKind::Text,
         });
+        // Do NOT clear `text_citations` here: `annotation_added` can buffer a
+        // citation before the first `text_delta` opens the block, and
+        // `close_any` already clears the buffer when a text block closes. A
+        // clear at open time would drop those pre-delta citations.
         self.text_buffer.clear();
-        self.text_citations.clear();
         out.push(sse(
             "content_block_start",
             &json!({
@@ -440,6 +443,20 @@ impl AnthropicSseMachine {
                 "content_block": {"type": "text", "text": ""}
             }),
         ));
+        // Flush any citations buffered before this block opened. `annotation_added`
+        // stores a citation but can't stream its `citations_delta` while no text
+        // block is open, so emit them now that the block exists — otherwise
+        // streaming clients only ever see them in the final reconstructed block.
+        for citation in &self.text_citations {
+            out.push(sse(
+                "content_block_delta",
+                &json!({
+                    "type": "content_block_delta",
+                    "index": self.index,
+                    "delta": {"type": "citations_delta", "citation": citation}
+                }),
+            ));
+        }
         out
     }
 
@@ -1111,5 +1128,58 @@ mod tests {
             .unwrap()
             .iter()
             .all(|block| block["type"] != "text"));
+    }
+
+    #[test]
+    fn citation_before_first_text_delta_is_preserved() {
+        // `annotation.added` can arrive before the first `output_text.delta`.
+        // It buffers the citation in `text_citations`; the subsequent
+        // `open_text` must not clear that buffer, or the pre-delta citation is
+        // lost from the reconstructed text block.
+        let mut machine = AnthropicSseMachine::new("test", false, false);
+        let mut output = machine.apply(event(
+            "response.output_item.added",
+            json!({"item": {"type": "message"}}),
+        ));
+        output.extend(machine.apply(event(
+            "response.output_text.annotation.added",
+            json!({"annotation": {
+                "type": "url_citation",
+                "url": "https://example.com",
+                "title": "Example",
+                "cited_text": "quoted"
+            }}),
+        )));
+        output.extend(machine.apply(event(
+            "response.output_text.delta",
+            json!({"delta": "Hello"}),
+        )));
+        output.extend(machine.apply(event("response.output_text.done", json!({}))));
+        output.extend(machine.finish());
+        let final_json = machine.final_json();
+
+        // The buffered citation survives into the final reconstructed block...
+        assert_eq!(
+            final_json["content"][0],
+            json!({
+                "type": "text",
+                "text": "Hello",
+                "citations": [{
+                    "type": "web_search_result_location",
+                    "url": "https://example.com",
+                    "title": "Example",
+                    "cited_text": "quoted"
+                }]
+            })
+        );
+        // ...and streaming clients also receive it as a `citations_delta`, flushed
+        // when the lazily-opened text block starts.
+        assert!(
+            output
+                .iter()
+                .any(|frame| frame.contains("citations_delta")
+                    && frame.contains("https://example.com")),
+            "pre-delta citation must be streamed as a citations_delta frame"
+        );
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -293,6 +293,16 @@ pub(crate) fn normalize_empty_text_blocks(request: &mut Value) {
         let original = content.clone();
         content.retain(|block| !is_empty_text_block(block));
         if content.is_empty() {
+            // Reaching here means *every* block was empty text: a message with
+            // no text, tool_use, or thinking at all. The #132 poisoned turns
+            // (tool-only / reasoning-only) always carry a surviving tool_use or
+            // thinking block, so the adapter never produces this shape — it is a
+            // degenerate case only. Anthropic rejects both an empty `content`
+            // array and an empty text block, and dropping the message would
+            // break user/assistant alternation, so there is no local transform
+            // that makes such a message valid. We keep the first block as a
+            // last resort rather than risk an alternation error; the block may
+            // still be empty (see the `keeps_one_block...` test).
             if let Some(block) = original.into_iter().next() {
                 content.push(block);
             }
@@ -326,7 +336,7 @@ mod tests {
     use axum::http::Uri;
     use serde_json::json;
 
-    use super::{is_count_tokens, normalize_empty_text_blocks};
+    use super::{is_count_tokens, is_empty_text_block, normalize_empty_text_blocks};
 
     #[test]
     fn detects_count_tokens_path() {
@@ -366,14 +376,26 @@ mod tests {
         );
     }
 
+    // A message whose content is *only* empty text is a degenerate shape the
+    // #132 adapter path never produces (tool-only / reasoning-only turns always
+    // keep a tool_use or thinking block). Anthropic rejects both an empty
+    // `content` array and an empty text block, and dropping the message would
+    // break role alternation, so normalization keeps one block rather than risk
+    // an alternation error — meaning the surviving block may itself still be
+    // empty. This test pins that known limitation so the fallback is not
+    // mistaken for a fix that guarantees a non-empty survivor.
     #[test]
-    fn keeps_one_block_when_a_message_contains_only_empty_text() {
+    fn keeps_one_block_for_an_all_empty_text_message_even_if_still_empty() {
         let mut body = json!({
             "messages": [{"role": "assistant", "content": [{"type": "text", "text": "  "}]}]
         });
 
         normalize_empty_text_blocks(&mut body);
 
-        assert_eq!(body["messages"][0]["content"].as_array().unwrap().len(), 1);
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1, "must never leave an empty content array");
+        // Known limitation: with no non-empty block to fall back to, the
+        // surviving block is still the empty text block.
+        assert!(is_empty_text_block(&content[0]));
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -6,6 +6,7 @@ use axum::{
     http::{HeaderMap, HeaderValue, Method, StatusCode, Uri},
     response::IntoResponse,
 };
+use serde_json::Value;
 use tracing::Instrument;
 
 use crate::{
@@ -131,6 +132,7 @@ async fn forward(
                 response: UpstreamError::from_message(message).into_response(),
             }
         })?;
+    let body = normalize_request_body(body.to_vec());
     let route = routing::resolve(&state.config, &body).map_err(|error| ForwardError {
         message: "failed to route request".to_string(),
         response: error.into_response(),
@@ -167,7 +169,6 @@ async fn forward(
             CountTokens::Estimate => count_tokens_unsupported(),
         });
     }
-    let body = body.to_vec();
     let provider = route.provider.clone();
     let model = route.model.clone();
     let result = match route.adapter {
@@ -273,6 +274,40 @@ pub(crate) fn is_count_tokens(uri: &Uri) -> bool {
     uri.path().ends_with("/count_tokens")
 }
 
+fn normalize_request_body(body: Vec<u8>) -> Vec<u8> {
+    let Ok(mut request) = serde_json::from_slice::<Value>(&body) else {
+        return body;
+    };
+    normalize_empty_text_blocks(&mut request);
+    serde_json::to_vec(&request).unwrap_or(body)
+}
+
+pub(crate) fn normalize_empty_text_blocks(request: &mut Value) {
+    let Some(messages) = request.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for message in messages {
+        let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let original = content.clone();
+        content.retain(|block| !is_empty_text_block(block));
+        if content.is_empty() {
+            if let Some(block) = original.into_iter().next() {
+                content.push(block);
+            }
+        }
+    }
+}
+
+fn is_empty_text_block(block: &Value) -> bool {
+    block.get("type").and_then(Value::as_str) == Some("text")
+        && block
+            .get("text")
+            .and_then(Value::as_str)
+            .is_some_and(|text| text.trim().is_empty())
+}
+
 fn count_tokens_unsupported() -> (StatusCode, axum::response::Response) {
     let status = StatusCode::NOT_IMPLEMENTED;
     (
@@ -289,8 +324,9 @@ fn count_tokens_unsupported() -> (StatusCode, axum::response::Response) {
 #[cfg(test)]
 mod tests {
     use axum::http::Uri;
+    use serde_json::json;
 
-    use super::is_count_tokens;
+    use super::{is_count_tokens, normalize_empty_text_blocks};
 
     #[test]
     fn detects_count_tokens_path() {
@@ -303,5 +339,41 @@ mod tests {
                 .unwrap()
         ));
         assert!(!is_count_tokens(&"/v1/messages".parse::<Uri>().unwrap()));
+    }
+
+    #[test]
+    fn strips_empty_text_blocks_and_preserves_other_content() {
+        let mut body = json!({
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "  \n"},
+                    {"type": "thinking", "thinking": "reason"},
+                    {"type": "tool_use", "id": "tool_1", "name": "work", "input": {}}
+                ]
+            }]
+        });
+
+        normalize_empty_text_blocks(&mut body);
+
+        assert_eq!(
+            body["messages"][0]["content"],
+            json!([
+                {"type": "thinking", "thinking": "reason"},
+                {"type": "tool_use", "id": "tool_1", "name": "work", "input": {}}
+            ])
+        );
+    }
+
+    #[test]
+    fn keeps_one_block_when_a_message_contains_only_empty_text() {
+        let mut body = json!({
+            "messages": [{"role": "assistant", "content": [{"type": "text", "text": "  "}]}]
+        });
+
+        normalize_empty_text_blocks(&mut body);
+
+        assert_eq!(body["messages"][0]["content"].as_array().unwrap().len(), 1);
     }
 }

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -1,6 +1,7 @@
 use std::{io::ErrorKind, net::SocketAddr, time::Duration};
 
 use reqwest::StatusCode;
+use serde_json::{json, Value};
 use shunt::{
     config::{Config, CountTokens, RoutePrefixConfig},
     server,
@@ -627,6 +628,60 @@ async fn message_start_input_tokens_is_zero_when_count_tokens_estimate() {
         message_start_input_tokens(&sse),
         0,
         "estimate mode must leave message_start at 0; got:\n{sse}"
+    );
+    upstream.verify().await;
+}
+
+#[tokio::test]
+async fn messages_strip_empty_text_blocks_before_forwarding_upstream() {
+    // Regression for #132: a Codex/LiteLLM turn can persist an empty
+    // `{"type":"text","text":""}` block in the transcript. When the client
+    // switches back to a native Claude model, that poisoned request is
+    // forwarded to api.anthropic.com, which rejects empty text blocks with a
+    // 400 ("text content blocks must be non-empty"). The gateway must strip
+    // empty/whitespace-only text blocks on the way through (keeping tool_use /
+    // thinking) so the switch stays valid. This exercises the real forward()
+    // HTTP path end-to-end, not just the normalize_empty_text_blocks helper.
+    if !can_bind_loopback() {
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let request_body = json!({
+        "model": "claude-sonnet-4-5",
+        "messages": [{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {"type": "text", "text": "  \n"},
+                {"type": "tool_use", "id": "tool_1", "name": "work", "input": {}}
+            ]
+        }]
+    });
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .body(serde_json::to_vec(&request_body).unwrap())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let requests = upstream.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let forwarded: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(
+        forwarded["messages"][0]["content"],
+        json!([{"type": "tool_use", "id": "tool_1", "name": "work", "input": {}}]),
+        "empty text blocks must be stripped before reaching the upstream"
     );
     upstream.verify().await;
 }

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -846,7 +846,7 @@ fn translates_grok_web_search_results_and_citations_to_anthropic_blocks() {
 }
 
 #[test]
-fn citation_without_open_text_block_opens_one_and_omits_missing_encrypted_index() {
+fn citation_without_text_does_not_create_an_empty_text_block() {
     let fixture = concat!(
         "event: response.created\n",
         "data: {\"response\":{\"id\":\"resp_search\"}}\n\n",
@@ -864,30 +864,12 @@ fn citation_without_open_text_block_opens_one_and_omits_missing_encrypted_index(
     let names = event_names(&emitted);
     assert_eq!(
         names,
-        vec![
-            "message_start",
-            "ping",
-            "content_block_start",
-            "content_block_delta",
-            "content_block_stop",
-            "message_delta",
-            "message_stop"
-        ]
+        vec!["message_start", "ping", "message_delta", "message_stop"]
     );
     assert!(!emitted.contains("encrypted_index"));
 
     let final_json = machine.final_json();
-    assert_eq!(final_json["content"][0]["type"], "text");
-    assert_eq!(final_json["content"][0]["text"], "");
-    assert_eq!(
-        final_json["content"][0]["citations"][0]["url"],
-        "https://example.com/"
-    );
-    assert_eq!(final_json["content"][0]["citations"][0]["title"], "");
-    assert_eq!(final_json["content"][0]["citations"][0]["cited_text"], "");
-    assert!(final_json["content"][0]["citations"][0]
-        .get("encrypted_index")
-        .is_none());
+    assert!(final_json["content"].as_array().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Codex Responses turns that only call tools or reason emit a stray empty text content block, which Claude's Messages API rejects with a 400 when a conversation switches from a Codex-backed model to Claude.

## Milestone / spec

N/A — targeted bugfix in the Responses SSE translation layer.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it
- [ ] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [ ] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

- `src/model/responses.rs` — the SSE state machine no longer opens a text block on a `message` item-added event; `close_open` now skips emitting `content_block_stop` / pushing a content block when the buffered text is empty (whitespace-only), which covers tool-only and reasoning-only turns.
- `src/proxy.rs` — added a defensive `normalize_request_body` / `normalize_empty_text_blocks` layer in `forward()` that strips empty text blocks from inbound request bodies before routing, while keeping at least one block per message if all were empty (belt-and-suspenders in case an empty block still slips through from another producer).
- `tests/responses_translate.rs` — updated the citation-without-text test to assert no empty text block is emitted.

Closes #132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400s from Claude’s Messages API when switching from Codex-backed turns by dropping empty text blocks, keeping the SSE stream balanced for whitespace-only text, and preserving/streaming citations that arrive before the first text delta.

- **Bug Fixes**
  - SSE: no empty text blocks for tool-only, reasoning-only, or citation-only turns; whitespace-only text is dropped from final content while start/stop indexes stay balanced; citations buffered before the first text delta are preserved, streamed as citations_delta when the text block opens, and included in final content when text is non-empty.
  - Proxy: `normalize_request_body` runs before routing to strip empty/whitespace-only text blocks; keeps one block if all were empty (documented fallback).
  - Tests: added end-to-end passthrough test confirming upstream receives stripped content; unit tests cover balanced indexes, pre-delta citation streaming/preservation, and the all-empty-text fallback.

<sup>Written for commit 694e3227bf9faea3adf68bc4058f8cffe13f3c3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

