### PR TITLE
perf(codex): bound WebSocket event channel

### DIFF
--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -29,7 +29,7 @@
 //! only ever valid on the exact connection that produced it, which is why the
 //! continuation state is stored on the [`Connection`] rather than globally.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
@@ -79,6 +79,11 @@ const MAX_POOL_ENTRIES: usize = 10_000;
 /// downstream response. This bounds memory for slow clients while leaving room
 /// for normal backend bursts and interleaved control frames.
 const EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Non-control frames read while an event send is backpressured. The queue is
+/// capped independently of the event channel so control frames remain responsive
+/// without allowing a slow client to accumulate the whole stream.
+const DEFERRED_FRAME_CAPACITY: usize = 8;
 
 /// WebSocket event types that end a response.
 const TERMINAL_EVENTS: &[&str] = &[
@@ -587,7 +592,7 @@ enum DeferredFrame {
 
 /// Result of forwarding one event through the bounded channel.
 enum ForwardEvent {
-    Sent(Option<DeferredFrame>),
+    Sent,
     ReceiverClosed,
 }
 
@@ -703,6 +708,7 @@ async fn forward_event(
     source: &mut WsSource,
     events: &mpsc::Sender<Result<ResponseEvent, CodexWsError>>,
     event: Result<ResponseEvent, CodexWsError>,
+    deferred: &mut VecDeque<DeferredFrame>,
 ) -> ForwardEvent {
     let send = events.send(event);
     tokio::pin!(send);
@@ -710,29 +716,19 @@ async fn forward_event(
         tokio::select! {
             result = &mut send => {
                 return if result.is_ok() {
-                    ForwardEvent::Sent(None)
+                    ForwardEvent::Sent
                 } else {
                     ForwardEvent::ReceiverClosed
                 };
             }
-            frame = source.next() => {
+            frame = source.next(), if deferred.len() < DEFERRED_FRAME_CAPACITY => {
                 match frame {
                     Some(Ok(Message::Ping(data))) => {
                         let _ = send_message(conn, Message::Pong(data)).await;
                     }
                     Some(Ok(Message::Pong(_))) => conn.pong.notify_waiters(),
-                    Some(frame) => {
-                        if send.await.is_err() {
-                            return ForwardEvent::ReceiverClosed;
-                        }
-                        return ForwardEvent::Sent(Some(DeferredFrame::Frame(frame)));
-                    }
-                    None => {
-                        if send.await.is_err() {
-                            return ForwardEvent::ReceiverClosed;
-                        }
-                        return ForwardEvent::Sent(Some(DeferredFrame::Eof));
-                    }
+                    Some(frame) => deferred.push_back(DeferredFrame::Frame(frame)),
+                    None => deferred.push_back(DeferredFrame::Eof),
                 }
             }
         }
@@ -757,9 +753,9 @@ async fn run_turn(
     let mut response_id = None;
     let mut output_items = Vec::new();
     let mut turn_state = None;
-    let mut deferred = None;
+    let mut deferred = VecDeque::new();
     loop {
-        let next = if let Some(deferred) = deferred.take() {
+        let next = if let Some(deferred) = deferred.pop_front() {
             match deferred {
                 DeferredFrame::Frame(frame) => Some(frame),
                 DeferredFrame::Eof => None,
@@ -802,8 +798,8 @@ async fn run_turn(
                 let name = event.event.as_deref().unwrap_or("");
                 let is_terminal = TERMINAL_EVENTS.contains(&name);
                 let completed = name == REUSABLE_TERMINAL;
-                match forward_event(conn, source, events, Ok(event)).await {
-                    ForwardEvent::Sent(next) => deferred = next,
+                match forward_event(conn, source, events, Ok(event), &mut deferred).await {
+                    ForwardEvent::Sent => {}
                     ForwardEvent::ReceiverClosed => {
                         // Receiver dropped (client cancelled): the turn is abandoned.
                         evict(conn);
@@ -816,7 +812,7 @@ async fn run_turn(
                     // to the idle connection, not this completed turn; preserve it by
                     // refusing to pool this socket rather than silently discarding an
                     // already-observed Close/error or consuming the next protocol item.
-                    if deferred.is_some() {
+                    if !deferred.is_empty() {
                         *conn.continuation.lock().unwrap() = None;
                         evict(conn);
                         return TurnEnd::Dead;
@@ -1641,9 +1637,9 @@ mod tests {
             let Some(Ok(Message::Text(_))) = ws.next().await else {
                 panic!("expected a client frame");
             };
-            // Overflow the bounded channel by one event. The reader must keep
-            // polling control frames while that event waits for channel capacity.
-            for index in 0..=EVENT_CHANNEL_CAPACITY {
+            // Overflow both bounded buffers before Ping. The reader must keep
+            // polling control frames while downstream capacity remains unavailable.
+            for index in 0..EVENT_CHANNEL_CAPACITY + DEFERRED_FRAME_CAPACITY {
                 ws.send(Message::Text(format!(
                     r#"{{"type":"response.output_text.delta","delta":"{index}"}}"#
                 )))
@@ -1701,7 +1697,7 @@ mod tests {
         }
         assert_eq!(
             deltas,
-            (0..=EVENT_CHANNEL_CAPACITY)
+            (0..EVENT_CHANNEL_CAPACITY + DEFERRED_FRAME_CAPACITY)
                 .map(|index| index.to_string())
                 .collect::<Vec<_>>(),
             "deferred events retain backend order"

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -1620,6 +1620,56 @@ mod tests {
         server.abort();
     }
 
+    /// Dropping a downstream receiver while the bounded channel is full cancels
+    /// the blocked send, abandons the turn, and closes the non-pooled socket.
+    #[tokio::test]
+    async fn receiver_drop_releases_backpressured_turn() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(socket).await.unwrap();
+            let Some(Ok(Message::Text(_))) = ws.next().await else {
+                panic!("expected a client frame");
+            };
+            for _ in 0..EVENT_CHANNEL_CAPACITY + 1 {
+                ws.send(Message::Text(
+                    r#"{"type":"response.output_text.delta","delta":"x"}"#.to_string(),
+                ))
+                .await
+                .unwrap();
+            }
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Close(_))) | None | Some(Err(_)) => break,
+                    Some(Ok(_)) => continue,
+                }
+            }
+        });
+
+        let url = format!("ws://{addr}/codex/responses");
+        let frame = response_create_frame(serde_json::json!({"model": "m", "input": []}));
+        let events = open_simple(&url, HeaderMap::new(), &frame, None)
+            .await
+            .expect("websocket should connect");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while events.capacity() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("backend fills the bounded event channel");
+        drop(events);
+
+        tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("receiver cancellation closes the backpressured turn")
+            .unwrap();
+    }
+
     /// Issue #155: the bounded event channel must apply backpressure without
     /// starving control frames even after capacity is exhausted. The backend
     /// overfills the channel, sends a Ping, then waits for its Pong while the client

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -17,9 +17,10 @@
 //! while the connection sits idle between turns, so the backend never closes it
 //! with `keepalive ping timeout`. A turn is dispatched to that reader over a
 //! command channel; the reader streams the turn's events, records continuation
-//! state on a clean completion, and returns to idle keepalive duty. Because the
-//! reader forwards events over an *unbounded* channel it never blocks on
-//! downstream backpressure, so control frames are always serviced promptly.
+//! state on a clean completion, and returns to idle keepalive duty. Turn events
+//! cross a bounded channel, applying backpressure when a client falls behind while
+//! retaining enough burst capacity for the reader to service interleaved control
+//! frames promptly.
 //!
 //! On a reused connection this module also records the completed turn's response
 //! id and output items as [`StoredContinuation`], so the next turn can replay
@@ -74,6 +75,11 @@ const POOL_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// Hard cap on pooled connections, a backstop against unbounded session churn.
 const MAX_POOL_ENTRIES: usize = 10_000;
 
+/// Maximum number of turn events buffered between the WebSocket reader and the
+/// downstream response. This bounds memory for slow clients while leaving room
+/// for normal backend bursts and interleaved control frames.
+const EVENT_CHANNEL_CAPACITY: usize = 64;
+
 /// WebSocket event types that end a response.
 const TERMINAL_EVENTS: &[&str] = &[
     "response.completed",
@@ -101,9 +107,9 @@ type WsSource = SplitStream<WsStream>;
 struct StartTurn {
     /// The `response.create` text frame to write before streaming.
     frame: Message,
-    /// Where the reader forwards this turn's events. Unbounded so downstream
-    /// backpressure never blocks the reader (and thus never starves `Pong`s).
-    events: mpsc::UnboundedSender<Result<ResponseEvent, CodexWsError>>,
+    /// Where the reader forwards this turn's events. Bounded so a slow client
+    /// applies backpressure instead of accumulating the entire stream in memory.
+    events: mpsc::Sender<Result<ResponseEvent, CodexWsError>>,
     /// What to record as continuation state on a clean completion.
     record: RecordPlan,
     /// Held for the turn's duration; dropped by the reader when the turn ends,
@@ -288,10 +294,9 @@ impl CodexWsError {
 }
 
 /// Receiver of translated events, terminated by `None`. A single `Err` item ends
-/// the stream (the reader stops the turn after sending it). Unbounded so the
-/// reader never blocks forwarding events, keeping control-frame handling
-/// independent of downstream consumption speed.
-pub type CodexWsEvents = mpsc::UnboundedReceiver<Result<ResponseEvent, CodexWsError>>;
+/// the stream (the reader stops the turn after sending it). Bounded to apply
+/// backpressure when downstream consumption falls behind.
+pub type CodexWsEvents = mpsc::Receiver<Result<ResponseEvent, CodexWsError>>;
 
 /// Rewrite an `http(s)` Responses URL to its `ws(s)` equivalent. The backend
 /// serves the websocket at the same path the HTTP adapter POSTs to.
@@ -397,7 +402,7 @@ impl Turn {
         let conn = self.conn.clone();
         let reused = self.reused;
         let pool_key = self.pool_key.take();
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
         let command = StartTurn {
             frame: Message::Text(payload),
             events: tx,
@@ -573,6 +578,19 @@ enum TurnEnd {
     Dead,
 }
 
+/// A non-control frame read while an event send was backpressured. It is replayed
+/// through the main turn loop once the pending event reaches the client.
+enum DeferredFrame {
+    Frame(Result<Message, tungstenite::Error>),
+    Eof,
+}
+
+/// Result of forwarding one event through the bounded channel.
+enum ForwardEvent {
+    Sent(Option<DeferredFrame>),
+    ReceiverClosed,
+}
+
 /// Surface an explicit error on any turn command still buffered when the reader
 /// exits, instead of letting it drop silently. A turn can be dispatched during the
 /// reader's teardown: `begin` returns before a `Close`/EOF breaks the loop, then
@@ -584,7 +602,7 @@ enum TurnEnd {
 fn fail_pending_commands(commands: &mut mpsc::Receiver<StartTurn>) {
     commands.close();
     while let Ok(StartTurn { events, .. }) = commands.try_recv() {
-        let _ = events.send(Err(CodexWsError::transport(
+        let _ = events.try_send(Err(CodexWsError::transport(
             "codex websocket closed before the turn could start",
         )));
     }
@@ -612,9 +630,11 @@ async fn run_connection(
                     break;
                 };
                 if let Err(error) = send_message(&conn, frame).await {
-                    let _ = events.send(Err(CodexWsError::transport(format!(
-                        "websocket send failed: {error}"
-                    ))));
+                    let _ = events
+                        .send(Err(CodexWsError::transport(format!(
+                            "websocket send failed: {error}"
+                        ))))
+                        .await;
                     evict(&conn);
                     drop(events);
                     drop(slot);
@@ -678,33 +698,85 @@ async fn run_connection(
     let _ = sink.close().await;
 }
 
+async fn forward_event(
+    conn: &Connection,
+    source: &mut WsSource,
+    events: &mpsc::Sender<Result<ResponseEvent, CodexWsError>>,
+    event: Result<ResponseEvent, CodexWsError>,
+) -> ForwardEvent {
+    let send = events.send(event);
+    tokio::pin!(send);
+    loop {
+        tokio::select! {
+            result = &mut send => {
+                return if result.is_ok() {
+                    ForwardEvent::Sent(None)
+                } else {
+                    ForwardEvent::ReceiverClosed
+                };
+            }
+            frame = source.next() => {
+                match frame {
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = send_message(conn, Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Pong(_))) => conn.pong.notify_waiters(),
+                    Some(frame) => {
+                        if send.await.is_err() {
+                            return ForwardEvent::ReceiverClosed;
+                        }
+                        return ForwardEvent::Sent(Some(DeferredFrame::Frame(frame)));
+                    }
+                    None => {
+                        if send.await.is_err() {
+                            return ForwardEvent::ReceiverClosed;
+                        }
+                        return ForwardEvent::Sent(Some(DeferredFrame::Eof));
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Stream one turn: pull frames until a terminal event, close, or error,
 /// forwarding each Text frame as a [`ResponseEvent`] while capturing the response
 /// id, output items, and turn-state token needed to record continuation. Answers
-/// `Ping` frames inline (independent of the unbounded event channel, so downstream
-/// backpressure never starves control-frame handling). On a clean completion the
-/// continuation is recorded and, for a not-yet-pooled connection, the connection
-/// is pooled.
+/// `Ping` frames inline. The bounded event channel has burst capacity so normal
+/// event batches do not delay control-frame handling; sustained downstream
+/// backpressure eventually propagates to the socket and bounds memory. On a clean
+/// completion, continuation is recorded and, for a not-yet-pooled connection, the
+/// connection is pooled.
 async fn run_turn(
     conn: &Arc<Connection>,
     source: &mut WsSource,
-    events: &mpsc::UnboundedSender<Result<ResponseEvent, CodexWsError>>,
+    events: &mpsc::Sender<Result<ResponseEvent, CodexWsError>>,
     record: RecordPlan,
     pooled: &mut bool,
 ) -> TurnEnd {
     let mut response_id = None;
     let mut output_items = Vec::new();
     let mut turn_state = None;
+    let mut deferred = None;
     loop {
-        let next = match tokio::time::timeout(IDLE_TIMEOUT, source.next()).await {
-            Ok(next) => next,
-            Err(_) => {
-                let _ = events.send(Err(CodexWsError::transport(format!(
-                    "websocket idle timeout after {}s",
-                    IDLE_TIMEOUT.as_secs()
-                ))));
-                evict(conn);
-                return TurnEnd::Dead;
+        let next = if let Some(deferred) = deferred.take() {
+            match deferred {
+                DeferredFrame::Frame(frame) => Some(frame),
+                DeferredFrame::Eof => None,
+            }
+        } else {
+            match tokio::time::timeout(IDLE_TIMEOUT, source.next()).await {
+                Ok(next) => next,
+                Err(_) => {
+                    let _ = events
+                        .send(Err(CodexWsError::transport(format!(
+                            "websocket idle timeout after {}s",
+                            IDLE_TIMEOUT.as_secs()
+                        ))))
+                        .await;
+                    evict(conn);
+                    return TurnEnd::Dead;
+                }
             }
         };
 
@@ -719,7 +791,9 @@ async fn run_turn(
                 // A rejected `previous_response_id` is not forwarded to the client;
                 // it is signalled so the caller can retry with the full input.
                 if is_previous_response_missing(&event.data) {
-                    let _ = events.send(Err(CodexWsError::previous_response_missing()));
+                    let _ = events
+                        .send(Err(CodexWsError::previous_response_missing()))
+                        .await;
                     *conn.continuation.lock().unwrap() = None;
                     evict(conn);
                     return TurnEnd::Dead;
@@ -728,10 +802,13 @@ async fn run_turn(
                 let name = event.event.as_deref().unwrap_or("");
                 let is_terminal = TERMINAL_EVENTS.contains(&name);
                 let completed = name == REUSABLE_TERMINAL;
-                if events.send(Ok(event)).is_err() {
-                    // Receiver dropped (client cancelled): the turn is abandoned.
-                    evict(conn);
-                    return TurnEnd::Dead;
+                match forward_event(conn, source, events, Ok(event)).await {
+                    ForwardEvent::Sent(next) => deferred = next,
+                    ForwardEvent::ReceiverClosed => {
+                        // Receiver dropped (client cancelled): the turn is abandoned.
+                        evict(conn);
+                        return TurnEnd::Dead;
+                    }
                 }
                 if is_terminal {
                     if completed {
@@ -766,9 +843,11 @@ async fn run_turn(
             }
             Some(Ok(Message::Pong(_))) => conn.pong.notify_waiters(),
             Some(Ok(Message::Binary(_))) => {
-                let _ = events.send(Err(CodexWsError::transport(
-                    "unexpected binary websocket frame",
-                )));
+                let _ = events
+                    .send(Err(CodexWsError::transport(
+                        "unexpected binary websocket frame",
+                    )))
+                    .await;
                 evict(conn);
                 return TurnEnd::Dead;
             }
@@ -778,9 +857,11 @@ async fn run_turn(
                 // Anthropic `error` event (or the JSON path logs a failure) rather
                 // than a silently short, fake-success response.
                 tracing::warn!(close_frame = ?frame, "codex websocket closed before a terminal event");
-                let _ = events.send(Err(CodexWsError::transport(
-                    "codex websocket closed before the response completed",
-                )));
+                let _ = events
+                    .send(Err(CodexWsError::transport(
+                        "codex websocket closed before the response completed",
+                    )))
+                    .await;
                 evict(conn);
                 return TurnEnd::Dead;
             }
@@ -788,17 +869,21 @@ async fn run_turn(
                 // Stream ended (EOF / dropped connection) before a terminal event —
                 // same truncation case as an explicit Close.
                 tracing::warn!("codex websocket stream ended before a terminal event");
-                let _ = events.send(Err(CodexWsError::transport(
-                    "codex websocket ended before the response completed",
-                )));
+                let _ = events
+                    .send(Err(CodexWsError::transport(
+                        "codex websocket ended before the response completed",
+                    )))
+                    .await;
                 evict(conn);
                 return TurnEnd::Dead;
             }
             Some(Ok(Message::Frame(_))) => {}
             Some(Err(error)) => {
-                let _ = events.send(Err(CodexWsError::transport(format!(
-                    "websocket stream error: {error}"
-                ))));
+                let _ = events
+                    .send(Err(CodexWsError::transport(format!(
+                        "websocket stream error: {error}"
+                    ))))
+                    .await;
                 evict(conn);
                 return TurnEnd::Dead;
             }
@@ -1529,12 +1614,12 @@ mod tests {
         server.abort();
     }
 
-    /// Issue #93: downstream backpressure (a client not consuming events) must not
-    /// starve WebSocket control-frame handling. The reader forwards events over an
-    /// unbounded channel, so a mid-stream `Ping` is answered even while the client
-    /// holds the receiver without reading.
+    /// Issue #155: the bounded event channel must apply backpressure without
+    /// starving control frames during ordinary bursts. The backend fills the
+    /// channel exactly to capacity, sends a Ping, then waits for its Pong while the
+    /// client deliberately holds the receiver without reading.
     #[tokio::test]
-    async fn backpressure_does_not_starve_control_frames() {
+    async fn bounded_backpressure_does_not_starve_control_frames() {
         use tokio::net::TcpListener;
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1545,8 +1630,9 @@ mod tests {
             let Some(Ok(Message::Text(_))) = ws.next().await else {
                 panic!("expected a client frame");
             };
-            // Emit a burst of data events the client will not consume yet.
-            for _ in 0..8 {
+            // Overflow the bounded channel by one event. The reader must keep
+            // polling control frames while that event waits for channel capacity.
+            for _ in 0..=EVENT_CHANNEL_CAPACITY {
                 ws.send(Message::Text(
                     r#"{"type":"response.output_text.delta","delta":"x"}"#.to_string(),
                 ))
@@ -1590,9 +1676,10 @@ mod tests {
 
         // Now drain: every queued event (deltas + completed) is still delivered.
         let count = drain(&mut events).await;
-        assert!(
-            count >= 9,
-            "queued events delivered after backpressure: {count}"
+        assert_eq!(
+            count,
+            EVENT_CHANNEL_CAPACITY + 2,
+            "queued events and terminal event delivered after backpressure"
         );
     }
 
@@ -1682,7 +1769,7 @@ mod tests {
     #[tokio::test]
     async fn buffered_command_on_reader_exit_surfaces_error() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel::<StartTurn>(1);
-        let (ev_tx, mut ev_rx) = mpsc::unbounded_channel();
+        let (ev_tx, mut ev_rx) = mpsc::channel(1);
         let lock = Arc::new(AsyncMutex::new(()));
         cmd_tx
             .send(StartTurn {
@@ -1708,7 +1795,7 @@ mod tests {
         // The drained command released its slot, so re-locking here cannot deadlock.
         // The channel is now closed, so a racing dispatch fails fast instead of
         // buffering into a reader that will never receive it.
-        let (ev_tx2, _ev_rx2) = mpsc::unbounded_channel();
+        let (ev_tx2, _ev_rx2) = mpsc::channel(1);
         assert!(
             cmd_tx
                 .send(StartTurn {

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -811,6 +811,16 @@ async fn run_turn(
                     }
                 }
                 if is_terminal {
+                    // `forward_event` may have read one non-control frame while the
+                    // bounded send was waiting. A frame after a terminal event belongs
+                    // to the idle connection, not this completed turn; preserve it by
+                    // refusing to pool this socket rather than silently discarding an
+                    // already-observed Close/error or consuming the next protocol item.
+                    if deferred.is_some() {
+                        *conn.continuation.lock().unwrap() = None;
+                        evict(conn);
+                        return TurnEnd::Dead;
+                    }
                     if completed {
                         if let Some(response_id) = response_id {
                             let stored = StoredContinuation {
@@ -1615,9 +1625,10 @@ mod tests {
     }
 
     /// Issue #155: the bounded event channel must apply backpressure without
-    /// starving control frames during ordinary bursts. The backend fills the
-    /// channel exactly to capacity, sends a Ping, then waits for its Pong while the
-    /// client deliberately holds the receiver without reading.
+    /// starving control frames even after capacity is exhausted. The backend
+    /// overfills the channel, sends a Ping, then waits for its Pong while the client
+    /// deliberately holds the receiver without reading. Distinct deltas verify the
+    /// read-ahead frame is replayed in exact order.
     #[tokio::test]
     async fn bounded_backpressure_does_not_starve_control_frames() {
         use tokio::net::TcpListener;
@@ -1632,10 +1643,10 @@ mod tests {
             };
             // Overflow the bounded channel by one event. The reader must keep
             // polling control frames while that event waits for channel capacity.
-            for _ in 0..=EVENT_CHANNEL_CAPACITY {
-                ws.send(Message::Text(
-                    r#"{"type":"response.output_text.delta","delta":"x"}"#.to_string(),
-                ))
+            for index in 0..=EVENT_CHANNEL_CAPACITY {
+                ws.send(Message::Text(format!(
+                    r#"{{"type":"response.output_text.delta","delta":"{index}"}}"#
+                )))
                 .await
                 .unwrap();
             }
@@ -1674,13 +1685,28 @@ mod tests {
             .expect("server should observe a Pong before we consume events")
             .unwrap();
 
-        // Now drain: every queued event (deltas + completed) is still delivered.
-        let count = drain(&mut events).await;
+        // Now drain: every queued event is delivered in backend order, followed by
+        // the terminal event.
+        let mut deltas = Vec::new();
+        let mut terminal = false;
+        while let Some(item) = events.recv().await {
+            let event = item.expect("stream remains healthy");
+            match event.event.as_deref() {
+                Some("response.output_text.delta") => {
+                    deltas.push(event.data["delta"].as_str().unwrap().to_string());
+                }
+                Some("response.completed") => terminal = true,
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
         assert_eq!(
-            count,
-            EVENT_CHANNEL_CAPACITY + 2,
-            "queued events and terminal event delivered after backpressure"
+            deltas,
+            (0..=EVENT_CHANNEL_CAPACITY)
+                .map(|index| index.to_string())
+                .collect::<Vec<_>>(),
+            "deferred events retain backend order"
         );
+        assert!(terminal, "terminal event follows every queued delta");
     }
 
     /// A non-pooled turn (no session key) is used for exactly one turn, so once it

--- a/src/adapters/responses/websocket.rs
+++ b/src/adapters/responses/websocket.rs
@@ -427,7 +427,7 @@ mod tests {
 
         // A delivered first event commits: it is buffered for replay and the
         // channel is handed back intact.
-        let (_tx, rx) = mpsc::unbounded_channel();
+        let (_tx, rx) = mpsc::channel(16);
         let event = ResponseEvent {
             event: Some("response.created".to_string()),
             data: Value::Null,
@@ -440,7 +440,7 @@ mod tests {
         );
 
         // A transport error before the first event falls back to HTTP.
-        let (_tx, rx) = mpsc::unbounded_channel();
+        let (_tx, rx) = mpsc::channel(16);
         let error = CodexWsError {
             status: None,
             retry_after: None,
@@ -454,7 +454,7 @@ mod tests {
         );
 
         // An empty stream (channel closed before any event) also falls back.
-        let (_tx, rx) = mpsc::unbounded_channel();
+        let (_tx, rx) = mpsc::channel(16);
         assert!(
             commit_or_fallback(None, rx).is_err(),
             "an empty stream falls back to HTTP"

--- a/src/adapters/responses/ws_stream.rs
+++ b/src/adapters/responses/ws_stream.rs
@@ -204,8 +204,8 @@ mod tests {
     async fn json_events_response_surfaces_mid_stream_transport_error_as_bad_gateway() {
         // A transport error mid-stream must not be presented as a successful
         // partial answer — it is surfaced as a gateway error carrying the body.
-        let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(Err(transport_error("upstream blew up", "socket dropped")))
+        let (tx, rx) = mpsc::channel(16);
+        tx.try_send(Err(transport_error("upstream blew up", "socket dropped")))
             .unwrap();
         drop(tx);
 
@@ -219,9 +219,9 @@ mod tests {
     #[tokio::test]
     async fn json_events_response_collects_ok_events_then_finishes() {
         // The `Ok` and channel-closed (`None`) arms produce a 200 message.
-        let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(Ok(created_event())).unwrap();
-        tx.send(Ok(ResponseEvent {
+        let (tx, rx) = mpsc::channel(16);
+        tx.try_send(Ok(created_event())).unwrap();
+        tx.try_send(Ok(ResponseEvent {
             event: Some("response.completed".to_string()),
             data: json!({ "response": { "id": "resp_1" } }),
         }))
@@ -238,14 +238,14 @@ mod tests {
     /// failure so the "error after real content" case is exercised too.
     #[tokio::test]
     async fn json_events_response_surfaces_backend_error_event_as_gateway_error() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(Ok(created_event())).unwrap();
-        tx.send(Ok(ResponseEvent {
+        let (tx, rx) = mpsc::channel(16);
+        tx.try_send(Ok(created_event())).unwrap();
+        tx.try_send(Ok(ResponseEvent {
             event: Some("response.output_text.delta".to_string()),
             data: json!({ "delta": "partial" }),
         }))
         .unwrap();
-        tx.send(Ok(ResponseEvent {
+        tx.try_send(Ok(ResponseEvent {
             event: Some("response.failed".to_string()),
             data: json!({
                 "type": "response.failed",
@@ -270,9 +270,9 @@ mod tests {
     /// still returns a `502` promptly instead of hanging on `recv()`.
     #[tokio::test]
     async fn json_events_response_returns_on_backend_error_without_channel_close() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(Ok(created_event())).unwrap();
-        tx.send(Ok(ResponseEvent {
+        let (tx, rx) = mpsc::channel(16);
+        tx.try_send(Ok(created_event())).unwrap();
+        tx.try_send(Ok(ResponseEvent {
             event: Some("response.failed".to_string()),
             data: json!({
                 "type": "response.failed",
@@ -303,8 +303,8 @@ mod tests {
     async fn stream_events_response_emits_error_event_on_mid_stream_failure() {
         // Mid-stream transport errors become an Anthropic `error` SSE event so the
         // client sees a reason instead of a silent truncation.
-        let (tx, rx) = mpsc::unbounded_channel();
-        tx.send(Err(transport_error("mid stream boom", "socket dropped")))
+        let (tx, rx) = mpsc::channel(16);
+        tx.try_send(Err(transport_error("mid stream boom", "socket dropped")))
             .unwrap();
         drop(tx);
 
@@ -330,7 +330,7 @@ mod tests {
     async fn stream_events_response_replays_buffered_event_and_flushes_on_close() {
         // The peeked first event (buffered) is replayed and, once the channel
         // closes, `machine.finish()` flushes the terminal Anthropic events.
-        let (tx, rx) = mpsc::unbounded_channel::<Result<ResponseEvent, CodexWsError>>();
+        let (tx, rx) = mpsc::channel::<Result<ResponseEvent, CodexWsError>>(1);
         drop(tx); // channel closed: only the buffered event drives output
 
         let response = stream_events_response(


### PR DESCRIPTION
## Summary

Bound the Codex WebSocket event channel so a slow downstream client applies backpressure instead of allowing the entire stream to accumulate in memory. Control-frame handling remains responsive while preserving streaming semantics.

## Milestone / spec

Issue #155 — Tier 3 concurrency / robustness of #149.

## Checklist

- [ ] `cargo build` passes
- [ ] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean
- [ ] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [ ] Frozen spec in `docs/` updated if this change deviates from it
- [ ] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [ ] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

Please focus on the bounded-channel behavior, producer backpressure, and preservation of Ping/Pong/control-frame responsiveness under a slow consumer.

Closes #155

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the Codex WebSocket event channel to 64 to apply backpressure and cap memory, while keeping Ping/Pong responsive. Added a bounded deferred-frame queue so control frames stay responsive and event order remains exact under backpressure; receiver drop now cancels a backpressured turn and closes the socket. Addresses #155.

- **Refactors**
  - Switched turn events to bounded `mpsc::channel(EVENT_CHANNEL_CAPACITY)`; updated `CodexWsEvents`.
  - Added `forward_event` to await sends while polling the socket, buffering up to `DEFERRED_FRAME_CAPACITY` non-control frames/EOF and replaying them in order.
  - Preserved terminal-event safety: if any frame was deferred, the socket is not pooled.
  - Tightened error/tests: awaited bounded sends, propagated receiver-close, used `try_send` for fail-fast paths; tests overflow both buffers, verify exact ordered delivery, and assert receiver-drop cancels a backpressured turn.

<sup>Written for commit 23c982d0d60be7a4f4e8c9e2bb8848e806e4550f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

