### PR TITLE
perf(request-body): avoid redundant parse/serialize/clone on the hot path

### DIFF
--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -585,7 +585,7 @@ fn content_blocks(content: Option<&Value>) -> Cow<'_, [Value]> {
     match content {
         Some(Value::String(text)) => Cow::Owned(vec![json!({"type": "text", "text": text})]),
         Some(Value::Array(blocks)) => Cow::Borrowed(blocks),
-        _ => Cow::Owned(Vec::new()),
+        _ => Cow::Borrowed(&[]),
     }
 }
 

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -119,7 +120,7 @@ pub fn translate_request(
     }
     out.insert(
         "input".to_string(),
-        json!(input_items(&request, &tool_search)),
+        Value::Array(input_items(&request, &tool_search)),
     );
     // Only emit tools/tool_choice when at least one tool survives translation.
     // The hosted web-search tool is dropped on flavors that reject it (xAI), and
@@ -279,18 +280,18 @@ fn input_items(request: &Value, context: &ToolSearchContext) -> Vec<Value> {
         );
         let blocks = content_blocks(message.get("content"));
         let mut pending = Vec::new();
-        for block in blocks {
+        for block in blocks.iter() {
             match block.get("type").and_then(Value::as_str) {
-                Some("text") => text_part(role, &block, &mut pending),
-                Some("image") => image_part(&block, &mut pending),
-                Some("document") => document_part(&block, &mut pending),
-                Some("tool_use") => tool_use_item(&mut out, role, &mut pending, &block, context),
+                Some("text") => text_part(role, block, &mut pending),
+                Some("image") => image_part(block, &mut pending),
+                Some("document") => document_part(block, &mut pending),
+                Some("tool_use") => tool_use_item(&mut out, role, &mut pending, block, context),
                 Some("tool_result") => {
-                    tool_result_item(&mut out, role, &mut pending, &block, context)
+                    tool_result_item(&mut out, role, &mut pending, block, context)
                 }
-                Some("thinking") => reasoning_item(&mut out, role, &mut pending, &block),
+                Some("thinking") => reasoning_item(&mut out, role, &mut pending, block),
                 Some("redacted_thinking") => {
-                    redacted_reasoning_item(&mut out, role, &mut pending, &block)
+                    redacted_reasoning_item(&mut out, role, &mut pending, block)
                 }
                 _ => {}
             }
@@ -580,11 +581,11 @@ fn reasoning_input_item(id: &str, encrypted_content: &str, summary: &str) -> Val
     item
 }
 
-fn content_blocks(content: Option<&Value>) -> Vec<Value> {
+fn content_blocks(content: Option<&Value>) -> Cow<'_, [Value]> {
     match content {
-        Some(Value::String(text)) => vec![json!({"type": "text", "text": text})],
-        Some(Value::Array(blocks)) => blocks.clone(),
-        _ => Vec::new(),
+        Some(Value::String(text)) => Cow::Owned(vec![json!({"type": "text", "text": text})]),
+        Some(Value::Array(blocks)) => Cow::Borrowed(blocks),
+        _ => Cow::Owned(Vec::new()),
     }
 }
 
@@ -592,8 +593,13 @@ fn flush_message(out: &mut Vec<Value>, role: &str, pending: &mut Vec<Value>) {
     if pending.is_empty() {
         return;
     }
-    out.push(json!({"type": "message", "role": role, "content": pending}));
-    pending.clear();
+    // Move the accumulated blocks into the message instead of serializing them
+    // into a fresh JSON tree (`json!` would deep-copy the whole content array).
+    let mut message = Map::with_capacity(3);
+    message.insert("type".to_string(), Value::from("message"));
+    message.insert("role".to_string(), Value::from(role));
+    message.insert("content".to_string(), Value::Array(std::mem::take(pending)));
+    out.push(Value::Object(message));
 }
 
 /// Claude Code's tool-search feature puts `{type:"tool_reference", tool_name}`

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -278,36 +278,46 @@ fn normalize_request_body(body: Vec<u8>) -> Vec<u8> {
     let Ok(mut request) = serde_json::from_slice::<Value>(&body) else {
         return body;
     };
-    normalize_empty_text_blocks(&mut request);
-    serde_json::to_vec(&request).unwrap_or(body)
+    // Re-serialize only when a block was actually dropped. The common case (no
+    // empty text block) keeps the original bytes and skips the encode entirely.
+    if normalize_empty_text_blocks(&mut request) {
+        serde_json::to_vec(&request).unwrap_or(body)
+    } else {
+        body
+    }
 }
 
-pub(crate) fn normalize_empty_text_blocks(request: &mut Value) {
+pub(crate) fn normalize_empty_text_blocks(request: &mut Value) -> bool {
     let Some(messages) = request.get_mut("messages").and_then(Value::as_array_mut) else {
-        return;
+        return false;
     };
+    let mut changed = false;
     for message in messages {
         let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) else {
             continue;
         };
-        let original = content.clone();
-        content.retain(|block| !is_empty_text_block(block));
-        if content.is_empty() {
-            // Reaching here means *every* block was empty text: a message with
-            // no text, tool_use, or thinking at all. The #132 poisoned turns
-            // (tool-only / reasoning-only) always carry a surviving tool_use or
-            // thinking block, so the adapter never produces this shape — it is a
+        if content.iter().all(is_empty_text_block) {
+            // Every block is empty text: a message with no text, tool_use, or
+            // thinking at all. The #132 poisoned turns (tool-only /
+            // reasoning-only) always carry a surviving tool_use or thinking
+            // block, so the adapter never produces this shape — it is a
             // degenerate case only. Anthropic rejects both an empty `content`
             // array and an empty text block, and dropping the message would
             // break user/assistant alternation, so there is no local transform
-            // that makes such a message valid. We keep the first block as a
-            // last resort rather than risk an alternation error; the block may
-            // still be empty (see the `keeps_one_block...` test).
-            if let Some(block) = original.into_iter().next() {
-                content.push(block);
+            // that makes such a message valid. Keep the first block as a last
+            // resort (truncating in place, no clone); the block may still be
+            // empty (see the `keeps_one_block...` test).
+            if content.len() > 1 {
+                content.truncate(1);
+                changed = true;
             }
+        } else {
+            let before = content.len();
+            content.retain(|block| !is_empty_text_block(block));
+            changed |= content.len() != before;
         }
     }
+    changed
 }
 
 fn is_empty_text_block(block: &Value) -> bool {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -386,6 +386,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn truncates_an_all_empty_text_message_to_one_block() {
+        let mut body = json!({
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "  \n"}
+                ]
+            }]
+        });
+
+        assert!(normalize_empty_text_blocks(&mut body));
+
+        let content = body["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1, "must retain exactly one content block");
+        assert!(is_empty_text_block(&content[0]));
+    }
+
     // A message whose content is *only* empty text is a degenerate shape the
     // #132 adapter path never produces (tool-only / reasoning-only turns always
     // keep a tool_use or thinking block). Anthropic rejects both an empty


### PR DESCRIPTION
## Summary

Removes redundant JSON parse / re-serialize / deep-clone of the request body on the per-request hot path. On long Claude Code sessions (the full conversation history is sent each turn) these copies scale with body size and run on every request.

## Changes

- **`proxy::normalize_request_body`** — re-serializes only when an empty text block is actually dropped (the common case keeps the original bytes and skips the encode). `normalize_empty_text_blocks` filters in place (no per-message `content.clone()`) and returns whether it changed anything.
- **`responses_request::content_blocks`** — borrows array-shaped content via `Cow` instead of `blocks.clone()`.
- **`responses_request::flush_message`** — moves pending blocks into the message with `mem::take` instead of re-serializing them via `json!`.
- **`translate_request`** — wraps `input_items` in `Value::Array` instead of `json!(...)`, which deep-copies the whole translated history.

## Behavior

Functionally equivalent. Existing tests pass unchanged (`cargo test --all-features --workspace`); `fmt` / `clippy -D warnings` are clean; streaming semantics and the Anthropic error shape are preserved.

**Wire-representation note:** when no empty text block is dropped, the request body is now passed **verbatim** instead of being re-serialized. This restores the pre-#141 passthrough behavior — `normalize_request_body` was added in #141 (the empty-block fix), and re-serializing every valid body (which sorts object keys, since `serde_json` builds without `preserve_order`) was an unintended side effect. JSON key order / whitespace is semantically insignificant to upstream and to prompt caching, so this is functionally equivalent while avoiding the per-request re-encode on the common (unchanged) path.

## Measurement

Regression-guarded by the CodSpeed `translate_request` / `count_input_tokens` benchmarks added in #147 — this PR's CodSpeed report will show the delta against the `main` baseline.

## Scope note

`adapters/anthropic::rewrite_account_uuid` (per-account body clone + double serialize) is deferred to a follow-up on #150 — it needs a `Bytes`/borrow change with a wider blast radius.

Closes #150
Part of #149
