### PR TITLE
docs(readme): add pre-1.0 status note across all locales

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,9 @@
 
 **OpenAI**、**ChatGPT/Codex**（`codex login` でサブスクリプションを再利用）、**xAI**（API キー）、**Grok**（`shunt login xai` で SuperGrok / X Premium+ サブスクリプションを再利用）、**Cursor**（`shunt login cursor` でサブスクリプションを再利用）、そして **Anthropic** パススルーが標準搭載されており、さらに Anthropic Messages 互換のバックエンド（Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway、…）は TOML テーブルを 1 つ書くだけで、コード変更なしに追加できます。
 
+> [!NOTE]
+> `shunt` は活発に開発中の 1.0 未満（pre-1.0）ソフトウェアです。[SemVer](https://semver.org/lang/ja/#spec-item-4) の慣例に従い、`0.x` リリースには設定キー・CLI・動作に対する破壊的変更（breaking change）が含まれる場合があります。アップグレード前に[リリースノート](https://github.com/pleaseai/shunt/releases)を確認してください。
+
 ## インストール
 
 ```bash

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@
 **OpenAI**、**ChatGPT/Codex**（`codex login` でサブスクリプションを再利用）、**xAI**（API キー）、**Grok**（`shunt login xai` で SuperGrok / X Premium+ サブスクリプションを再利用）、**Cursor**（`shunt login cursor` でサブスクリプションを再利用）、そして **Anthropic** パススルーが標準搭載されており、さらに Anthropic Messages 互換のバックエンド（Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway、…）は TOML テーブルを 1 つ書くだけで、コード変更なしに追加できます。
 
 > [!NOTE]
-> `shunt` は活発に開発中の 1.0 未満（pre-1.0）ソフトウェアです。[SemVer](https://semver.org/lang/ja/#spec-item-4) の慣例に従い、`0.x` リリースには設定キー・CLI・動作に対する破壊的変更（breaking change）が含まれる場合があります。アップグレード前に[リリースノート](https://github.com/pleaseai/shunt/releases)を確認してください。
+> `shunt` は活発に開発中の 1.0 未満（pre-1.0）ソフトウェアです。[SemVer](https://semver.org/lang/ja/#spec) の慣例に従い、`0.x` リリースには設定キー・CLI・動作に対する破壊的変更（breaking change）が含まれる場合があります。アップグレード前に[リリースノート](https://github.com/pleaseai/shunt/releases)を確認してください。
 
 ## インストール
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 **OpenAI**, **ChatGPT/Codex**(`codex login`으로 구독을 재사용), **xAI**(API 키), **Grok**(`shunt login xai`로 SuperGrok / X Premium+ 구독을 재사용), **Cursor**(`shunt login cursor`로 구독을 재사용), **Anthropic** 패스스루가 기본 내장되어 있으며, Anthropic Messages 호환 백엔드(Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway 등)라면 무엇이든 TOML 테이블 하나만 추가하면 됩니다. 코드 변경은 필요 없습니다.
 
 > [!NOTE]
-> `shunt`는 활발히 개발 중인 1.0 미만(pre-1.0) 소프트웨어입니다. [SemVer](https://semver.org/lang/ko/#spec-item-4) 관례에 따라 `0.x` 릴리스에는 설정 키, CLI, 동작에 대한 호환성이 깨지는 변경(breaking change)이 포함될 수 있으니, 업그레이드 전에 [릴리스 노트](https://github.com/pleaseai/shunt/releases)를 확인하세요.
+> `shunt`는 활발히 개발 중인 1.0 미만(pre-1.0) 소프트웨어입니다. [SemVer](https://semver.org/lang/ko/#spec) 관례에 따라 `0.x` 릴리스에는 설정 키, CLI, 동작에 대한 호환성이 깨지는 변경(breaking change)이 포함될 수 있으니, 업그레이드 전에 [릴리스 노트](https://github.com/pleaseai/shunt/releases)를 확인하세요.
 
 ## 설치
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,6 +17,9 @@
 
 **OpenAI**, **ChatGPT/Codex**(`codex login`으로 구독을 재사용), **xAI**(API 키), **Grok**(`shunt login xai`로 SuperGrok / X Premium+ 구독을 재사용), **Cursor**(`shunt login cursor`로 구독을 재사용), **Anthropic** 패스스루가 기본 내장되어 있으며, Anthropic Messages 호환 백엔드(Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway 등)라면 무엇이든 TOML 테이블 하나만 추가하면 됩니다. 코드 변경은 필요 없습니다.
 
+> [!NOTE]
+> `shunt`는 활발히 개발 중인 1.0 미만(pre-1.0) 소프트웨어입니다. [SemVer](https://semver.org/lang/ko/#spec-item-4) 관례에 따라 `0.x` 릴리스에는 설정 키, CLI, 동작에 대한 호환성이 깨지는 변경(breaking change)이 포함될 수 있으니, 업그레이드 전에 [릴리스 노트](https://github.com/pleaseai/shunt/releases)를 확인하세요.
+
 ## 설치
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The name is the mechanism: an electrical/railway *shunt* diverts a selected part
 It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), **xAI** (API key), **Grok** (reuse your SuperGrok / X Premium+ subscription via `shunt login xai`), **Cursor** (reuse your subscription via `shunt login cursor`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table or YAML mapping away, no code changes.
 
 > [!NOTE]
-> `shunt` is pre-1.0 software under active development. Per [SemVer](https://semver.org/#spec-item-4), `0.x` releases may include breaking changes to configuration keys, the CLI, and behavior — check the [release notes](https://github.com/pleaseai/shunt/releases) before upgrading.
+> `shunt` is pre-1.0 software under active development. Per [SemVer](https://semver.org/#spec), `0.x` releases may include breaking changes to configuration keys, the CLI, and behavior — check the [release notes](https://github.com/pleaseai/shunt/releases) before upgrading.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The name is the mechanism: an electrical/railway *shunt* diverts a selected part
 
 It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), **xAI** (API key), **Grok** (reuse your SuperGrok / X Premium+ subscription via `shunt login xai`), **Cursor** (reuse your subscription via `shunt login cursor`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table or YAML mapping away, no code changes.
 
+> [!NOTE]
+> `shunt` is pre-1.0 software under active development. Per [SemVer](https://semver.org/#spec-item-4), `0.x` releases may include breaking changes to configuration keys, the CLI, and behavior — check the [release notes](https://github.com/pleaseai/shunt/releases) before upgrading.
+
 ## Install
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,9 @@
 
 它内置了 **OpenAI**、**ChatGPT/Codex**(通过 `codex login` 复用你的订阅)、**xAI**(API 密钥)、**Grok**(通过 `shunt login xai` 复用你的 SuperGrok / X Premium+ 订阅)、**Cursor**(通过 `shunt login cursor` 复用你的订阅)以及 **Anthropic** 透传 —— 而任何兼容 Anthropic-Messages 的后端(Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway……)只需一个 TOML 表即可接入,无需改动代码。
 
+> [!NOTE]
+> `shunt` 是仍在活跃开发中的 1.0 之前(pre-1.0)软件。按照 [SemVer](https://semver.org/lang/zh-CN/#spec-item-4) 惯例,`0.x` 版本可能包含对配置键、CLI 和行为的破坏性变更(breaking change) —— 升级前请查看[发布说明](https://github.com/pleaseai/shunt/releases)。
+
 ## 安装
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 它内置了 **OpenAI**、**ChatGPT/Codex**(通过 `codex login` 复用你的订阅)、**xAI**(API 密钥)、**Grok**(通过 `shunt login xai` 复用你的 SuperGrok / X Premium+ 订阅)、**Cursor**(通过 `shunt login cursor` 复用你的订阅)以及 **Anthropic** 透传 —— 而任何兼容 Anthropic-Messages 的后端(Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway……)只需一个 TOML 表即可接入,无需改动代码。
 
 > [!NOTE]
-> `shunt` 是仍在活跃开发中的 1.0 之前(pre-1.0)软件。按照 [SemVer](https://semver.org/lang/zh-CN/#spec-item-4) 惯例,`0.x` 版本可能包含对配置键、CLI 和行为的破坏性变更(breaking change) —— 升级前请查看[发布说明](https://github.com/pleaseai/shunt/releases)。
+> `shunt` 是仍在活跃开发中的 1.0 之前(pre-1.0)软件。按照 [SemVer](https://semver.org/lang/zh-CN/#spec) 惯例,`0.x` 版本可能包含对配置键、CLI 和行为的破坏性变更(breaking change) —— 升级前请查看[发布说明](https://github.com/pleaseai/shunt/releases)。
 
 ## 安装
 

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -3,6 +3,10 @@ title: Installation
 description: Install shunt via Homebrew, cargo, prebuilt binaries, or from source.
 ---
 
+:::note[Pre-1.0 software]
+`shunt` is pre-1.0 software under active development. Per [SemVer](https://semver.org/#spec), `0.x` releases may include breaking changes to configuration keys, the CLI, and behavior — check the [release notes](https://github.com/pleaseai/shunt/releases) before upgrading.
+:::
+
 ## Homebrew (macOS / Linux)
 
 ```bash

--- a/site/src/content/docs/ja/getting-started/installation.md
+++ b/site/src/content/docs/ja/getting-started/installation.md
@@ -3,6 +3,10 @@ title: インストール
 description: Homebrew、cargo、ビルド済みバイナリ、またはソースから shunt をインストールする。
 ---
 
+:::note[pre-1.0 ソフトウェア]
+`shunt` は活発に開発中の 1.0 未満（pre-1.0）ソフトウェアです。[SemVer](https://semver.org/lang/ja/#spec) の慣例に従い、`0.x` リリースには設定キー・CLI・動作に対する破壊的変更（breaking change）が含まれる場合があります。アップグレード前に[リリースノート](https://github.com/pleaseai/shunt/releases)を確認してください。
+:::
+
 ## Homebrew (macOS / Linux)
 
 ```bash

--- a/site/src/content/docs/ko/getting-started/installation.md
+++ b/site/src/content/docs/ko/getting-started/installation.md
@@ -3,6 +3,10 @@ title: 설치
 description: Homebrew, cargo, 사전 빌드 바이너리 또는 소스로 shunt 설치하기.
 ---
 
+:::note[pre-1.0 소프트웨어]
+`shunt`는 활발히 개발 중인 1.0 미만(pre-1.0) 소프트웨어입니다. [SemVer](https://semver.org/lang/ko/#spec) 관례에 따라 `0.x` 릴리스에는 설정 키, CLI, 동작에 대한 호환성이 깨지는 변경(breaking change)이 포함될 수 있으니, 업그레이드 전에 [릴리스 노트](https://github.com/pleaseai/shunt/releases)를 확인하세요.
+:::
+
 ## Homebrew (macOS / Linux)
 
 ```bash

--- a/site/src/content/docs/zh-cn/getting-started/installation.md
+++ b/site/src/content/docs/zh-cn/getting-started/installation.md
@@ -3,6 +3,10 @@ title: 安装
 description: 通过 Homebrew、cargo、预构建二进制文件或从源码安装 shunt。
 ---
 
+:::note[pre-1.0 软件]
+`shunt` 是仍在活跃开发中的 1.0 之前(pre-1.0)软件。按照 [SemVer](https://semver.org/lang/zh-CN/#spec) 惯例,`0.x` 版本可能包含对配置键、CLI 和行为的破坏性变更(breaking change) —— 升级前请查看[发布说明](https://github.com/pleaseai/shunt/releases)。
+:::
+
 ## Homebrew (macOS / Linux)
 
 ```bash


### PR DESCRIPTION
## Summary

Add a prominent pre-1.0 status note to every README locale so users know that `0.x` upgrades may include breaking changes.

The note appears between the introduction and installation instructions, links to the locale-specific SemVer 0.x convention, and points readers to the GitHub release notes before upgrading.

## Milestone / spec

N/A — documentation-only clarification; no implementation behavior or frozen spec changes.

## Checklist

- [ ] `cargo build` passes (not run; documentation-only change)
- [ ] `cargo test` passes (not run; documentation-only change)
- [ ] `cargo clippy --all-targets -- -D warnings` clean (not run; documentation-only change)
- [ ] `cargo fmt --all --check` clean (not run; documentation-only change)
- [x] Source files stay under 500 lines (no source files changed)
- [x] English source documentation matches surrounding style; localized README translations remain aligned
- [x] Frozen spec in `docs/` updated if this change deviates from it (not applicable; no behavior change)
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — all four README locales updated; no product behavior changed
- [x] Any new GitHub Action is pinned to a full commit SHA (no workflow changes)

## Notes for reviewers

- Verify the GitHub `> [!NOTE]` alert renders between the introduction and Install section in all four README locales.
- Verify each SemVer link targets the matching locale and the release-notes link is consistent.
- No linked issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-1.0 status note to every README and Installation page across all locales for `shunt`, warning that `0.x` releases may include breaking changes. The note appears before install instructions, links to the locale-specific SemVer `#spec`, and points to the GitHub release notes.

<sup>Written for commit 4a295501648097ff158d912789d88947987fec28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

