### PR TITLE
fix(proxy): move count_tokens tiktoken encoding off the async runtime

### DIFF
--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -254,7 +254,10 @@ async fn count_tokens_response(
             .unwrap_or(CountTokens::Estimate);
         Ok(match mode {
             CountTokens::Tiktoken => {
-                let input_tokens = count_tokens::count_input_tokens(&body);
+                let input_tokens =
+                    tokio::task::spawn_blocking(move || count_tokens::count_input_tokens(&body))
+                        .await
+                        .unwrap_or(0);
                 (
                     StatusCode::OK,
                     axum::Json(serde_json::json!({ "input_tokens": input_tokens })).into_response(),


### PR DESCRIPTION
## Summary

- Prevent large local `count_tokens` requests from stalling unrelated Tokio runtime work.
- Move the CPU-bound tiktoken encoding onto Tokio's blocking pool.
- Preserve the existing `0` fallback when the blocking task cannot be joined.

Closes #246

## Milestone / spec

Internal performance fix; no documented behavior or protocol semantics change.

## Test evidence

- `cargo build --all-features`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` (957 library tests plus all integration suites passed)
- `cargo test --all-features --test passthrough count_tokens_uses_tiktoken_by_default -- --exact`

## Documentation

- README: considered; no update needed because setup and capabilities are unchanged.
- `docs/`: considered; no implementation semantics or spec changed.
- `site/`: considered; no user-facing behavior, config, endpoint, or CLI change.
- `wiki/`: considered; generated content was not edited.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (existing focused endpoint coverage remains green)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec unchanged because behavior semantics are unchanged
- [x] User-facing docs considered; no update required
- [x] No GitHub Actions changed

## Notes for reviewers

The implementation mirrors the existing Responses HTTP/WebSocket input-estimation pattern: `spawn_blocking(...).await.unwrap_or(0)`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `tiktoken` encoding for `count_tokens` off the async runtime using `tokio::task::spawn_blocking` to avoid stalling other tasks. Keeps the 0-token fallback when the blocking task cannot be joined; no API or protocol changes.

<sup>Written for commit bf643e1fba4f0e335b1f3290f923c1a931e3a025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

