### PR TITLE
chore(codex): bump mirrored Codex CLI identity to rust-v0.144.4

### DIFF
--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -172,12 +172,12 @@ For a Codex request shunt sends the Codex-CLI identity so client-version gating 
 | `authorization` | `Bearer <access_token>` |
 | `chatgpt-account-id` | `<account_id>` |
 | `originator` | `codex_cli_rs` |
-| `user-agent` | `codex_cli_rs/0.144.1` (`CODEX_USER_AGENT`) |
-| `version` | `0.144.1` (`CODEX_CLIENT_VERSION`) |
+| `user-agent` | `codex_cli_rs/0.144.4` (`CODEX_USER_AGENT`) |
+| `version` | `0.144.4` (`CODEX_CLIENT_VERSION`) |
 | `OpenAI-Beta` | `responses=experimental` |
 | `content-type` | `application/json` |
 
-The `user-agent` / `version` are **pinned to openai/codex rust-v0.144.1**. If a future slug
+The `user-agent` / `version` are **pinned to openai/codex rust-v0.144.4**. If a future slug
 demands a newer client, bump `CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION` in
 `src/adapters/responses/request.rs`.
 
@@ -694,7 +694,7 @@ auto-discovered accounts, so imported store logins still get pooling.)
 - No model-based routing — every inbound request goes to the one configured provider, regardless
   of the `model` field in the body.
 - **Verbatim header passthrough.** The outbound path *synthesizes* the Codex identity headers of
-  §4.4 (pinned `originator`/`user-agent`/`version=codex_cli_rs/0.144.1`, `OpenAI-Beta`, session
+  §4.4 (pinned `originator`/`user-agent`/`version=codex_cli_rs/0.144.4`, `OpenAI-Beta`, session
   headers). The inbound endpoint does **not** — the client already *is* a Codex CLI, so its own
   request headers (`version`, `originator`, `OpenAI-Beta`, `x-codex-*`, …) are forwarded unchanged
   and shunt swaps in **only** the pool account's `Authorization` + `chatgpt-account-id` (and strips

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -694,7 +694,7 @@ auto-discovered accounts, so imported store logins still get pooling.)
 - No model-based routing — every inbound request goes to the one configured provider, regardless
   of the `model` field in the body.
 - **Verbatim header passthrough.** The outbound path *synthesizes* the Codex identity headers of
-  §4.4 (pinned `originator`/`user-agent`/`version=codex_cli_rs/0.144.4`, `OpenAI-Beta`, session
+  §4.4 (pinned `originator`/`user-agent=codex_cli_rs/0.144.4`/`version=0.144.4`, `OpenAI-Beta`, session
   headers). The inbound endpoint does **not** — the client already *is* a Codex CLI, so its own
   request headers (`version`, `originator`, `OpenAI-Beta`, `x-codex-*`, …) are forwarded unchanged
   and shunt swaps in **only** the pool account's `Authorization` + `chatgpt-account-id` (and strips

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -85,7 +85,7 @@ the Codex CLI speaks the same wire protocol to shunt that it would speak directl
 Because the inbound client **is** a real Codex CLI (unlike the `/v1/messages` path, where shunt
 *impersonates* one), the passthrough forwards the client's **own request headers verbatim** rather
 than synthesizing them. shunt's translating path builds a fresh request with a hardcoded Codex
-identity (`originator=codex_cli_rs`, `user-agent`/`version=codex_cli_rs/0.144.1`,
+identity (`originator=codex_cli_rs`, `user-agent`/`version=codex_cli_rs/0.144.4`,
 `OpenAI-Beta: responses=experimental`, and session/window headers derived from the session id); the
 inbound passthrough does **not** — it forwards whatever `version`, `originator`, `user-agent`,
 `OpenAI-Beta`, `session-id`, `thread-id`, `x-codex-window-id`, `x-codex-*`, `content-type`, and

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -85,7 +85,7 @@ the Codex CLI speaks the same wire protocol to shunt that it would speak directl
 Because the inbound client **is** a real Codex CLI (unlike the `/v1/messages` path, where shunt
 *impersonates* one), the passthrough forwards the client's **own request headers verbatim** rather
 than synthesizing them. shunt's translating path builds a fresh request with a hardcoded Codex
-identity (`originator=codex_cli_rs`, `user-agent`/`version=codex_cli_rs/0.144.4`,
+identity (`originator=codex_cli_rs`, `user-agent=codex_cli_rs/0.144.4`, `version=0.144.4`,
 `OpenAI-Beta: responses=experimental`, and session/window headers derived from the session id); the
 inbound passthrough does **not** — it forwards whatever `version`, `originator`, `user-agent`,
 `OpenAI-Beta`, `session-id`, `thread-id`, `x-codex-window-id`, `x-codex-*`, `content-type`, and

--- a/docs/running.md
+++ b/docs/running.md
@@ -543,7 +543,7 @@ an accurate window, one model at a time. (Subagents are a separate path — see 
 > on the `originator` + `version` headers ([openai/codex#31967](https://github.com/openai/codex/issues/31967)).
 > shunt therefore sends the Codex CLI identity headers (`originator: codex_cli_rs`,
 > `version`, and a matching `user-agent`) on ChatGPT OAuth requests, **pinned to
-> openai/codex rust-v0.144.1**. If a future slug demands a newer client, bump the pinned
+> openai/codex rust-v0.144.4**. If a future slug demands a newer client, bump the pinned
 > version in `src/adapters/responses/request.rs` (`CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`).
 
 Per-context selection also works via Claude Code's own knobs — divert one agent to a mapped model

--- a/site/src/content/docs/guides/codex.md
+++ b/site/src/content/docs/guides/codex.md
@@ -106,7 +106,7 @@ earlier ones (a free account has resolved to `gpt-5.5`). shunt surfaces the back
 Some slugs carry a `minimal_client_version` (e.g. `gpt-5.6-luna` needs ≥ 0.144.0). When the
 request's client identity is missing or too old the backend answers `Model not found <slug>`.
 shunt avoids this by sending the pinned Codex CLI identity headers (`originator: codex_cli_rs`,
-`user-agent`, `version`), pinned to **openai/codex rust-v0.144.1**. See
+`user-agent`, `version`), pinned to **openai/codex rust-v0.144.4**. See
 [openai/codex#31967](https://github.com/openai/codex/issues/31967).
 :::
 

--- a/site/src/content/docs/ja/guides/codex.md
+++ b/site/src/content/docs/ja/guides/codex.md
@@ -80,7 +80,7 @@ ChatGPT アカウントのバックエンドは `gpt-*-codex` スラッグ（例
 :::
 
 :::note[`Model not found <slug>` は entitlement ではなくクライアントバージョンのゲーティング]
-一部のスラッグは `minimal_client_version` を持ちます（例 `gpt-5.6-luna` は ≥ 0.144.0 が必要）。リクエストのクライアント identity が欠落しているか古すぎる場合、バックエンドは `Model not found <slug>` と応答します。shunt は固定された Codex CLI の identity ヘッダー（`originator: codex_cli_rs`、`user-agent`、`version`）を **openai/codex rust-v0.144.1** に固定して送ることで、これを回避します。[openai/codex#31967](https://github.com/openai/codex/issues/31967) を参照してください。
+一部のスラッグは `minimal_client_version` を持ちます（例 `gpt-5.6-luna` は ≥ 0.144.0 が必要）。リクエストのクライアント identity が欠落しているか古すぎる場合、バックエンドは `Model not found <slug>` と応答します。shunt は固定された Codex CLI の identity ヘッダー（`originator: codex_cli_rs`、`user-agent`、`version`）を **openai/codex rust-v0.144.4** に固定して送ることで、これを回避します。[openai/codex#31967](https://github.com/openai/codex/issues/31967) を参照してください。
 :::
 
 ## 4. Claude Code でモデルを選択する

--- a/site/src/content/docs/ko/guides/codex.md
+++ b/site/src/content/docs/ko/guides/codex.md
@@ -76,7 +76,7 @@ ChatGPT 계정 백엔드는 `gpt-*-codex` 슬러그(예: `gpt-5.2-codex`)를 `40
 :::
 
 :::note[`Model not found <slug>`는 자격이 아니라 클라이언트 버전 게이팅입니다]
-일부 슬러그는 `minimal_client_version`을 요구합니다(예: `gpt-5.6-luna`는 ≥ 0.144.0 필요). 요청의 클라이언트 신원이 없거나 너무 오래되면 백엔드는 `Model not found <slug>`를 반환합니다. shunt는 고정된 Codex CLI 신원 헤더(`originator: codex_cli_rs`, `user-agent`, `version`)를 **openai/codex rust-v0.144.1**에 고정하여 보내므로 이를 피합니다. [openai/codex#31967](https://github.com/openai/codex/issues/31967)을 참고하세요.
+일부 슬러그는 `minimal_client_version`을 요구합니다(예: `gpt-5.6-luna`는 ≥ 0.144.0 필요). 요청의 클라이언트 신원이 없거나 너무 오래되면 백엔드는 `Model not found <slug>`를 반환합니다. shunt는 고정된 Codex CLI 신원 헤더(`originator: codex_cli_rs`, `user-agent`, `version`)를 **openai/codex rust-v0.144.4**에 고정하여 보내므로 이를 피합니다. [openai/codex#31967](https://github.com/openai/codex/issues/31967)을 참고하세요.
 :::
 
 ## 4. Claude Code에서 모델 선택

--- a/site/src/content/docs/zh-cn/guides/codex.md
+++ b/site/src/content/docs/zh-cn/guides/codex.md
@@ -103,7 +103,7 @@ ChatGPT 账户后端**拒绝** `gpt-*-codex` slug(例如 `gpt-5.2-codex`),返回
 一些 slug 带有 `minimal_client_version`(例如 `gpt-5.6-luna` 需要 ≥ 0.144.0)。当
 请求的客户端身份缺失或过旧时,后端会应答 `Model not found <slug>`。
 shunt 通过发送固定的 Codex CLI 身份头(`originator: codex_cli_rs`、
-`user-agent`、`version`)来避免这一点,固定到 **openai/codex rust-v0.144.1**。见
+`user-agent`、`version`)来避免这一点,固定到 **openai/codex rust-v0.144.4**。见
 [openai/codex#31967](https://github.com/openai/codex/issues/31967)。
 :::
 

--- a/src/adapters/responses/request.rs
+++ b/src/adapters/responses/request.rs
@@ -3,7 +3,7 @@
 
 use crate::{auth::Credential, routing::Route, server::AppState};
 
-/// Codex CLI client identity, mirrored from openai/codex rust-v0.144.1.
+/// Codex CLI client identity, mirrored from openai/codex rust-v0.144.4.
 ///
 /// The ChatGPT backend routes newer model slugs (e.g. gpt-5.6-luna, which has
 /// `minimal_client_version: 0.144.0`) by client identity and answers
@@ -15,8 +15,8 @@ use crate::{auth::Credential, routing::Route, server::AppState};
 /// (codex-rs/login/src/auth/default_client.rs) and sends the bare CLI
 /// version in a `version` header (codex-rs/model-provider-info/src/lib.rs).
 /// Bump both together when a new slug requires a newer client version.
-pub(super) const CODEX_USER_AGENT: &str = "codex_cli_rs/0.144.1";
-pub(super) const CODEX_CLIENT_VERSION: &str = "0.144.1";
+pub(super) const CODEX_USER_AGENT: &str = "codex_cli_rs/0.144.4";
+pub(super) const CODEX_CLIENT_VERSION: &str = "0.144.4";
 
 /// Grok CLI identity, mirrored from the official Grok CLI (via
 /// raine/claude-code-proxy `src/providers/grok/client.rs`). The subscription

--- a/tests/inbound_codex_endpoint.rs
+++ b/tests/inbound_codex_endpoint.rs
@@ -571,7 +571,7 @@ async fn authorization_bearer_authenticates_the_endpoint() {
 async fn forwards_client_identity_headers_verbatim_and_strips_shunt_token() {
     // codex -> shunt -> codex swaps ONLY the credential headers. The Codex CLI's
     // own identity headers reach the backend verbatim — shunt does NOT resynthesize
-    // them from a hardcoded `codex_cli_rs/0.144.1` / `responses=experimental`, so a
+    // them from a hardcoded `codex_cli_rs/0.144.4` / `responses=experimental`, so a
     // newer client's real version drives model version gating — while the shunt
     // client-token header is stripped and never leaks upstream.
     if !can_bind_loopback() {


### PR DESCRIPTION
## Summary

Bump shunt's mirrored Codex CLI client identity from `codex_cli_rs/0.144.1` to `codex_cli_rs/0.144.4`, matching the latest upstream stable `openai/codex` release from 2026-07-14.

This is routine fidelity maintenance only. An audit of upstream versions 0.144.1 through 0.144.4, plus 0.145.0-alpha.13, found no protocol-surface change requiring an adapter fix: identity-header generation, server-side model-version gating, and the WebSocket v2 beta value (`responses_websockets=2026-02-06`) remain unchanged.

The change updates `CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`, related mirror and test comments, and pinned identity references across the engineering and localized site documentation. It does not change functional behavior.

## Milestone / spec

- `docs/codex-configuration.md`
- `docs/running.md`
- `docs/m11-inbound-codex-endpoint.md`

## Checklist

- [ ] `cargo build` passes
- [ ] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

Verification completed:

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Request identity unit tests
- `inbound_codex_endpoint` integration tests (17 tests)

Review focus: confirm the mirrored identity is consistently pinned to `rust-v0.144.4` / `codex_cli_rs/0.144.4` across source, tests, and documentation. No issue is linked to this maintenance change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the mirrored Codex CLI identity to `codex_cli_rs/0.144.4` to match upstream and keep model-version gating accurate. Bumps `CODEX_USER_AGENT`/`CODEX_CLIENT_VERSION` and clarifies docs/tests that `user-agent=codex_cli_rs/0.144.4` while `version=0.144.4`; no functional changes.

<sup>Written for commit d79c9f64e7b929234c618370c4e0f7909a4df939. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

