### PR TITLE
fix(gemini): preserve thought signatures across tool turns

### DIFF
--- a/docs/plans/gemini-provider/STATUS.md
+++ b/docs/plans/gemini-provider/STATUS.md
@@ -1,10 +1,16 @@
 # STATUS — Native Gemini provider (Path B)
 
-Last updated: 2026-07-22 (See `docs/notes/gemini-provider-capacity-and-models.md`)
+Last updated: 2026-07-25 (issue #237 Gemini 3 tool continuation fix)
 
 ## Stage
-Plan authored; S1 auth spike DONE (see `logs/2026-07-21_S1-auth-spike.md`). Backend, wire
-format, and the two target slugs live-verified.
+Provider implementation is open in #234. Issue #237 reproduced a Gemini 3 tool-continuation
+failure: response translation dropped `thoughtSignature`, so reconstructed `functionCall`
+history received HTTP 400. The fix is in progress on `fix/237-gemini-thought-signatures`:
+carry exact signatures in namespaced Anthropic `tool_use.id` values and restore them on the
+next Gemini request; use Google's documented placeholder only for imported unsigned Gemini 3
+history. Focused translation tests pass; full quality gates pass. A live Gemini 3.1 Pro response
+proved the provider returns a signature on its tool call, but provider 429s blocked the immediate
+continuation probe; retry after quota cooldown remains.
 
 **AUTH DECISION (2026-07-21, amended 2026-07-22): reuse the gemini-cli subscription token.**
 Hard constraint from user: must use the Google One AI Pro subscription at ZERO added cost.
@@ -21,8 +27,9 @@ API key rejected (adds per-token cost).
 - **Known fragility:** Google is sunsetting this client for individuals. Rerun the Gemini CLI
   login if the shared token expires and no refresh client credentials are configured.
 
-External advisory panel (codex/gemini/grok) was not run (agent_ctl blocked by local python hook);
-run `/plan review gemini-provider` if you want the cross-model attack before/while building.
+External root-cause review and final-diff review were run with Codex for #237. Codex confirmed
+the original signature-loss path, caught an intermediate carrier-association gap that was removed,
+and found no surviving defect in the final `tool_use.id` design.
 
 ## Base state (clean before tickets)
 - Repo: `shunt`. Currently on `feat/214-admin-live-activity` (UNRELATED). **Create `feat/NN-gemini-provider` off a clean `main`** + a tracking issue before TICKET-C1/A1/etc. (S1 is a scratch spike, no branch needed).
@@ -55,6 +62,7 @@ Critical path to first spawnable Gemini agent: S1 → C1 → A1/B1 → B2 → D1
 A2 (own login) was dropped; E1 (multi-account concurrency) is the remaining v2 hardening.
 
 ## Next action
-S1 + C1 done on branch `feat/gemini-provider`. A1 reads the shared Gemini CLI credential
-file and optionally refreshes with operator-supplied client credentials; B1/B2/D1/T1/X1 are
-implemented and verified. E1 (multi-account concurrency) remains future hardening.
+Retry the live two-tool Gemini 3 continuation after the provider quota cooldown. The deterministic
+round-trip suite, format, clippy, and all 1,189 workspace tests pass; the final diff's independent
+review found no surviving defect. After the live retry, update #237/#234 and commit the focused
+fix once the user approves the commit plan.

--- a/docs/plans/gemini-provider/TICKETS.md
+++ b/docs/plans/gemini-provider/TICKETS.md
@@ -70,9 +70,9 @@ error shape; full protocol/translation test coverage; `cargo fmt` + `clippy -D w
 
 ### TICKET-B2 — Response + SSE translation (Gemini → Anthropic events) · TODO · depends-on: B1 · wave 3
 **Problem:** the wrapped Gemini response/stream must become Anthropic Messages events.
-**Do:** `src/model/gemini.rs` — non-stream response → Anthropic message; SSE `data:` chunks → `content_block_delta`(text_delta), `functionCall`→`tool_use` blocks, `finishReason`→`message_delta.stop_reason`, `usageMetadata`→usage; thinking parts → thinking blocks; handle no-`[DONE]` stream end. Precedent: `src/model/responses.rs`.
+**Do:** `src/model/gemini.rs` — non-stream response → Anthropic message; SSE `data:` chunks → `content_block_delta`(text_delta), `functionCall`→`tool_use` blocks, `finishReason`→`message_delta.stop_reason`, `usageMetadata`→usage; thinking parts → thinking blocks; handle no-`[DONE]` stream end. Precedent: `src/model/responses.rs`. Gemini 3 `thoughtSignature` is gateway-private continuation state: encode a signed function-call part's exact opaque value in the corresponding Anthropic `tool_use.id`, then restore it to that `functionCall` when Claude Code returns the id in assistant history and `tool_result.tool_use_id`. This keeps tool inputs unmodified, works whether thinking is enabled or disabled, remains stateless across restarts, and naturally preserves first-call-only placement for parallel calls. For imported unsigned Gemini 3 function-call history, use Google's documented placeholder on the first call in that model content; do not add it to Gemini 2.5 history.
 **Files:** `src/model/gemini.rs`.
-**Done when:** golden tests turn captured SSE frames (see `logs/`) into the correct Anthropic event sequence for text, tool-call, and finish; non-stream path covered.
+**Done when:** golden tests turn captured SSE frames (see `logs/`) into the correct Anthropic event sequence for text, tool-call, and finish; non-stream path covered; sequential and parallel Gemini 3 tool turns replay their exact signatures and unsigned Gemini 2.5 history remains unchanged.
 
 ## Stream D — Adapter
 

--- a/src/adapters/gemini/mod.rs
+++ b/src/adapters/gemini/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     auth::{resolve_credential, Credential},
     config::AuthMode,
     model::gemini::{map_gemini_error, GeminiSseMachine},
-    model::gemini_request::{translate_request, wrap_code_assist_envelope},
+    model::gemini_request::{translate_request_for_model, wrap_code_assist_envelope},
     routing::Route,
     server::AppState,
 };
@@ -97,7 +97,7 @@ async fn forward(
 
     let is_streaming = json_body.get("stream").and_then(Value::as_bool) == Some(true);
 
-    let inner_req = translate_request(&json_body)?;
+    let inner_req = translate_request_for_model(&json_body, &route.upstream_model)?;
 
     let base_url = provider.base_url.trim_end_matches('/');
 

--- a/src/model/gemini.rs
+++ b/src/model/gemini.rs
@@ -2,9 +2,16 @@
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde_json::{json, Value};
 
 use crate::adapters::AdapterError;
+
+const GEMINI_TOOL_USE_ID_PREFIX: &str = "call_gemini_v1_";
+
+/// Pack Gemini's opaque function-call signature into the Anthropic tool-use join
+/// key. Claude Code returns this id unchanged in assistant history and in the
+/// matching `tool_result`, including when extended thinking is disabled.
 
 #[derive(Debug, Clone)]
 pub struct SseEvent {
@@ -225,7 +232,12 @@ impl GeminiSseMachine {
                 .unwrap_or("unknown_tool");
             let args = func_call.get("args").cloned().unwrap_or_else(|| json!({}));
 
-            let tool_use_id = format!("call_{:012x}", rand::random::<u64>());
+            let tool_use_id = part
+                .get("thoughtSignature")
+                .and_then(Value::as_str)
+                .filter(|signature| !signature.is_empty())
+                .map(encode_tool_use_id)
+                .unwrap_or_else(|| format!("call_{:012x}", rand::random::<u64>()));
             let idx = self.block_index;
 
             events.push(SseEvent {
@@ -439,6 +451,13 @@ impl GeminiSseMachine {
             }
         })
     }
+}
+
+fn encode_tool_use_id(signature: &str) -> String {
+    format!(
+        "{GEMINI_TOOL_USE_ID_PREFIX}{}",
+        URL_SAFE_NO_PAD.encode(signature)
+    )
 }
 
 /// Translate Gemini error JSON payload to Anthropic error envelope.

--- a/src/model/gemini_request.rs
+++ b/src/model/gemini_request.rs
@@ -1,12 +1,17 @@
 //! Anthropic Messages -> Gemini generateContent request translation.
 
 use axum::response::IntoResponse;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 
 use crate::adapters::AdapterError;
 
 const MAX_SCHEMA_DEPTH: usize = 64;
+const GEMINI_3_MODEL_PREFIX: &str = "gemini-3";
+const GEMINI_TOOL_USE_ID_PREFIX: &str = "call_gemini_v1_";
+// Google documents this exact value for imported/custom Gemini 3 function-call history.
+const GEMINI_THOUGHT_SIGNATURE_PLACEHOLDER: &str = "context_engineering_is_the_way to_go";
 
 fn bad_request(message: impl Into<String>) -> AdapterError {
     AdapterError {
@@ -18,9 +23,15 @@ fn bad_request(message: impl Into<String>) -> AdapterError {
 
 /// Translate an Anthropic Messages request into a Gemini `generateContent` request body.
 ///
-/// Decoupled from the Code Assist envelope (`{model, project, request}`); callers
-/// targeting Code Assist can wrap the resulting JSON payload with [`wrap_code_assist_envelope`].
+/// Uses the request's model id for model-specific history validation. Adapters with
+/// an alias should call [`translate_request_for_model`] with the resolved upstream id.
 pub fn translate_request(request: &Value) -> Result<Value, AdapterError> {
+    let model = request.get("model").and_then(Value::as_str).unwrap_or("");
+    translate_request_for_model(request, model)
+}
+
+/// Translate a request using the resolved Gemini model id.
+pub fn translate_request_for_model(request: &Value, model: &str) -> Result<Value, AdapterError> {
     let mut out = Map::new();
 
     // 1. System instruction
@@ -29,7 +40,7 @@ pub fn translate_request(request: &Value) -> Result<Value, AdapterError> {
     }
 
     // 2. Contents (multi-turn history)
-    let contents = translate_messages(request)?;
+    let contents = translate_messages(request, model)?;
     out.insert("contents".to_string(), Value::Array(contents));
 
     // 3. Generation Config
@@ -90,7 +101,7 @@ fn translate_system_instruction(request: &Value) -> Option<Value> {
     }
 }
 
-fn translate_messages(request: &Value) -> Result<Vec<Value>, AdapterError> {
+fn translate_messages(request: &Value, model: &str) -> Result<Vec<Value>, AdapterError> {
     let Some(messages) = request.get("messages").and_then(Value::as_array) else {
         return Ok(Vec::new());
     };
@@ -106,6 +117,7 @@ fn translate_messages(request: &Value) -> Result<Vec<Value>, AdapterError> {
         };
 
         let mut parts = Vec::new();
+        let mut saw_function_call = false;
 
         if let Some(content) = message.get("content") {
             match content {
@@ -166,15 +178,26 @@ fn translate_messages(request: &Value) -> Result<Vec<Value>, AdapterError> {
                                 let input =
                                     block.get("input").cloned().unwrap_or_else(|| json!({}));
                                 if !name.is_empty() {
-                                    if let Some(id) = block.get("id").and_then(Value::as_str) {
+                                    let id = block.get("id").and_then(Value::as_str).unwrap_or("");
+                                    if !id.is_empty() {
                                         tool_names.insert(id.to_string(), name.to_string());
                                     }
-                                    parts.push(json!({
+                                    let signature = decode_tool_use_signature(id).or_else(|| {
+                                        (!saw_function_call
+                                            && model.starts_with(GEMINI_3_MODEL_PREFIX))
+                                        .then(|| GEMINI_THOUGHT_SIGNATURE_PLACEHOLDER.to_string())
+                                    });
+                                    let mut part = json!({
                                         "functionCall": {
                                             "name": name,
                                             "args": input
                                         }
-                                    }));
+                                    });
+                                    if let Some(signature) = signature {
+                                        part["thoughtSignature"] = Value::String(signature);
+                                    }
+                                    parts.push(part);
+                                    saw_function_call = true;
                                 }
                             }
                             "tool_result" => {
@@ -216,6 +239,14 @@ fn translate_messages(request: &Value) -> Result<Vec<Value>, AdapterError> {
     }
 
     Ok(contents)
+}
+
+fn decode_tool_use_signature(id: &str) -> Option<String> {
+    let encoded = id.strip_prefix(GEMINI_TOOL_USE_ID_PREFIX)?;
+    let bytes = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    String::from_utf8(bytes)
+        .ok()
+        .filter(|signature| !signature.is_empty())
 }
 
 fn extract_tool_result_content(block: &Value) -> Result<Value, AdapterError> {

--- a/tests/gemini_translate.rs
+++ b/tests/gemini_translate.rs
@@ -1,6 +1,8 @@
 use serde_json::json;
 use shunt::model::gemini::{map_gemini_error, translate_gemini_error_val, GeminiSseMachine};
-use shunt::model::gemini_request::{translate_request, wrap_code_assist_envelope};
+use shunt::model::gemini_request::{
+    translate_request, translate_request_for_model, wrap_code_assist_envelope,
+};
 
 #[test]
 fn test_translate_plain_user_message() {
@@ -140,6 +142,176 @@ fn test_tool_result_uses_original_function_name() {
         translated["contents"][2]["parts"][0]["functionResponse"]["name"],
         "get_weather"
     );
+}
+
+#[test]
+fn test_gemini_3_thought_signature_survives_tool_round_trip() {
+    let signature = "opaque-step-1-signature";
+    let mut machine = GeminiSseMachine::new("gemini-3.1-pro-preview");
+    let chunk = json!({
+        "candidates": [{
+            "content": {
+                "role": "model",
+                "parts": [{
+                    "functionCall": {
+                        "name": "default_api:Read",
+                        "args": { "file_path": "a.tex" }
+                    },
+                    "thoughtSignature": signature
+                }]
+            },
+            "finishReason": "STOP"
+        }]
+    });
+
+    let events = machine.process_chunk(&chunk);
+    assert_eq!(events[1].event, "content_block_start");
+    assert_eq!(events[1].data["content_block"]["type"], "tool_use");
+    assert_eq!(events[1].data["index"], 0);
+    assert!(events[1].data["content_block"]["id"]
+        .as_str()
+        .unwrap()
+        .starts_with("call_gemini_v1_"));
+    let assistant_content = machine.final_json()["content"].clone();
+    let tool_use_id = assistant_content
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|block| block["type"] == "tool_use")
+        .and_then(|block| block["id"].as_str())
+        .unwrap();
+    let request = json!({
+        "messages": [
+            { "role": "user", "content": "Read a.tex" },
+            { "role": "assistant", "content": assistant_content },
+            { "role": "user", "content": [{
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": "file contents"
+            }]}
+        ]
+    });
+
+    let translated = translate_request(&request).unwrap();
+    assert_eq!(
+        translated["contents"][1]["parts"][0]["thoughtSignature"],
+        signature
+    );
+}
+
+#[test]
+fn test_gemini_3_parallel_calls_keep_signature_on_first_call() {
+    let request = json!({
+        "messages": [{
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call_gemini_v1_cGFyYWxsZWwtc2lnbmF0dXJl",
+                    "name": "read_file",
+                    "input": { "path": "a.tex" }
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_2",
+                    "name": "read_file",
+                    "input": { "path": "b.tex" }
+                }
+            ]
+        }]
+    });
+
+    let translated = translate_request_for_model(&request, "gemini-3.1-pro-preview").unwrap();
+    let parts = translated["contents"][0]["parts"].as_array().unwrap();
+    assert_eq!(parts[0]["thoughtSignature"], "parallel-signature");
+    assert!(parts[1].get("thoughtSignature").is_none());
+}
+
+#[test]
+fn test_gemini_3_sequential_steps_keep_distinct_signatures() {
+    let request = json!({
+        "messages": [
+            { "role": "user", "content": "Read both files" },
+            { "role": "assistant", "content": [
+                { "type": "tool_use", "id": "call_gemini_v1_c3RlcC0x", "name": "read_file", "input": { "path": "a.tex" } }
+            ]},
+            { "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "call_gemini_v1_c3RlcC0x", "content": "a" }
+            ]},
+            { "role": "assistant", "content": [
+                { "type": "tool_use", "id": "call_gemini_v1_c3RlcC0y", "name": "read_file", "input": { "path": "b.tex" } }
+            ]}
+        ]
+    });
+
+    let translated = translate_request_for_model(&request, "gemini-3.1-pro-preview").unwrap();
+    assert_eq!(
+        translated["contents"][1]["parts"][0]["thoughtSignature"],
+        "step-1"
+    );
+    assert_eq!(
+        translated["contents"][3]["parts"][0]["thoughtSignature"],
+        "step-2"
+    );
+}
+
+#[test]
+fn test_unsigned_gemini_3_history_uses_documented_placeholder() {
+    let request = json!({
+        "messages": [{
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_imported",
+                "name": "read_file",
+                "input": { "path": "a.tex" }
+            }]
+        }]
+    });
+
+    let translated = translate_request_for_model(&request, "gemini-3.1-pro-preview").unwrap();
+    assert_eq!(
+        translated["contents"][0]["parts"][0]["thoughtSignature"],
+        "context_engineering_is_the_way to_go"
+    );
+}
+
+#[test]
+fn test_foreign_tool_use_id_uses_gemini_3_placeholder() {
+    let request = json!({
+        "messages": [{
+            "role": "assistant",
+            "content": [
+                { "type": "tool_use", "id": "toolu_foreign", "name": "read_file", "input": {} }
+            ]
+        }]
+    });
+
+    let translated = translate_request_for_model(&request, "gemini-3.1-pro-preview").unwrap();
+    assert_eq!(
+        translated["contents"][0]["parts"][0]["thoughtSignature"],
+        "context_engineering_is_the_way to_go"
+    );
+}
+
+#[test]
+fn test_unsigned_gemini_2_5_history_stays_unsigned() {
+    let request = json!({
+        "messages": [{
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_legacy",
+                "name": "read_file",
+                "input": { "path": "a.tex" }
+            }]
+        }]
+    });
+
+    let translated = translate_request_for_model(&request, "gemini-2.5-pro").unwrap();
+    assert!(translated["contents"][0]["parts"][0]
+        .get("thoughtSignature")
+        .is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve each Gemini 3 function-call `thoughtSignature` across the Anthropic `tool_use` / `tool_result` round trip
- encode the opaque signature in `tool_use.id`, which Claude Code returns as the tool-result join key even when thinking is disabled
- restore the signature to the corresponding Gemini `functionCall`; use Google's documented placeholder only for imported unsigned Gemini 3 history
- cover streaming/non-streaming, sequential/parallel calls, malformed or foreign ids, and Gemini 2.5 compatibility

Closes #237

## Milestone / spec

Gemini provider follow-up to #233 and #234. The continuation invariant is recorded in `docs/plans/gemini-provider/TICKETS.md` and current verification state in `STATUS.md`.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (1,189 tests; deterministic translation coverage added)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated for the continuation invariant
- [x] User-facing docs considered: no config, endpoint, CLI, provider/model-support, or setup behavior changes; README/site changes are not needed
- [x] No GitHub Actions added

## Observed verification

The original deterministic round trip failed because the reconstructed function-call history had `thoughtSignature: null`; it now preserves the exact opaque value. Focused Gemini translation tests pass 15/15, and the full workspace passes 1,189/1,189 tests.

An isolated live gateway on a separate port confirmed Gemini 3.1 Pro returns a signature-bearing tool call and the adapter emits the encoded join id. Google returned provider-side HTTP 429 on immediate continuation attempts for both Pro and Flash, so a live two-tool completion remains quota-blocked; no post-fix missing-signature 400 was observed.

## Notes for reviewers

Review the carrier boundary in `src/model/gemini.rs` and `src/model/gemini_request.rs`: the signature is opaque gateway continuation state, is not placed in tool arguments, and is decoded only from shunt's namespaced ids. The adapter passes the resolved `route.upstream_model` so Gemini 3 fallback behavior does not depend on a local alias.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Gemini 3 `functionCall.thoughtSignature` across tool turns by packing it into `tool_use.id` and restoring it on the next request. Fixes continuation 400s and works for streaming, non-streaming, sequential, and parallel calls; Gemini 2.5 stays unchanged.

- **Bug Fixes**
  - Encode signature into namespaced `tool_use.id` (`call_gemini_v1_{base64url}`) and decode back to `functionCall.thoughtSignature`.
  - Use Google’s placeholder for imported unsigned Gemini 3 history (`context_engineering_is_the_way to_go`); never add it for Gemini 2.5.
  - Tolerates malformed/foreign ids without breaking continuation.
  - Adapter now uses `translate_request_for_model` with the resolved upstream model; adds focused tests for signatures and compatibility.

<sup>Written for commit b2bbcde91222b545320b85f9a189e54dff16b447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

