### PR TITLE
feat(codex): OpenAI-shaped error envelopes for gateway-owned errors on the inbound Codex endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - Write documentation and code in English.
 - Keep Rust files focused and preferably under 500 lines.
 - Preserve streaming semantics; do not buffer upstream SSE responses unless the client requested non-streaming output.
-- Keep gateway-owned errors in Anthropic error shape.
+- Keep gateway-owned errors in the Anthropic error shape, except on the inbound Codex endpoint (`[server.codex_endpoint]`), where gateway-owned errors use the OpenAI Responses error shape so its OpenAI-protocol clients parse them through their own error path (issue #127).
 - Prefer table-driven config additions over hardcoded provider logic.
 
 ## Documentation

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -161,9 +161,17 @@ Responses-shaped body it would have gotten from `chatgpt.com` directly, error or
 If every account fails **before** any upstream response is received at all (for example, every
 account's credentials are unresolvable), there is no real upstream body to relay, so shunt returns
 a gateway-owned `502 bad gateway` with the fixed message `all Codex OAuth accounts failed before
-receiving an upstream response`. This is Anthropic-shaped — the one gateway-owned error on this
-otherwise-passthrough path, since a Responses client has no better format to hand it than the same
-shape `/v1/messages` uses for its own gateway-owned errors.
+receiving an upstream response`.
+
+Every **gateway-owned** error on this endpoint — this 502, the inbound-auth `401`, an oversized or
+unreadable request body, an unconfigured endpoint, or an account-store scan failure — is returned
+in the **OpenAI Responses error shape** (`{"error":{"message":..,"type":..,"code":null}}`),
+preserving its status code, so a Codex CLI (or any OpenAI Responses client) parses it through its
+own error path rather than the Anthropic `{"type":"error",...}` envelope shunt uses elsewhere. This
+is the one deliberate exception to the byte-for-byte passthrough: relayed **upstream** errors
+(429/4xx/5xx from the backend) still pass through verbatim and unchanged. The re-shaping happens
+once, at the endpoint boundary (`codex_endpoint::post` → `error::into_openai_error_shape`), so the
+Anthropic Messages path keeps its own error shape untouched (issue #127).
 
 ## Single-account fallback
 

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -164,7 +164,7 @@ a gateway-owned `502 bad gateway` with the fixed message `all Codex OAuth accoun
 receiving an upstream response`.
 
 Every **gateway-owned** error on this endpoint — this 502, the inbound-auth `401`, an oversized or
-unreadable request body, or an account-store scan failure — is returned
+unreadable request body, a Codex endpoint disabled by hot reload, or an account-store scan failure — is returned
 in the **OpenAI Responses error shape** (`{"error":{"message":..,"type":..,"code":null}}`),
 preserving its status code, so a Codex CLI (or any OpenAI Responses client) parses it through its
 own error path rather than the Anthropic `{"type":"error",...}` envelope shunt uses elsewhere. This

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -164,7 +164,7 @@ a gateway-owned `502 bad gateway` with the fixed message `all Codex OAuth accoun
 receiving an upstream response`.
 
 Every **gateway-owned** error on this endpoint — this 502, the inbound-auth `401`, an oversized or
-unreadable request body, an unconfigured endpoint, or an account-store scan failure — is returned
+unreadable request body, or an account-store scan failure — is returned
 in the **OpenAI Responses error shape** (`{"error":{"message":..,"type":..,"code":null}}`),
 preserving its status code, so a Codex CLI (or any OpenAI Responses client) parses it through its
 own error path rather than the Anthropic `{"type":"error",...}` envelope shunt uses elsewhere. This

--- a/site/src/content/docs/guides/inbound-codex-endpoint.md
+++ b/site/src/content/docs/guides/inbound-codex-endpoint.md
@@ -92,6 +92,7 @@ With no `[[providers.codex.accounts]]` configured **and an empty shunt account s
 - **No translation.** The inbound Responses body is forwarded upstream byte-for-byte, and the upstream response — SSE or JSON, success or error — is relayed back verbatim (status and `content-type` preserved). There is no Anthropic Messages ⇄ Responses translation step at all.
 - **No model-based routing.** Every request goes to the one provider named in `[server.codex_endpoint]`; the body's `model` field forwards through as-is and never selects a provider.
 - **Exhaustion relays verbatim.** If every pooled account is tried and at least one upstream response came back, shunt relays that last response unchanged rather than re-shaping it into an Anthropic-style error, since a Responses client expects the raw shape it would have gotten from the real ChatGPT backend.
+- **Gateway-owned errors are OpenAI-shaped.** When the failure is shunt's own — a bad or missing client token (`401`), an unresolvable pool with no upstream response (`502`), an oversized request body, or an unconfigured endpoint — shunt returns it in the OpenAI Responses error shape (`{"error":{"message":…,"type":…,"code":null}}`) with the same status code, so the Codex CLI parses it through its own error path instead of the Anthropic `{"type":"error",…}` envelope. Relayed *upstream* errors (429/4xx/5xx from the backend) still pass through verbatim.
 - **HTTP/SSE only.** Even when the target provider has `websocket = true`, this endpoint always uses the HTTP transport.
 
 ## Security

--- a/src/codex_endpoint.rs
+++ b/src/codex_endpoint.rs
@@ -93,7 +93,13 @@ pub async fn post(
                     error = %error.message,
                     "inbound codex request failed"
                 );
-                error.response
+                // Gateway-owned errors on this endpoint are built with the gateway's
+                // Anthropic-shaped responders (`ShuntError` / `UpstreamError` /
+                // adapter+auth `AdapterError`s). A Codex CLI (or any OpenAI Responses
+                // client) pointed here expects the OpenAI `{"error":{...}}` envelope,
+                // so re-shape at this single boundary (status preserved). Relayed
+                // upstream errors never reach here — they return verbatim as `Ok`.
+                crate::error::into_openai_error_shape(error.response).await
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,8 +125,10 @@ struct OpenAiErrorDetail {
 /// behavior) is unchanged.
 pub async fn into_openai_error_shape(response: Response) -> Response {
     let status = response.status();
-    // Gateway-owned error bodies are tiny JSON envelopes; read the whole thing.
-    let body = to_bytes(response.into_body(), usize::MAX).await.ok();
+    // Gateway-owned error bodies are tiny JSON envelopes; cap the read at 64 KiB
+    // as defense-in-depth. The bound is never hit in practice, and an oversized
+    // body degrades to the empty-message fallback below rather than an OOM.
+    let body = to_bytes(response.into_body(), 64 * 1024).await.ok();
     let (kind, message) = body
         .as_deref()
         .and_then(|bytes| serde_json::from_slice::<Value>(bytes).ok())

--- a/src/error.rs
+++ b/src/error.rs
@@ -199,7 +199,7 @@ mod tests {
         assert!(body.get("type").is_none());
         assert_eq!(body["error"]["message"], "missing client token");
         assert_eq!(body["error"]["type"], "authentication_error");
-        assert!(body["error"]["code"].is_null());
+        assert!(body["error"].get("code").is_some_and(Value::is_null));
     }
 
     #[tokio::test]
@@ -209,9 +209,11 @@ mod tests {
         let reshaped = into_openai_error_shape(response).await;
         assert_eq!(reshaped.status(), StatusCode::BAD_GATEWAY);
         let body = body_json(reshaped).await;
+        // No top-level Anthropic `type:"error"` — else an unchanged envelope would pass.
+        assert!(body.get("type").is_none());
         assert_eq!(body["error"]["message"], "all Codex OAuth accounts failed");
         assert_eq!(body["error"]["type"], "api_error");
-        assert!(body["error"]["code"].is_null());
+        assert!(body["error"].get("code").is_some_and(Value::is_null));
     }
 
     #[tokio::test]
@@ -224,6 +226,6 @@ mod tests {
         let body = body_json(reshaped).await;
         assert_eq!(body["error"]["message"], "plain text boom");
         assert_eq!(body["error"]["type"], "api_error");
-        assert!(body["error"]["code"].is_null());
+        assert!(body["error"].get("code").is_some_and(Value::is_null));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,11 @@
 use axum::{
+    body::to_bytes,
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
 use serde::Serialize;
+use serde_json::Value;
 
 #[derive(Debug)]
 pub struct UpstreamError {
@@ -88,5 +90,140 @@ impl IntoResponse for ShuntError {
             }),
         )
             .into_response()
+    }
+}
+
+/// OpenAI Responses-shaped error body: `{"error":{"message":..,"type":..,"code":null}}`.
+/// Used only by the inbound Codex endpoint (`[server.codex_endpoint]`), whose
+/// clients speak the OpenAI Responses protocol and expect this envelope rather
+/// than the Anthropic `{"type":"error",...}` shape the gateway uses everywhere else.
+#[derive(Debug, Serialize)]
+struct OpenAiErrorBody {
+    error: OpenAiErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiErrorDetail {
+    message: String,
+    #[serde(rename = "type")]
+    kind: String,
+    /// Always `null` for gateway-owned errors — serialized (not skipped) so the
+    /// body matches the shape an OpenAI Responses client parses.
+    code: Option<String>,
+}
+
+/// Re-shape a gateway-owned, Anthropic-shaped error [`Response`] into the OpenAI
+/// Responses error envelope, preserving the HTTP status.
+///
+/// The inbound Codex endpoint reuses the gateway's Anthropic-shaped responders
+/// ([`ShuntError`], [`UpstreamError`], and the adapter/auth `AdapterError`s), but a
+/// Codex CLI — or any OpenAI Responses client — pointed at it expects
+/// `{"error":{...}}` instead, so its own error path can surface a meaningful
+/// message rather than a raw/garbled one. Relayed *upstream* errors never reach
+/// this: the passthrough returns them verbatim as `Ok`, so only shunt-owned
+/// failures are re-shaped here. The status code (and thus the client's retry
+/// behavior) is unchanged.
+pub async fn into_openai_error_shape(response: Response) -> Response {
+    let status = response.status();
+    // Gateway-owned error bodies are tiny JSON envelopes; read the whole thing.
+    let body = to_bytes(response.into_body(), usize::MAX).await.ok();
+    let (kind, message) = body
+        .as_deref()
+        .and_then(|bytes| serde_json::from_slice::<Value>(bytes).ok())
+        .and_then(|value| {
+            let detail = value.get("error")?;
+            let message = detail.get("message").and_then(Value::as_str)?.to_string();
+            // Preserve the Anthropic `error.type` (e.g. `authentication_error`,
+            // `api_error`) so the OpenAI-shaped `type` still carries the same
+            // gateway semantics; default defensively if it is ever absent.
+            let kind = detail
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("api_error")
+                .to_string();
+            Some((kind, message))
+        })
+        .unwrap_or_else(|| {
+            // The gateway-owned responders always emit the Anthropic envelope, so
+            // this only guards an unexpected body: keep the status and surface
+            // whatever text there was rather than an empty error.
+            let message = body
+                .as_deref()
+                .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+                .unwrap_or_default();
+            ("api_error".to_string(), message)
+        });
+    (
+        status,
+        Json(OpenAiErrorBody {
+            error: OpenAiErrorDetail {
+                message,
+                kind,
+                code: None,
+            },
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use serde_json::Value;
+
+    use super::{into_openai_error_shape, ShuntError, UpstreamError};
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        serde_json::from_slice(&bytes).expect("error body should be JSON")
+    }
+
+    #[tokio::test]
+    async fn reshapes_shunt_error_401_to_openai_shape() {
+        // A gateway-owned auth failure keeps its 401 status but is re-wrapped in
+        // the OpenAI `{"error":{message,type,code}}` envelope, preserving the type.
+        let response = ShuntError::new(
+            StatusCode::UNAUTHORIZED,
+            "authentication_error",
+            "missing client token",
+        )
+        .into_response();
+        let reshaped = into_openai_error_shape(response).await;
+        assert_eq!(reshaped.status(), StatusCode::UNAUTHORIZED);
+        let body = body_json(reshaped).await;
+        // OpenAI shape: no top-level `type: "error"`, and the detail is under `error`.
+        assert!(body.get("type").is_none());
+        assert_eq!(body["error"]["message"], "missing client token");
+        assert_eq!(body["error"]["type"], "authentication_error");
+        assert!(body["error"]["code"].is_null());
+    }
+
+    #[tokio::test]
+    async fn reshapes_upstream_error_502_to_openai_shape() {
+        let response =
+            UpstreamError::from_message("all Codex OAuth accounts failed").into_response();
+        let reshaped = into_openai_error_shape(response).await;
+        assert_eq!(reshaped.status(), StatusCode::BAD_GATEWAY);
+        let body = body_json(reshaped).await;
+        assert_eq!(body["error"]["message"], "all Codex OAuth accounts failed");
+        assert_eq!(body["error"]["type"], "api_error");
+        assert!(body["error"]["code"].is_null());
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_body_is_not_the_anthropic_envelope() {
+        // A non-Anthropic body must still yield a valid OpenAI error (status kept,
+        // raw text surfaced) rather than an empty or panicking response.
+        let response = (StatusCode::BAD_GATEWAY, "plain text boom").into_response();
+        let reshaped = into_openai_error_shape(response).await;
+        assert_eq!(reshaped.status(), StatusCode::BAD_GATEWAY);
+        let body = body_json(reshaped).await;
+        assert_eq!(body["error"]["message"], "plain text boom");
+        assert_eq!(body["error"]["type"], "api_error");
+        assert!(body["error"]["code"].is_null());
     }
 }

--- a/tests/inbound_codex_endpoint.rs
+++ b/tests/inbound_codex_endpoint.rs
@@ -1110,9 +1110,14 @@ fn assert_openai_error_shape(body: &serde_json::Value, expected_type: &str) {
         "expected a non-empty error.message, got {body}"
     );
     assert_eq!(body["error"]["type"], expected_type);
+    // `Value` indexing returns `Null` for a missing key, so require `code` to be
+    // present AND null — otherwise a regression that dropped the field entirely
+    // (e.g. `skip_serializing_if`) would still pass.
     assert!(
-        body["error"]["code"].is_null(),
-        "expected error.code to be null, got {body}"
+        body["error"]
+            .get("code")
+            .is_some_and(serde_json::Value::is_null),
+        "expected error.code to be present and null, got {body}"
     );
 }
 
@@ -1172,8 +1177,9 @@ async fn gateway_owned_502_body_is_openai_shaped() {
     let missing_env = format!("SHUNT_TEST_INBOUND_502_MISSING_{}", std::process::id());
     std::env::remove_var(&missing_env);
 
-    // base_url is never used (no upstream call happens); point it at an unreachable
-    // loopback address to prove no request escapes.
+    // Resolution fails before any upstream call, so base_url is never used; point
+    // it at an unreachable loopback address as a backstop, so no real request could
+    // escape even if that assumption regressed.
     let gateway = start_gateway_with(test_config(
         "http://127.0.0.1:1",
         vec![account("account-502-shape", &missing_env)],

--- a/tests/inbound_codex_endpoint.rs
+++ b/tests/inbound_codex_endpoint.rs
@@ -1094,6 +1094,102 @@ async fn refresh_retry_still_unauthorized_rotates_to_next_account() {
     fs::remove_dir_all(&dir).ok();
 }
 
+/// Assert a gateway-owned error body is OpenAI Responses-shaped
+/// (`{"error":{"message","type","code":null}}`) and NOT the Anthropic envelope
+/// (`{"type":"error","error":{...}}`) — the distinction issue #127 turns on.
+fn assert_openai_error_shape(body: &serde_json::Value, expected_type: &str) {
+    // Anthropic errors carry a top-level `"type":"error"`; the OpenAI shape does not.
+    assert!(
+        body.get("type").is_none(),
+        "expected OpenAI shape without a top-level `type`, got {body}"
+    );
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| !message.is_empty()),
+        "expected a non-empty error.message, got {body}"
+    );
+    assert_eq!(body["error"]["type"], expected_type);
+    assert!(
+        body["error"]["code"].is_null(),
+        "expected error.code to be null, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn gateway_owned_401_body_is_openai_shaped() {
+    // A gateway-owned auth failure (bad/missing client token) must reach an OpenAI
+    // Responses client in its own error envelope, not the Anthropic one, so the
+    // Codex CLI surfaces a meaningful message. Status stays 401.
+    if !can_bind_loopback() {
+        return;
+    }
+    let token_a = chatgpt_token(FAR_FUTURE_EXP, "acct-401-shape");
+    std::env::set_var("SHUNT_TEST_INBOUND_401_SHAPE", &token_a);
+    let tokens_env = format!("SHUNT_TEST_INBOUND_401_SHAPE_TOKENS_{}", std::process::id());
+    std::env::set_var(&tokens_env, "cli:secret-token");
+
+    // The upstream is never contacted — auth fails first — so no mock is needed.
+    let upstream = MockServer::start().await;
+    let mut config = test_config(
+        &upstream.uri(),
+        vec![account("account-401-shape", "SHUNT_TEST_INBOUND_401_SHAPE")],
+    );
+    config.server.auth = Some(InboundAuthConfig {
+        header: "x-shunt-token".to_string(),
+        tokens_env: tokens_env.clone(),
+    });
+    let gateway = start_gateway_with(config).await;
+
+    // No client token → 401 before any upstream call.
+    let response = post_responses(&gateway, "/responses", None, None).await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body: serde_json::Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_openai_error_shape(&body, "authentication_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("client token"),
+        "expected the auth failure message, got {body}"
+    );
+
+    std::env::remove_var("SHUNT_TEST_INBOUND_401_SHAPE");
+    std::env::remove_var(&tokens_env);
+}
+
+#[tokio::test]
+async fn gateway_owned_502_body_is_openai_shaped() {
+    // When every pooled account fails to resolve *before* any upstream response,
+    // there is no upstream body to relay, so shunt returns its own 502 — which must
+    // be OpenAI-shaped on this endpoint, not the Anthropic envelope.
+    if !can_bind_loopback() {
+        return;
+    }
+    // A single account whose `token_env` is deliberately unset: resolution fails,
+    // the account cools down, and with no other account the pool is exhausted with
+    // no upstream ever contacted → the gateway-owned 502.
+    let missing_env = format!("SHUNT_TEST_INBOUND_502_MISSING_{}", std::process::id());
+    std::env::remove_var(&missing_env);
+
+    // base_url is never used (no upstream call happens); point it at an unreachable
+    // loopback address to prove no request escapes.
+    let gateway = start_gateway_with(test_config(
+        "http://127.0.0.1:1",
+        vec![account("account-502-shape", &missing_env)],
+    ))
+    .await;
+
+    let response = post_responses(&gateway, "/v1/responses", None, None).await;
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    let body: serde_json::Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_openai_error_shape(&body, "api_error");
+    assert_eq!(
+        body["error"]["message"],
+        "all Codex OAuth accounts failed before receiving an upstream response"
+    );
+}
+
 #[tokio::test]
 async fn refresh_retry_non_success_rotates_to_next_account() {
     // Refresh succeeds but the refreshed retry fails with a non-401 non-2xx (5xx):


### PR DESCRIPTION
## Summary

The inbound Codex endpoint (`[server.codex_endpoint]`, M11) relays upstream ChatGPT/Codex responses verbatim, but gateway-generated errors were still returned in the Anthropic error envelope. OpenAI Responses clients expect `{"error":{"message":...,"type":...,"code":null}}`, so these failures could surface as raw or garbled errors.

This change reshapes gateway-owned errors once at the inbound Codex boundary while leaving relayed upstream responses and the Anthropic Messages path unchanged.

## Milestone / spec

M11 — `docs/m11-inbound-codex-endpoint.md`

Closes #127

## Changes

- Add `error::into_openai_error_shape(Response) -> Response`, preserving HTTP status and error-type semantics while defensively handling unexpected bodies.
- Apply the reshaper only to `codex_endpoint::post`'s `Err` path; upstream responses continue through `Ok` byte-for-byte.
- Cover gateway-owned 401 and 502 responses with integration tests, plus three focused unit tests for the reshaper.
- Update the M11 specification and inbound Codex endpoint user guide.
- Intentionally leave the issue's optional `own_error` log-field cleanup out of scope.

## Acceptance criteria

- [x] Each shunt-owned error on all three Codex routes returns an OpenAI-shaped `{"error":{...}}` body with the original status code.
- [x] Relayed upstream errors remain byte-for-byte verbatim.
- [x] Tests assert that gateway-owned 401 and 502 bodies use the OpenAI shape.

## Checklist

- [ ] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

The key boundary is `codex_endpoint::post`: all gateway-owned failures enter its `Err` arm, while upstream HTTP/SSE responses enter `Ok`. Reviewers should verify that the conversion remains confined to that `Err` arm so upstream response bodies stay verbatim and Anthropic-facing routes remain unaffected.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` (530 library tests plus all integration suites, including 5 new tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return OpenAI Responses-shaped error envelopes for gateway-owned failures on the inbound Codex endpoint so Codex/OpenAI clients parse errors correctly. Upstream responses (including upstream errors) remain relayed verbatim.

- New Features
  - Added `error::into_openai_error_shape(Response) -> Response` to emit `{"error":{"message","type","code":null}}` while preserving HTTP status.
  - Applied only on the `Err` path in `codex_endpoint::post`; Anthropic Messages path and relayed upstream errors are unchanged.
  - Covers gateway-owned 401/502 and similar failures (e.g., oversized body, unconfigured or hot-reload-disabled endpoint, account-store scan failure); upstream 429/4xx/5xx still pass through.

- Bug Fixes
  - Bounded error-body read to 64 KiB and added a safe fallback when the body isn’t Anthropic-shaped.
  - Hardened tests: require `error.code` to be present and null; assert no top-level `type:"error"` on 502.
  - Docs updated: noted the sanctioned exception in `AGENTS.md` and the hot-reload-disabled endpoint case (issue #127).

<sup>Written for commit d3e62d9bb83345c1bca07aed5e42b0ccdf396e84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

