### PR TITLE
docs: Claude Desktop support — discovery filter + connect guide

### DIFF
--- a/.claude/agent-memory/review-review-issue-fixer/MEMORY.md
+++ b/.claude/agent-memory/review-review-issue-fixer/MEMORY.md
@@ -1,0 +1,1 @@
+- [Codex quota stable identity](codex-quota-stable-identity.md) — Pass AccountConfig to quota recording so UUID-backed state matches snapshots.

--- a/.claude/agent-memory/review-review-issue-fixer/codex-quota-stable-identity.md
+++ b/.claude/agent-memory/review-review-issue-fixer/codex-quota-stable-identity.md
@@ -1,6 +1,6 @@
 ---
 name: codex-quota-stable-identity
- description: Codex quota recording must receive AccountConfig and key health by account_identity
+description: Codex quota recording must receive AccountConfig and key health by account_identity
 metadata:
   type: project
 ---

--- a/.claude/agent-memory/review-review-issue-fixer/codex-quota-stable-identity.md
+++ b/.claude/agent-memory/review-review-issue-fixer/codex-quota-stable-identity.md
@@ -1,0 +1,11 @@
+---
+name: codex-quota-stable-identity
+ description: Codex quota recording must receive AccountConfig and key health by account_identity
+metadata:
+  type: project
+---
+Codex quota headers are recorded through `AccountPool::note_codex_quota` with the full `AccountConfig`, so UUID-backed accounts use the same stable identity as snapshot/health. HTTP, inbound, pooled HTTP, and websocket handshake paths must preserve the AccountConfig; the account name remains only for response headers and websocket pool keys.
+
+**Why:** Keying by account name orphaned quota state whenever a Codex account had a UUID different from its configured name.
+
+**How to apply:** When adding or changing Codex quota call sites, pass the selected account config rather than deriving an identity string.

--- a/.claude/agent-memory/review-review-pr-test-analyzer/MEMORY.md
+++ b/.claude/agent-memory/review-review-pr-test-analyzer/MEMORY.md
@@ -10,3 +10,4 @@
 - [shunt Codex admin coverage](shunt-codex-admin-coverage.md) — PR #144 Codex admin OAuth happy path/storage/list/pool/delete are strong; gaps remain for state/account-id rejection, Codex-route CSRF wiring, and pending-kind isolation.
 - [shunt account scan cache coverage](shunt-account-scan-cache-coverage.md) — PR #163 covers hit/invalidation triggers without race risk, but never asserts changed scan output replaces the cached account list.
 - [shunt perf hot-path coverage](shunt-perf-hot-path-coverage.md) — PR #182 auth single-flight and quota behavior are covered; WS idle-timer reset/tie and BoundaryTracker len-0/3 cases are not.
+- [shunt client usage fable coverage](shunt-client-usage-fable-coverage.md) — PR #179 usage aggregate tests cover 5h/7d but omit populated fable (7d_oi) data, leaving that production mapping unguarded.

--- a/.claude/agent-memory/review-review-pr-test-analyzer/shunt-client-usage-fable-coverage.md
+++ b/.claude/agent-memory/review-review-pr-test-analyzer/shunt-client-usage-fable-coverage.md
@@ -1,0 +1,8 @@
+---
+name: shunt-client-usage-fable-coverage
+description: PR #179 client usage aggregate tests omit the fable 7d_oi window despite wiring it in production
+metadata:
+  type: reference
+---
+
+PR #179's usage aggregate tests cover 5h and 7d but the fixture leaves utilization_7d_oi/reset_7d_oi unset, so the fable mapping at usage.rs aggregate cannot regress visibly. When reviewing future usage/quota surfaces, require one fixture with populated fable data and reset assertion.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -119,6 +119,11 @@ export default defineConfig({
               slug: 'guides/connect-claude-code',
             },
             {
+              label: 'Connect Claude Desktop',
+              translations: { ko: 'Claude Desktop 연결', ja: 'Claude Desktop の接続', 'zh-CN': '连接 Claude Desktop' },
+              slug: 'guides/connect-claude-desktop',
+            },
+            {
               label: 'Connect the Codex CLI',
               translations: { ko: 'Codex CLI 연결', ja: 'Codex CLI の接続', 'zh-CN': '连接 Codex CLI' },
               slug: 'guides/connect-codex-cli',

--- a/site/src/content/docs/guides/connect-claude-desktop.md
+++ b/site/src/content/docs/guides/connect-claude-desktop.md
@@ -1,0 +1,109 @@
+---
+title: Connect Claude Desktop
+description: Point Claude Desktop's third-party inference at shunt, authenticate, and pick models.
+---
+
+Based on the official [Deploy Claude Desktop with an LLM gateway](https://claude.com/docs/third-party/claude-desktop/gateway) guide — shunt *is* the gateway you point it at. shunt implements the Anthropic [Messages API](https://docs.claude.com/en/api/messages) (`POST /v1/messages` with streaming and tool use) and the optional `GET /v1/models`, which is exactly the gateway contract Claude Desktop's third-party inference expects.
+
+:::note[Claude Desktop's gateway config is managed, not a user file]
+Every key below is an [MDM / Bootstrap managed setting](https://claude.com/docs/third-party/claude-desktop/mdm). Set them in the in-app window (**Developer → Configure Third-Party Inference…**), which exports a `.mobileconfig` (macOS) or `.reg` (Windows) file, or push them through your MDM. There is no `~/.claude`-style user file for these.
+:::
+
+## 1. Point Claude Desktop at shunt
+
+In **Developer → Configure Third-Party Inference…**, set **Inference provider** to **Gateway** and **Gateway base URL** to your running shunt (default bind `127.0.0.1:3001`):
+
+| Claude Desktop key | Value |
+| :-- | :-- |
+| `inferenceProvider` | `gateway` |
+| `inferenceGatewayBaseUrl` | `http://127.0.0.1:3001` (or your public shunt URL) |
+
+shunt serves plain HTTP; for anything beyond a loopback deployment, terminate TLS in front or tunnel it, exactly as for [sharing the gateway](/guides/shared-gateway/).
+
+## 2. Choose an authentication approach
+
+Claude Desktop offers three approaches. shunt maps cleanly onto the static key (and its credential-helper variant); per-user SSO is a gateway-side capability shunt does **not** implement inbound.
+
+| Claude Desktop approach | shunt side | Notes |
+| :-- | :-- | :-- |
+| **Static API key** (`inferenceGatewayApiKey`) | [`[server.auth]`](/guides/shared-gateway/) client token | Recommended. |
+| **Credential helper** (`inferenceCredentialHelper`) | an executable printing a `[server.auth]` client token | For orgs that already mint gateway credentials. |
+| **Interactive SSO** (`inferenceGatewayOidc` + `inferenceCredentialKind: interactive`) | not supported inbound | shunt validates *static* tokens, not external-IdP JWTs — see below. |
+
+### Static API key (recommended)
+
+Enable [`[server.auth]`](/guides/shared-gateway/#inbound-client-tokens) on shunt and hand each user a client token:
+
+```toml
+[server.auth]
+header = "x-shunt-token"          # default
+tokens_env = "SHUNT_CLIENT_TOKENS"
+```
+
+Put that token in Claude Desktop's `inferenceGatewayApiKey`. shunt accepts the client token in `Authorization: Bearer` or `x-api-key`, so either **Gateway auth scheme** works:
+
+| Claude Desktop key | Value |
+| :-- | :-- |
+| `inferenceGatewayApiKey` | your shunt client token |
+| `inferenceGatewayAuthScheme` | `bearer` (default) or `x-api-key` |
+
+Without `[server.auth]`, shunt requires no inbound credential (fine for a personal loopback gateway); Claude Desktop still wants the field populated, so enter any placeholder.
+
+The token gates `GET /v1/models` and injected-credential (mapped/pooled) models; [passthrough models](/guides/connect-claude-code/#3-provide-the-mapped-providers-credential) stay open and carry the operator's own provider credential.
+
+:::caution[shunt does not implement Claude Desktop's SSO contract]
+Claude Desktop's **Interactive sign-in** (`inferenceGatewayOidc`) has the app authenticate against an external IdP (Entra, Okta, …) and send that IdP's JWT to the gateway, which must validate `iss`/`aud`. shunt has no inbound JWT validator — its [`[server.gateway]`](/guides/gateway-login/) OAuth surface is a **device-flow login built for Claude Code**, a different contract. For per-user SSO attribution with Claude Desktop, front shunt with a JWT-validating proxy (LiteLLM, Kong, Envoy), or hand out per-user static tokens.
+:::
+
+## 3. Select models
+
+shunt serves `GET /v1/models`, so Claude Desktop auto-discovers the picker at launch. Two things govern what appears.
+
+**Discovery filter.** Claude Desktop's auto-discovery shows only *recognizably Claude* ids — the tier-named ones (`claude-sonnet-*`, `claude-opus-*`, `claude-haiku-*`, `claude-fable-*`). shunt's builtin catalog mirrors the reference Claude apps gateway exactly — nine tier-named ids, so Claude Desktop shows every one:
+
+```json
+// GET /v1/models — builtin catalog (auto_include_builtin_models), all tier-named
+{ "data": [
+  { "id": "claude-opus-4-6" },   { "id": "claude-sonnet-4-5-20250929" },
+  { "id": "claude-haiku-4-5-20251001" }, { "id": "claude-fable-5" },
+  { "id": "claude-opus-4-8" },   { "id": "claude-opus-4-7" },
+  { "id": "claude-opus-4-1-20250805" },  { "id": "claude-sonnet-5" },
+  { "id": "claude-sonnet-4-6" }
+] }
+```
+
+A curated `claude-<slug>-via-<provider>` alias (the pattern that works in Claude Code) is **dropped by Claude Desktop** — see [Model Discovery → Claude Desktop recognizes only tier-named ids](/guides/model-discovery/#claude-desktop-recognizes-only-tier-named-ids).
+
+**Exposing a non-Anthropic backend.** Two options:
+
+- **Map a tier-named id** with a `[[routes]]` `upstream_model`, so selecting it in Desktop resolves to your backend:
+
+  ```toml
+  [[routes]]
+  model = "claude-sonnet-5"        # a tier-named id Claude Desktop recognizes
+  provider = "codex"
+  upstream_model = "gpt-5.6-sol"   # real backend slug
+  ```
+
+- **Override discovery on the Desktop side** with an explicit `inferenceModels` list of the exact ids shunt routes on. When every entry is a full id, Claude Desktop skips the `/v1/models` call.
+
+:::note[`anthropic_family_tier` is not emitted yet]
+Claude Desktop will also accept an *opaque* alias if the `/v1/models` entry carries an `anthropic_family_tier` field (a tier name such as `sonnet`). shunt does not emit this field today ([#211](https://github.com/pleaseai/shunt/issues/211)), so tier-named ids or an explicit `inferenceModels` list are the current ways to surface a backend in Desktop.
+:::
+
+## 4. Verify
+
+Confirm shunt answers discovery and inference with the client token:
+
+```bash
+# Discovery — the token gates it when [server.auth] is set
+curl -s "$SHUNT_URL/v1/models" -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" | jq '.data[].id'
+
+# A tier-named id you mapped -> diverted to the backend
+curl -s -X POST "$SHUNT_URL/v1/messages" \
+  -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" \
+  -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+Then open Claude Desktop; the model picker should list the tier-named entries. If it is empty, discovery was filtered out (non-tier ids) or `/v1/models` was unreachable — set `inferenceModels` explicitly as a fallback.

--- a/site/src/content/docs/guides/model-discovery.md
+++ b/site/src/content/docs/guides/model-discovery.md
@@ -28,6 +28,21 @@ The alias appears in `/model` labeled *From gateway*; selecting it sends `claude
 
 For `gpt-*` ids without an alias, use `ANTHROPIC_CUSTOM_MODEL_OPTION` instead — see [Connect Claude Code](/guides/connect-claude-code/#4-select-a-mapped-model).
 
+## Claude Desktop recognizes only tier-named ids
+
+Claude Code accepts any discovered id beginning with `claude`/`anthropic`, but **Claude Desktop is stricter**: it surfaces only tier-named ids — `claude-sonnet-*`, `claude-opus-*`, `claude-haiku-*`, `claude-fable-*`. A `claude-<slug>-via-<provider>` alias like the one above therefore shows up in Claude Code but is **silently dropped by Claude Desktop**, since `gpt` is not a tier name.
+
+The builtin catalog is all tier-named, so it stays visible in Desktop; only your curated `claude-<slug>-via-<provider>` aliases are lost. To expose a non-Anthropic backend to Claude Desktop, reuse a tier-named id and map it with a `[[routes]]` `upstream_model`:
+
+```toml
+[[routes]]
+model = "claude-sonnet-5"        # a tier-named id Claude Desktop recognizes
+provider = "codex"
+upstream_model = "gpt-5.6-sol"   # real backend slug
+```
+
+Selecting it in Desktop resolves to the intended upstream. The route overrides the builtin catalog entry's default routing for that id, so pick a tier name whose backend mapping stays meaningful to your users.
+
 ## Discovery needs a gateway credential
 
 A claude.ai OAuth *login* alone won't trigger discovery. Claude Code only issues the `/v1/models` request when `ANTHROPIC_AUTH_TOKEN`, an API key, or an `apiKeyHelper` is set; under a plain Max/Pro subscription login it sends nothing — no request reaches shunt, no cache is written — even with the flag on. See [choosing the credential](/guides/connect-claude-code/#2-choose-the-anthropic-credential); `claude setup-token` is the recommended route.

--- a/site/src/content/docs/ja/guides/connect-claude-desktop.md
+++ b/site/src/content/docs/ja/guides/connect-claude-desktop.md
@@ -1,0 +1,109 @@
+---
+title: Claude Desktop の接続
+description: Claude Desktop のサードパーティ推論を shunt へ向け、認証してモデルを選択する。
+---
+
+公式の [Deploy Claude Desktop with an LLM gateway](https://claude.com/docs/third-party/claude-desktop/gateway) ガイドに基づいています — shunt *こそ*が、あなたが接続するゲートウェイです。shunt は Anthropic の [Messages API](https://docs.claude.com/en/api/messages)（ストリーミングとツール使用に対応する `POST /v1/messages`）と、オプションの `GET /v1/models` を実装しています。これはまさに、Claude Desktop のサードパーティ推論が期待するゲートウェイ契約です。
+
+:::note[Claude Desktop のゲートウェイ設定はユーザーファイルではなく管理対象です]
+以下のキーはすべて [MDM / Bootstrap 管理設定](https://claude.com/docs/third-party/claude-desktop/mdm)です。アプリ内のウィンドウ（**Developer → Configure Third-Party Inference…**）で設定して `.mobileconfig`（macOS）または `.reg`（Windows）ファイルをエクスポートするか、MDM 経由で配布してください。これらに対応する `~/.claude` のようなユーザーファイルはありません。
+:::
+
+## 1. Claude Desktop を shunt へ向ける
+
+**Developer → Configure Third-Party Inference…** で、**Inference provider** を **Gateway** に設定し、**Gateway base URL** に稼働中の shunt（デフォルトのバインド `127.0.0.1:3001`）を設定します。
+
+| Claude Desktop キー | 値 |
+| :-- | :-- |
+| `inferenceProvider` | `gateway` |
+| `inferenceGatewayBaseUrl` | `http://127.0.0.1:3001`（または公開 shunt URL） |
+
+shunt は平文 HTTP を提供します。ループバック以外へデプロイする場合は、[ゲートウェイの共有](/ja/guides/shared-gateway/)とまったく同じように、前段で TLS を終端するかトンネルを使ってください。
+
+## 2. 認証方式を選ぶ
+
+Claude Desktop には 3 つの方式があります。shunt は静的キー（およびその認証情報ヘルパー版）にそのまま対応しますが、ユーザー単位の SSO は shunt がインバウンドで実装しているゲートウェイ機能ではありません。
+
+| Claude Desktop の方式 | shunt 側 | 備考 |
+| :-- | :-- | :-- |
+| **静的 API キー**（`inferenceGatewayApiKey`） | [`[server.auth]`](/ja/guides/shared-gateway/) クライアントトークン | 推奨。 |
+| **認証情報ヘルパー**（`inferenceCredentialHelper`） | `[server.auth]` クライアントトークンを出力する実行可能ファイル | ゲートウェイ認証情報をすでに発行している組織向け。 |
+| **インタラクティブ SSO**（`inferenceGatewayOidc` + `inferenceCredentialKind: interactive`） | インバウンドでは未対応 | shunt は外部 IdP の JWT ではなく、*静的*トークンを検証します — 以下を参照してください。 |
+
+### 静的 API キー（推奨）
+
+shunt で [`[server.auth]`](/ja/guides/shared-gateway/#インバウンドのクライアントトークン) を有効にし、各ユーザーへクライアントトークンを配布します。
+
+```toml
+[server.auth]
+header = "x-shunt-token"          # default
+tokens_env = "SHUNT_CLIENT_TOKENS"
+```
+
+そのトークンを Claude Desktop の `inferenceGatewayApiKey` に設定します。shunt は `Authorization: Bearer` または `x-api-key` でクライアントトークンを受け付けるため、どちらの **Gateway auth scheme** でも動作します。
+
+| Claude Desktop キー | 値 |
+| :-- | :-- |
+| `inferenceGatewayApiKey` | shunt のクライアントトークン |
+| `inferenceGatewayAuthScheme` | `bearer`（デフォルト）または `x-api-key` |
+
+`[server.auth]` がなければ、shunt はインバウンドの認証情報を要求しません（個人用のループバックゲートウェイなら問題ありません）。それでも Claude Desktop はこのフィールドへの入力を要求するため、任意のプレースホルダーを指定してください。
+
+このトークンは `GET /v1/models` と、注入された認証情報を使う（マッピング/プールされた）モデルをゲートします。[パススルーモデル](/ja/guides/connect-claude-code/#3-マッピングされたプロバイダーの認証情報を用意する)は開いたままで、オペレーター自身のプロバイダー認証情報を運びます。
+
+:::caution[shunt は Claude Desktop の SSO 契約を実装していません]
+Claude Desktop の **Interactive sign-in**（`inferenceGatewayOidc`）では、アプリが外部 IdP（Entra、Okta など）で認証し、その IdP の JWT をゲートウェイへ送ります。ゲートウェイ側では `iss`/`aud` を検証する必要があります。shunt にはインバウンド JWT バリデーターがありません — [`[server.gateway]`](/ja/guides/gateway-login/) の OAuth サーフェスは **Claude Code 向けに構築されたデバイスフローログイン**であり、別の契約です。Claude Desktop でユーザー単位の SSO アトリビューションを行うには、shunt の前段に JWT を検証するプロキシ（LiteLLM、Kong、Envoy）を置くか、ユーザー単位の静的トークンを配布してください。
+:::
+
+## 3. モデルを選択する
+
+shunt は `GET /v1/models` を提供するため、Claude Desktop は起動時にピッカーを自動検出します。何が表示されるかは 2 つの要素で決まります。
+
+**Discovery フィルター。** Claude Desktop の自動 discovery に表示されるのは、*Claude と認識できる* id、つまり tier 名の id（`claude-sonnet-*`、`claude-opus-*`、`claude-haiku-*`、`claude-fable-*`）のみです。shunt の組み込みカタログはリファレンス Claude apps gateway を正確にミラーしています。9 つすべてが tier 名の id なので、Claude Desktop にはそのすべてが表示されます。
+
+```json
+// GET /v1/models — builtin catalog (auto_include_builtin_models), all tier-named
+{ "data": [
+  { "id": "claude-opus-4-6" },   { "id": "claude-sonnet-4-5-20250929" },
+  { "id": "claude-haiku-4-5-20251001" }, { "id": "claude-fable-5" },
+  { "id": "claude-opus-4-8" },   { "id": "claude-opus-4-7" },
+  { "id": "claude-opus-4-1-20250805" },  { "id": "claude-sonnet-5" },
+  { "id": "claude-sonnet-4-6" }
+] }
+```
+
+選定した `claude-<slug>-via-<provider>` エイリアス（Claude Code で機能するパターン）は **Claude Desktop では破棄されます** — [モデルディスカバリー → Claude Desktop は tier 名の id のみを認識します](/ja/guides/model-discovery/#claude-desktop-は-tier-名の-id-のみを認識します)を参照してください。
+
+**非 Anthropic バックエンドを公開する。** 選択肢は 2 つあります。
+
+- **tier 名の id をマッピングする。** `[[routes]]` の `upstream_model` でマッピングすると、Desktop で選択したときにバックエンドへ解決されます。
+
+  ```toml
+  [[routes]]
+  model = "claude-sonnet-5"        # a tier-named id Claude Desktop recognizes
+  provider = "codex"
+  upstream_model = "gpt-5.6-sol"   # real backend slug
+  ```
+
+- **Desktop 側で discovery を上書きする。** shunt がルーティングする正確な id を、明示的な `inferenceModels` リストに指定します。すべてのエントリが完全な id なら、Claude Desktop は `/v1/models` の呼び出しをスキップします。
+
+:::note[`anthropic_family_tier` はまだ出力されません]
+`/v1/models` のエントリに `anthropic_family_tier` フィールド（`sonnet` などの tier 名）が含まれていれば、Claude Desktop は*不透明な*エイリアスも受け付けます。現時点の shunt はこのフィールドを出力しないため（[#211](https://github.com/pleaseai/shunt/issues/211)）、Desktop にバックエンドを表示する現在の方法は、tier 名の id または明示的な `inferenceModels` リストです。
+:::
+
+## 4. 検証
+
+クライアントトークンを使って、shunt が discovery と推論に応答することを確認します。
+
+```bash
+# Discovery — the token gates it when [server.auth] is set
+curl -s "$SHUNT_URL/v1/models" -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" | jq '.data[].id'
+
+# A tier-named id you mapped -> diverted to the backend
+curl -s -X POST "$SHUNT_URL/v1/messages" \
+  -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" \
+  -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+その後 Claude Desktop を開きます。モデルピッカーに tier 名のエントリが表示されるはずです。空の場合は、discovery がフィルターで除外された（tier 名でない id）か、`/v1/models` に到達できていません。フォールバックとして `inferenceModels` を明示的に設定してください。

--- a/site/src/content/docs/ja/guides/model-discovery.md
+++ b/site/src/content/docs/ja/guides/model-discovery.md
@@ -28,6 +28,21 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 
 エイリアスのない `gpt-*` id には、代わりに `ANTHROPIC_CUSTOM_MODEL_OPTION` を使ってください — [Connect Claude Code](/ja/guides/connect-claude-code/#4-select-a-mapped-model) を参照。
 
+## Claude Desktop は tier 名の id のみを認識します
+
+Claude Code は `claude`/`anthropic` で始まる discovery id をすべて受け入れますが、**Claude Desktop はより厳格です**。`claude-sonnet-*`、`claude-opus-*`、`claude-haiku-*`、`claude-fable-*` といった tier 名の id のみを表示します。したがって上記の `claude-<slug>-via-<provider>` エイリアスは Claude Code には現れますが、`gpt` は tier 名ではないため **Claude Desktop では静かに破棄されます**。
+
+組み込みカタログはすべて tier 名なので Desktop でも表示されたままです。失われるのは選定した `claude-<slug>-via-<provider>` エイリアスだけです。非 Anthropic バックエンドを Claude Desktop へ公開するには、tier 名の id を再利用し、`[[routes]]` の `upstream_model` でマッピングしてください。
+
+```toml
+[[routes]]
+model = "claude-sonnet-5"        # a tier-named id Claude Desktop recognizes
+provider = "codex"
+upstream_model = "gpt-5.6-sol"   # real backend slug
+```
+
+Desktop でそれを選ぶと、意図した上流へ解決されます。この route はその id に対する組み込みカタログのデフォルトルーティングを上書きするため、バックエンドのマッピングがユーザーにとって意味を保つ tier 名を選んでください。
+
 ## Discovery にはゲートウェイの認証情報が必要
 
 claude.ai OAuth の*ログイン*だけでは discovery はトリガーされません。Claude Code は `ANTHROPIC_AUTH_TOKEN`、API キー、または `apiKeyHelper` が設定されているときのみ `/v1/models` リクエストを発行します。素の Max/Pro サブスクリプションログインでは、フラグをオンにしても何も送りません — shunt に届くリクエストはなく、キャッシュも書かれません。[認証情報の選択](/ja/guides/connect-claude-code/#2-choose-the-anthropic-credential)を参照してください。`claude setup-token` が推奨ルートです。

--- a/site/src/content/docs/ko/guides/connect-claude-desktop.md
+++ b/site/src/content/docs/ko/guides/connect-claude-desktop.md
@@ -1,0 +1,109 @@
+---
+title: Claude Desktop 연결
+description: Claude Desktop의 서드 파티 추론을 shunt로 향하게 하고, 인증을 구성하고, 모델을 선택하기.
+---
+
+공식 [Deploy Claude Desktop with an LLM gateway](https://claude.com/docs/third-party/claude-desktop/gateway) 가이드를 기반으로 합니다 — Claude Desktop에서 연결할 게이트웨이가 바로 shunt입니다. shunt는 Anthropic [Messages API](https://docs.claude.com/en/api/messages)(스트리밍과 도구 사용을 지원하는 `POST /v1/messages`)와 선택 사항인 `GET /v1/models`를 구현하며, 이는 Claude Desktop의 서드 파티 추론이 기대하는 게이트웨이 계약과 정확히 일치합니다.
+
+:::note[Claude Desktop의 게이트웨이 구성은 사용자 파일이 아닌 관리형 설정입니다]
+아래의 모든 키는 [MDM / Bootstrap 관리형 설정](https://claude.com/docs/third-party/claude-desktop/mdm)입니다. `.mobileconfig`(macOS) 또는 `.reg`(Windows) 파일을 내보내는 앱 내 창(**Developer → Configure Third-Party Inference…**)에서 설정하거나 MDM을 통해 푸시하세요. 여기에는 `~/.claude` 형식의 사용자 파일이 없습니다.
+:::
+
+## 1. Claude Desktop을 shunt로 향하게 하기
+
+**Developer → Configure Third-Party Inference…**에서 **Inference provider**를 **Gateway**로 설정하고, **Gateway base URL**을 실행 중인 shunt(기본 bind `127.0.0.1:3001`)로 설정하세요:
+
+| Claude Desktop 키 | 값 |
+| :-- | :-- |
+| `inferenceProvider` | `gateway` |
+| `inferenceGatewayBaseUrl` | `http://127.0.0.1:3001` (또는 공개 shunt URL) |
+
+shunt는 평문 HTTP를 제공합니다. 루프백을 벗어난 배포에서는 [게이트웨이 공유](/ko/guides/shared-gateway/)와 마찬가지로 앞단에서 TLS를 종료하거나 터널을 사용하세요.
+
+## 2. 인증 방식 선택
+
+Claude Desktop은 세 가지 방식을 제공합니다. shunt는 정적 키(및 자격 증명 헬퍼 변형)에 자연스럽게 대응하지만, 사용자별 SSO는 게이트웨이 측 기능이며 shunt는 인바운드에서 이를 구현하지 않습니다.
+
+| Claude Desktop 방식 | shunt 측 | 참고 |
+| :-- | :-- | :-- |
+| **정적 API 키** (`inferenceGatewayApiKey`) | [`[server.auth]`](/ko/guides/shared-gateway/) 클라이언트 토큰 | 권장. |
+| **자격 증명 헬퍼** (`inferenceCredentialHelper`) | `[server.auth]` 클라이언트 토큰을 출력하는 실행 파일 | 이미 게이트웨이 자격 증명을 발급하는 조직용. |
+| **대화형 SSO** (`inferenceGatewayOidc` + `inferenceCredentialKind: interactive`) | 인바운드에서 지원하지 않음 | shunt는 외부 IdP JWT가 아닌 *정적* 토큰을 검증합니다 — 아래를 참고하세요. |
+
+### 정적 API 키(권장)
+
+shunt에서 [`[server.auth]`](/ko/guides/shared-gateway/#인바운드-클라이언트-토큰)를 활성화하고 각 사용자에게 클라이언트 토큰을 발급하세요:
+
+```toml
+[server.auth]
+header = "x-shunt-token"          # 기본값
+tokens_env = "SHUNT_CLIENT_TOKENS"
+```
+
+그 토큰을 Claude Desktop의 `inferenceGatewayApiKey`에 입력하세요. shunt는 `Authorization: Bearer` 또는 `x-api-key`로 클라이언트 토큰을 받으므로, 어느 **Gateway auth scheme**이든 사용할 수 있습니다:
+
+| Claude Desktop 키 | 값 |
+| :-- | :-- |
+| `inferenceGatewayApiKey` | shunt 클라이언트 토큰 |
+| `inferenceGatewayAuthScheme` | `bearer` (기본값) 또는 `x-api-key` |
+
+`[server.auth]`가 없으면 shunt는 인바운드 자격 증명을 요구하지 않습니다(개인 루프백 게이트웨이에는 괜찮습니다). 그래도 Claude Desktop은 이 필드가 채워져 있기를 요구하므로 아무 플레이스홀더나 입력하세요.
+
+이 토큰은 `GET /v1/models`와 자격 증명이 주입되는(매핑된/풀) 모델을 게이팅합니다. [패스스루 모델](/ko/guides/connect-claude-code/#3-매핑된-프로바이더의-자격-증명-제공)은 열린 채로 유지되며 운영자 자체의 프로바이더 자격 증명을 전달합니다.
+
+:::caution[shunt는 Claude Desktop의 SSO 계약을 구현하지 않습니다]
+Claude Desktop의 **Interactive sign-in**(`inferenceGatewayOidc`)은 앱이 외부 IdP(Entra, Okta 등)에 인증하고 해당 IdP의 JWT를 게이트웨이로 보내게 하며, 게이트웨이는 `iss`/`aud`를 검증해야 합니다. shunt에는 인바운드 JWT 검증기가 없습니다. shunt의 [`[server.gateway]`](/ko/guides/gateway-login/) OAuth 화면은 **Claude Code용으로 구축된 디바이스 플로 로그인**이며 서로 다른 계약입니다. Claude Desktop에서 사용자별 SSO 어트리뷰션을 사용하려면 JWT 검증 프록시(LiteLLM, Kong, Envoy)를 shunt 앞에 두거나 사용자별 정적 토큰을 배포하세요.
+:::
+
+## 3. 모델 선택
+
+shunt는 `GET /v1/models`를 제공하므로 Claude Desktop은 시작할 때 모델 선택기를 자동으로 디스커버리합니다. 무엇이 나타나는지는 두 가지 요소가 결정합니다.
+
+**디스커버리 필터.** Claude Desktop의 자동 디스커버리는 *Claude로 인식할 수 있는* id, 즉 tier 이름 id(`claude-sonnet-*`, `claude-opus-*`, `claude-haiku-*`, `claude-fable-*`)만 표시합니다. shunt의 내장 카탈로그는 레퍼런스 Claude apps gateway를 정확히 미러링하며, 9개 id가 모두 tier 이름이므로 Claude Desktop에 전부 표시됩니다:
+
+```json
+// GET /v1/models — 내장 카탈로그(auto_include_builtin_models), 모두 tier 이름 id
+{ "data": [
+  { "id": "claude-opus-4-6" },   { "id": "claude-sonnet-4-5-20250929" },
+  { "id": "claude-haiku-4-5-20251001" }, { "id": "claude-fable-5" },
+  { "id": "claude-opus-4-8" },   { "id": "claude-opus-4-7" },
+  { "id": "claude-opus-4-1-20250805" },  { "id": "claude-sonnet-5" },
+  { "id": "claude-sonnet-4-6" }
+] }
+```
+
+선별된 `claude-<slug>-via-<provider>` 별칭(Claude Code에서 동작하는 패턴)은 **Claude Desktop에서 버려집니다**. [모델 디스커버리 → Claude Desktop은 tier 이름 id만 인식합니다](/ko/guides/model-discovery/#claude-desktop은-tier-이름-id만-인식합니다)를 참고하세요.
+
+**비-Anthropic 백엔드 노출.** 두 가지 방법이 있습니다:
+
+- `[[routes]]`의 `upstream_model`로 **tier 이름 id를 매핑**하면 Desktop에서 이를 선택할 때 해당 백엔드로 해석됩니다:
+
+  ```toml
+  [[routes]]
+  model = "claude-sonnet-5"        # Claude Desktop이 인식하는 tier 이름 id
+  provider = "codex"
+  upstream_model = "gpt-5.6-sol"   # 실제 백엔드 슬러그
+  ```
+
+- shunt가 라우팅하는 정확한 id의 명시적 `inferenceModels` 목록으로 **Desktop 측 디스커버리를 오버라이드**하세요. 모든 항목이 전체 id이면 Claude Desktop은 `/v1/models` 호출을 건너뜁니다.
+
+:::note[`anthropic_family_tier`는 아직 출력되지 않습니다]
+`/v1/models` 항목에 `anthropic_family_tier` 필드(`sonnet` 같은 tier 이름)가 포함되어 있으면 Claude Desktop은 *불투명한* 별칭도 받아들입니다. 현재 shunt는 이 필드를 출력하지 않으므로([#211](https://github.com/pleaseai/shunt/issues/211)), tier 이름 id 또는 명시적인 `inferenceModels` 목록이 Desktop에 백엔드를 노출하는 현재 방법입니다.
+:::
+
+## 4. 검증
+
+클라이언트 토큰으로 shunt가 디스커버리와 추론에 응답하는지 확인하세요:
+
+```bash
+# 디스커버리 — [server.auth]가 설정되어 있으면 토큰으로 게이팅됨
+curl -s "$SHUNT_URL/v1/models" -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" | jq '.data[].id'
+
+# 매핑한 tier 이름 id -> 백엔드로 우회
+curl -s -X POST "$SHUNT_URL/v1/messages" \
+  -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" \
+  -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+그런 다음 Claude Desktop을 여세요. 모델 선택기에 tier 이름 항목이 표시되어야 합니다. 비어 있다면 디스커버리에서 필터링되었거나(tier 이름이 아닌 id) `/v1/models`에 접근할 수 없는 것입니다. 폴백으로 `inferenceModels`를 명시적으로 설정하세요.

--- a/site/src/content/docs/ko/guides/model-discovery.md
+++ b/site/src/content/docs/ko/guides/model-discovery.md
@@ -28,6 +28,21 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 
 별칭이 없는 `gpt-*` id에는 대신 `ANTHROPIC_CUSTOM_MODEL_OPTION`을 사용하세요 — [Claude Code 연결](/ko/guides/connect-claude-code/#4-select-a-mapped-model)을 참고하세요.
 
+## Claude Desktop은 tier 이름 id만 인식합니다
+
+Claude Code는 `claude`/`anthropic`으로 시작하는 디스커버리 id를 모두 받아들이지만, **Claude Desktop은 더 엄격합니다**. `claude-sonnet-*`, `claude-opus-*`, `claude-haiku-*`, `claude-fable-*` 같은 tier 이름 id만 표시합니다. 따라서 위의 `claude-<slug>-via-<provider>` 별칭은 Claude Code에는 나타나지만 `gpt`가 tier 이름이 아니므로 **Claude Desktop에서는 조용히 버려집니다**.
+
+내장 카탈로그는 모두 tier 이름이라 Desktop에서도 그대로 보입니다. 사라지는 것은 선별한 `claude-<slug>-via-<provider>` 별칭뿐입니다. 비-Anthropic 백엔드를 Claude Desktop에 노출하려면 tier 이름 id를 재사용하고 `[[routes]]`의 `upstream_model`로 매핑하세요:
+
+```toml
+[[routes]]
+model = "claude-sonnet-5"        # Claude Desktop이 인식하는 tier 이름 id
+provider = "codex"
+upstream_model = "gpt-5.6-sol"   # 실제 백엔드 슬러그
+```
+
+Desktop에서 이를 선택하면 의도한 업스트림으로 해석됩니다. 이 route는 해당 id에 대한 내장 카탈로그의 기본 라우팅을 덮어쓰므로, 백엔드 매핑이 사용자에게 여전히 의미 있는 tier 이름을 고르세요.
+
 ## 디스커버리에는 게이트웨이 자격 증명이 필요합니다
 
 claude.ai OAuth *로그인*만으로는 디스커버리가 발동하지 않습니다. Claude Code는 `ANTHROPIC_AUTH_TOKEN`, API 키, 또는 `apiKeyHelper`가 설정되어 있을 때만 `/v1/models` 요청을 보냅니다. 순수 Max/Pro 구독 로그인에서는 아무것도 보내지 않으며 — 요청이 shunt에 도달하지 않고, 캐시도 기록되지 않습니다 — 플래그가 켜져 있어도 그렇습니다. [자격 증명 선택](/ko/guides/connect-claude-code/#2-choose-the-anthropic-credential)을 참고하세요; `claude setup-token`이 권장 경로입니다.

--- a/site/src/content/docs/zh-cn/guides/connect-claude-desktop.md
+++ b/site/src/content/docs/zh-cn/guides/connect-claude-desktop.md
@@ -1,0 +1,109 @@
+---
+title: 连接 Claude Desktop
+description: 将 Claude Desktop 的第三方推理指向 shunt、配置认证并选择模型。
+---
+
+基于官方的 [使用 LLM 网关部署 Claude Desktop](https://claude.com/docs/third-party/claude-desktop/gateway) 指南 —— shunt *就是*你要指向的那个网关。shunt 实现了 Anthropic [Messages API](https://docs.claude.com/en/api/messages)（支持流式传输和工具使用的 `POST /v1/messages`）以及可选的 `GET /v1/models`，这正是 Claude Desktop 第三方推理所期望的网关契约。
+
+:::note[Claude Desktop 的网关配置由管理员管理，而不是用户文件]
+下面的每个键都是一项 [MDM / Bootstrap 托管设置](https://claude.com/docs/third-party/claude-desktop/mdm)。请在应用内窗口（**Developer → Configure Third-Party Inference…**）中设置它们，该窗口会导出 `.mobileconfig`（macOS）或 `.reg`（Windows）文件；也可以通过 MDM 推送它们。这里没有类似 `~/.claude` 的用户文件。
+:::
+
+## 1. 将 Claude Desktop 指向 shunt
+
+在 **Developer → Configure Third-Party Inference…** 中，将 **Inference provider** 设置为 **Gateway**，并将 **Gateway base URL** 设置为正在运行的 shunt（默认绑定 `127.0.0.1:3001`）：
+
+| Claude Desktop 键 | 值 |
+| :-- | :-- |
+| `inferenceProvider` | `gateway` |
+| `inferenceGatewayBaseUrl` | `http://127.0.0.1:3001`（或你的公开 shunt URL） |
+
+shunt 提供纯 HTTP；除回环部署外，都应像[共享网关](/zh-cn/guides/shared-gateway/)一样，在前置服务中终止 TLS 或通过隧道访问。
+
+## 2. 选择认证方式
+
+Claude Desktop 提供三种方式。shunt 可以直接配合静态密钥（以及它的凭据 helper 变体）；按用户 SSO 是网关侧的能力，shunt **不支持**这种入站认证。
+
+| Claude Desktop 方式 | shunt 侧 | 说明 |
+| :-- | :-- | :-- |
+| **静态 API 密钥**（`inferenceGatewayApiKey`） | [`[server.auth]`](/zh-cn/guides/shared-gateway/) 客户端 token | 推荐。 |
+| **凭据 helper**（`inferenceCredentialHelper`） | 输出 `[server.auth]` 客户端 token 的可执行文件 | 适用于已经签发网关凭据的组织。 |
+| **交互式 SSO**（`inferenceGatewayOidc` + `inferenceCredentialKind: interactive`） | 不支持入站 | shunt 验证*静态* token，而不是外部 IdP JWT —— 见下文。 |
+
+### 静态 API 密钥（推荐）
+
+在 shunt 上启用 [`[server.auth]`](/zh-cn/guides/shared-gateway/#入站客户端-token)，并为每位用户分配一个客户端 token：
+
+```toml
+[server.auth]
+header = "x-shunt-token"          # 默认
+tokens_env = "SHUNT_CLIENT_TOKENS"
+```
+
+将该 token 填入 Claude Desktop 的 `inferenceGatewayApiKey`。shunt 接受通过 `Authorization: Bearer` 或 `x-api-key` 传入的客户端 token，因此两种 **Gateway auth scheme** 都可以使用：
+
+| Claude Desktop 键 | 值 |
+| :-- | :-- |
+| `inferenceGatewayApiKey` | 你的 shunt 客户端 token |
+| `inferenceGatewayAuthScheme` | `bearer`（默认）或 `x-api-key` |
+
+未配置 `[server.auth]` 时，shunt 不要求入站凭据（适合个人回环网关）；Claude Desktop 仍要求填写该字段，因此可以输入任意占位值。
+
+该 token 会门控 `GET /v1/models` 和注入凭据的模型（映射/池化模型）；[透传模型](/zh-cn/guides/connect-claude-code/#3-提供映射提供方的凭据)保持开放，并携带运营者自己的提供方凭据。
+
+:::caution[shunt 未实现 Claude Desktop 的 SSO 契约]
+Claude Desktop 的**交互式登录**（`inferenceGatewayOidc`）会让应用通过外部 IdP（Entra、Okta 等）认证，并把该 IdP 的 JWT 发送给网关；网关必须验证 `iss`/`aud`。shunt 没有入站 JWT 验证器 —— 它的 [`[server.gateway]`](/zh-cn/guides/gateway-login/) OAuth 界面是**为 Claude Code 构建的设备流登录**，两者采用不同的契约。若要在 Claude Desktop 中按用户进行 SSO 归属，请在 shunt 前部署能验证 JWT 的代理（LiteLLM、Kong、Envoy），或分发按用户设置的静态 token。
+:::
+
+## 3. 选择模型
+
+shunt 提供 `GET /v1/models`，因此 Claude Desktop 会在启动时自动发现并填充模型选择器。显示哪些模型由以下两项因素决定。
+
+**发现过滤器。** Claude Desktop 的自动发现只显示*可识别为 Claude* 的 id —— 即 tier 命名的 id（`claude-sonnet-*`、`claude-opus-*`、`claude-haiku-*`、`claude-fable-*`）。shunt 的内置目录与参考 Claude apps gateway 完全一致 —— 其中有九个 tier 命名的 id，因此 Claude Desktop 会显示全部模型：
+
+```json
+// GET /v1/models — 内置目录（auto_include_builtin_models），全部采用 tier 命名
+{ "data": [
+  { "id": "claude-opus-4-6" },   { "id": "claude-sonnet-4-5-20250929" },
+  { "id": "claude-haiku-4-5-20251001" }, { "id": "claude-fable-5" },
+  { "id": "claude-opus-4-8" },   { "id": "claude-opus-4-7" },
+  { "id": "claude-opus-4-1-20250805" },  { "id": "claude-sonnet-5" },
+  { "id": "claude-sonnet-4-6" }
+] }
+```
+
+维护的 `claude-<slug>-via-<provider>` 别名（可用于 Claude Code 的模式）会**被 Claude Desktop 丢弃** —— 见[模型发现 → Claude Desktop 只识别 tier 命名的 id](/zh-cn/guides/model-discovery/#claude-desktop-只识别-tier-命名的-id)。
+
+**公开非 Anthropic 后端。** 有两种方式：
+
+- **映射一个 tier 命名的 id**，通过 `[[routes]]` 的 `upstream_model` 让在 Desktop 中选择该 id 时解析到你的后端：
+
+  ```toml
+  [[routes]]
+  model = "claude-sonnet-5"        # Claude Desktop 识别的 tier 命名 id
+  provider = "codex"
+  upstream_model = "gpt-5.6-sol"   # 真实后端 slug
+  ```
+
+- **在 Desktop 侧覆盖发现**，通过显式的 `inferenceModels` 列表填写 shunt 实际路由的确切 id。如果每个条目都是完整 id，Claude Desktop 会跳过 `/v1/models` 请求。
+
+:::note[尚未输出 `anthropic_family_tier`]
+如果 `/v1/models` 条目携带 `anthropic_family_tier` 字段（例如 `sonnet` 这样的 tier 名称），Claude Desktop 也会接受一个*不透明*别名。shunt 目前不输出该字段（[#211](https://github.com/pleaseai/shunt/issues/211)），因此当前要在 Desktop 中公开后端，只能使用 tier 命名的 id 或显式的 `inferenceModels` 列表。
+:::
+
+## 4. 验证
+
+确认 shunt 能使用客户端 token 响应发现和推理请求：
+
+```bash
+# 发现 —— 设置 [server.auth] 后由 token 门控
+curl -s "$SHUNT_URL/v1/models" -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" | jq '.data[].id'
+
+# 你映射的 tier 命名 id -> 分流到后端
+curl -s -X POST "$SHUNT_URL/v1/messages" \
+  -H "Authorization: Bearer $SHUNT_CLIENT_TOKEN" \
+  -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+然后打开 Claude Desktop；模型选择器中应列出 tier 命名的条目。如果选择器为空，说明发现结果已被过滤掉（id 不是 tier 命名）或无法访问 `/v1/models` —— 请显式设置 `inferenceModels` 作为后备方案。

--- a/site/src/content/docs/zh-cn/guides/model-discovery.md
+++ b/site/src/content/docs/zh-cn/guides/model-discovery.md
@@ -28,6 +28,21 @@ export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 
 对于没有别名的 `gpt-*` id,请改用 `ANTHROPIC_CUSTOM_MODEL_OPTION` —— 见 [连接 Claude Code](/zh-cn/guides/connect-claude-code/#4-select-a-mapped-model)。
 
+## Claude Desktop 只识别 tier 命名的 id
+
+Claude Code 接受任何以 `claude`/`anthropic` 开头的发现 id,但 **Claude Desktop 更严格**:它只显示 tier 命名的 id —— `claude-sonnet-*`、`claude-opus-*`、`claude-haiku-*`、`claude-fable-*`。因此上面的 `claude-<slug>-via-<provider>` 别名会出现在 Claude Code 中,但由于 `gpt` 不是 tier 名称,它会**在 Claude Desktop 中被静默丢弃**。
+
+内置目录全部是 tier 命名的,因此在 Desktop 中仍然可见;丢失的只有你维护的 `claude-<slug>-via-<provider>` 别名。要向 Claude Desktop 公开非 Anthropic 后端,请复用一个 tier 命名的 id,并通过 `[[routes]]` 的 `upstream_model` 进行映射:
+
+```toml
+[[routes]]
+model = "claude-sonnet-5"        # Claude Desktop 识别的 tier 命名 id
+provider = "codex"
+upstream_model = "gpt-5.6-sol"   # 真实后端 slug
+```
+
+在 Desktop 中选择它会解析到预期的上游。该 route 会覆盖内置目录中该 id 的默认路由,因此请选择一个后端映射对用户仍然有意义的 tier 名称。
+
 ## 发现需要一个网关凭据
 
 仅有 claude.ai OAuth *登录* 不会触发发现。只有当设置了 `ANTHROPIC_AUTH_TOKEN`、一个 API 密钥或一个 `apiKeyHelper` 时,Claude Code 才会发起 `/v1/models` 请求;在纯 Max/Pro 订阅登录下它什么都不发送 —— 没有请求抵达 shunt,也没有缓存被写入 —— 即使开启了标志也是如此。见 [选择凭据](/zh-cn/guides/connect-claude-code/#2-choose-the-anthropic-credential);`claude setup-token` 是推荐路径。


### PR DESCRIPTION
## Summary

Documentation for using **Claude Desktop** (third-party inference) with shunt. Two related pieces on branch `docs/claude-desktop-discovery`:

1. **New guide — Connect Claude Desktop** (`guides/connect-claude-desktop`, en + ko/ja/zh-cn, added to the sidebar). Points Claude Desktop at shunt (`inferenceProvider=gateway`), maps its auth approaches onto shunt, and explains model selection under the tier-name discovery filter.
   - **Auth:** static API key (`inferenceGatewayApiKey`) → shunt's [`[server.auth]`](https://shunt-docs.pages.dev/guides/shared-gateway/) client token (Bearer or x-api-key). shunt does **not** implement Claude Desktop's inbound external-IdP-JWT SSO contract — its `[server.gateway]` is a device-flow login built for Claude Code — so per-user SSO needs a JWT-validating proxy in front.
2. **Model-discovery constraint** (existing `guides/model-discovery`, en + ko/ja/zh-cn): a new "Claude Desktop recognizes only tier-named ids" section. Claude Desktop surfaces only `claude-{sonnet,opus,haiku,fable}-*`, so the recommended `claude-<slug>-via-<provider>` alias is silently dropped there; expose a non-Anthropic backend by mapping a tier-named id with `[[routes]]` (or listing full ids in Desktop's `inferenceModels`).

### Verified against the reference gateway

Ran the real `claude gateway` (2.1.214) and captured `GET /v1/models`:

- Builtin catalog = **9 tier-named ids**, identical (and in the same order) to shunt's `BUILTIN_MODEL_IDS`.
- Entry shape `{type:"model", id, display_name}` with `display_name` repeating the id; response envelope `{data, has_more, first_id, last_id}`.
- No `anthropic_family_tier` on the builtin catalog — it is the opt-in field a gateway sets to mark an *opaque* alias as Claude; shunt does not emit it yet.
- An `availableModels` policy filters the list and expands aliases to full ids.

## Checklist

- [ ] `cargo build` / `test` / `clippy` / `fmt` — N/A (docs-only, no Rust changes)
- [x] Source files stay under 500 lines
- [x] English only in code; prose localized to ko/ja/zh-cn (ja keeps code comments in English by convention)
- [x] User-facing docs — new `site/` guide + `model-discovery` section, sidebar registered; README unchanged (links to the guides); `wiki/` not hand-edited
- [ ] Any new GitHub Action pinned to a full commit SHA — N/A

## Notes for reviewers

- Two shunt↔reference `/v1/models` shape differences surfaced during verification and are **not** addressed here (worth tracking separately if we want strict parity): shunt entries omit the `type` field, and the response omits `has_more`/`first_id`/`last_id`.
- The tier-name-only Desktop filter is observed app behavior, consistent with the Claude Desktop gateway docs' "recognizably Claude" discovery filter plus the `anthropic_family_tier` escape hatch.
- Cross-page anchor slugs were matched per locale against the translated `model-discovery` headings (Astro slugs from translated text); each translation was confirmed via a site build.

Refs #211.
