### PR TITLE
chore(ci): bump release-please-action to v5.0.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,6 @@ jobs:
           private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Run release-please
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Bump `googleapis/release-please-action` from v4.4.1 to v5.0.0 in the release workflow while preserving the repository's full-SHA pinning policy.

The pinned commit changes from `5c625bfb5d1ff62eadeeb3772007f7f66fdcf071` (v4.4.1) to `45996ed1f6d02564a971a2fa1b5860e934307cf7` (v5.0.0).

## Milestone / spec

Not applicable — this is a CI dependency update and does not change product behavior or a frozen specification.

## Checklist

- [ ] `cargo build` passes
- [ ] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — no deviation
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — no user-facing change; no action-version references exist in `docs/`, `site/`, `README.md`, or `CONTRIBUTING.md`
- [x] Any new GitHub Action is pinned to a full commit SHA

## Notes for reviewers

- v5.0.0's only breaking change is the Node.js 20 to Node.js 24 runtime upgrade ([googleapis/release-please-action#1188](https://github.com/googleapis/release-please-action/pull/1188)). The workflow passes only the unchanged `token` input, and GitHub-hosted `ubuntu-latest` supports Node.js 24.
- v5.0.0 bundles `release-please` 17.6.0 instead of 17.3.0. This repository uses a single-package `release-type: rust` configuration in the default `release-please-config.json` path and the default `.release-please-manifest.json` path; both remain compatible with this 17.x minor update.
- The lightweight v5.0.0 tag resolves directly to the pinned 40-character commit SHA.
- `actions/create-github-app-token` is already current at v3.2.0 in both `release-please.yml` and `release.yml`, so it does not need a related bump.
- Runtime verification has not been performed because this workflow runs only on pushes to `main`. The first real exercise will be the next merge into `main` that opens or updates the release PR. If it fails, rollback is a one-line revert to the previous SHA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `googleapis/release-please-action` to v5.0.0 in the release workflow while keeping full-SHA pinning. This moves the runtime to Node 24 and bundles `release-please` 17.6.0, with no workflow input changes.

- **Dependencies**
  - `googleapis/release-please-action`: `5c625bfb…` (v4.4.1) → `45996ed1…` (v5.0.0); compatible with our single-package Rust config and GitHub `ubuntu-latest`.

<sup>Written for commit ac8a48180dac5b24a2b3819b6a5b36259d1d972d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

