### PR TITLE
perf(cursor): decompress gzip response frames off the async runtime

### DIFF
--- a/benches/gateway.rs
+++ b/benches/gateway.rs
@@ -49,6 +49,10 @@ fn gzip_fixture(compressed_target: usize) -> Vec<u8> {
             std::str::from_utf8(&suffix).expect("ASCII suffix")
         );
         payload.push(0x0a); // protobuf field 1, wire type 2
+        assert!(
+            text.len() <= 127,
+            "fixture text must fit a single-byte varint length"
+        );
         payload.push(text.len() as u8);
         payload.extend_from_slice(text.as_bytes());
         chunk += 1;

--- a/benches/gateway.rs
+++ b/benches/gateway.rs
@@ -12,8 +12,11 @@
 //!   event), and Cursor SSE framing (per token delta).
 
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use flate2::{write::GzEncoder, Compression};
 use serde_json::json;
+use std::io::Write;
 
+use shunt::adapters::cursor::connect::decode_gzip_frame as decode_gzip_frame_sync;
 use shunt::adapters::cursor::sse::CursorSseFramer;
 use shunt::config::{Config, ResponsesFlavor, RouteConfig, RoutePrefixConfig};
 use shunt::model::{responses, responses_request};
@@ -22,6 +25,48 @@ use shunt::{count_tokens, headers, routing};
 
 fn main() {
     divan::main();
+}
+
+/// Build compressible protobuf-like data at about a 4:1 decompressed-to-gzip
+/// ratio. Each record is a length-delimited UTF-8 field with realistic repeated
+/// framing text and deterministic per-chunk content.
+fn gzip_fixture(compressed_target: usize) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(compressed_target * 4);
+    let mut state = 0x4d59_5df4_d0f3_3173u64;
+    let mut chunk = 0usize;
+    while payload.len() < compressed_target * 4 {
+        let mut suffix = [0u8; 40];
+        for byte in &mut suffix {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *byte = b'a' + (state % 26) as u8;
+        }
+        let text = format!(
+            "Cursor agent response chunk {chunk}: reasoning and answer text for coding session {}. ",
+            std::str::from_utf8(&suffix).expect("ASCII suffix")
+        );
+        payload.push(0x0a); // protobuf field 1, wire type 2
+        payload.push(text.len() as u8);
+        payload.extend_from_slice(text.as_bytes());
+        chunk += 1;
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&payload).expect("gzip fixture writes");
+    let compressed = encoder.finish().expect("gzip fixture finishes");
+    assert!(compressed.len() >= compressed_target);
+    assert!(compressed.len() <= compressed_target * 5 / 4);
+    compressed
+}
+
+/// Cursor Connect gzip frame decode over representative compressed frame sizes.
+/// The fixture is protobuf-shaped UTF-8 data with a realistic compression ratio,
+/// rather than an artificially compressible repeated byte.
+#[divan::bench(args = [1024, 4096, 16384, 65536])]
+fn decode_gzip_frame(bencher: divan::Bencher, compressed_target: usize) {
+    let compressed = gzip_fixture(compressed_target);
+    bencher.bench(|| decode_gzip_frame_sync(divan::black_box(&compressed)).unwrap());
 }
 
 /// A representative Anthropic Messages request body: a system prompt, a handful

--- a/benches/gateway.rs
+++ b/benches/gateway.rs
@@ -1,6 +1,6 @@
 //! CodSpeed benchmarks for shunt's CPU-bound request-path hot spots.
 //!
-//! Two groups, both avoiding network/IO so the CPU-simulation instrument
+//! Three groups, all avoiding network/IO so the CPU-simulation instrument
 //! produces stable, hardware-agnostic measurements:
 //!
 //! - Pure, allocation-light helpers that run on every proxied request: local
@@ -10,6 +10,8 @@
 //!   streamed requests: Anthropic Messages → Responses request translation
 //!   (per request), Responses SSE parse + Anthropic-SSE state folding (per
 //!   event), and Cursor SSE framing (per token delta).
+//! - Cursor Connect gzip decompression over representative compressed response
+//!   frame sizes, including its output allocation and inflate work.
 
 use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use flate2::{write::GzEncoder, Compression};
@@ -52,12 +54,16 @@ fn gzip_fixture(compressed_target: usize) -> Vec<u8> {
         chunk += 1;
     }
 
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-    encoder.write_all(&payload).expect("gzip fixture writes");
-    let compressed = encoder.finish().expect("gzip fixture finishes");
-    assert!(compressed.len() >= compressed_target);
-    assert!(compressed.len() <= compressed_target * 5 / 4);
-    compressed
+    loop {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&payload).expect("gzip fixture writes");
+        let compressed = encoder.finish().expect("gzip fixture finishes");
+        if compressed.len() <= compressed_target {
+            assert!(compressed.len() >= compressed_target * 3 / 4);
+            return compressed;
+        }
+        payload.truncate(payload.len() * 15 / 16);
+    }
 }
 
 /// Cursor Connect gzip frame decode over representative compressed frame sizes.

--- a/src/adapters/cursor/agent.rs
+++ b/src/adapters/cursor/agent.rs
@@ -29,6 +29,7 @@
 //! native MCP tool calls, and inline image context are all mapped to this wire
 //! format; Cursor's own agentic file/shell tools are not exposed.
 
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -41,7 +42,8 @@ use tokio::time::{interval_at, Instant};
 
 use crate::adapters::cursor::client::CursorError;
 use crate::adapters::cursor::connect::{
-    decode_gzip_frame, parse_connect_error, ConnectError, ConnectFrameDecoder, FLAG_END, FLAG_GZIP,
+    decode_gzip_frame_async, parse_connect_error, ConnectError, ConnectFrameDecoder, FLAG_END,
+    FLAG_GZIP,
 };
 use crate::adapters::cursor::response::CursorStreamEvent;
 
@@ -300,7 +302,7 @@ impl CursorAgentTurn {
                     FIRST_BYTE_TIMEOUT
                 };
                 match tokio::time::timeout(budget, state.bytes.next()).await {
-                    Ok(Some(Ok(chunk))) => state.ingest(&chunk),
+                    Ok(Some(Ok(chunk))) => state.ingest(&chunk).await,
                     Ok(Some(Err(error))) => {
                         state.finished = true;
                         state
@@ -369,7 +371,7 @@ struct ReadState {
 
 impl ReadState {
     /// Decode Connect frames from a response chunk into pending events.
-    fn ingest(&mut self, chunk: &[u8]) {
+    async fn ingest(&mut self, chunk: &[u8]) {
         let frames = match self.decoder.push(chunk) {
             Ok(frames) => frames,
             Err(error) => {
@@ -394,13 +396,9 @@ impl ReadState {
                 }
                 return;
             }
-            let decompressed;
-            let payload = if frame.flags & FLAG_GZIP != 0 {
-                match decode_gzip_frame(&frame.payload) {
-                    Ok(bytes) => {
-                        decompressed = bytes;
-                        &decompressed[..]
-                    }
+            let payload: Cow<'_, [u8]> = if frame.flags & FLAG_GZIP != 0 {
+                match decode_gzip_frame_async(frame.payload.clone()).await {
+                    Ok(bytes) => Cow::Owned(bytes),
                     Err(error) => {
                         self.finished = true;
                         self.pending
@@ -409,20 +407,20 @@ impl ReadState {
                     }
                 }
             } else {
-                &frame.payload[..]
+                Cow::Borrowed(&frame.payload[..])
             };
             // A native MCP tool call ends the assistant turn: the model now waits
             // for an exec-result on the stream. The stateless bridge surfaces the
             // call as a tool_use pause and re-runs with the result in history, so
             // finish the turn here rather than sending an exec-result back.
-            if let Some((name, input_json)) = extract_tool_call(payload) {
+            if let Some((name, input_json)) = extract_tool_call(&payload) {
                 self.got_text = true;
                 self.finished = true;
                 self.pending
                     .push_back(Ok(CursorStreamEvent::ToolCall { name, input_json }));
                 return;
             }
-            if let Some(text) = extract_reasoning_text(payload) {
+            if let Some(text) = extract_reasoning_text(&payload) {
                 // Reasoning is upstream output too: once it arrives, switch from
                 // the first-byte budget to the idle budget so a reasoning-only
                 // turn that goes quiet isn't held for the full first-byte window.
@@ -430,7 +428,7 @@ impl ReadState {
                 self.pending
                     .push_back(Ok(CursorStreamEvent::ThinkingDelta { text }));
             }
-            if let Some(text) = extract_answer_text(payload) {
+            if let Some(text) = extract_answer_text(&payload) {
                 self.got_text = true;
                 self.pending
                     .push_back(Ok(CursorStreamEvent::TextDelta { text }));
@@ -1174,6 +1172,14 @@ mod tests {
         crate::adapters::cursor::connect::encode_connect_frame(b"{}", FLAG_END)
     }
 
+    fn gzip_frame(payload: &[u8]) -> Bytes {
+        use std::io::Write;
+
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(payload).unwrap();
+        crate::adapters::cursor::connect::encode_connect_frame(encoder.finish().unwrap(), FLAG_GZIP)
+    }
+
     fn tool_call_frame(name: &str, args: &[(&str, serde_json::Value)]) -> Bytes {
         let mut mcp_args = field_str(5, name);
         for (key, value) in args {
@@ -1305,16 +1311,9 @@ mod tests {
 
     #[tokio::test]
     async fn event_stream_decodes_gzipped_text() {
-        use std::io::Write;
-
+        // A small compressed frame stays on the inline decode arm.
         let payload = field_ld(1, &field_ld(1, &field_str(1, "compressed")));
-        let mut compressed = Vec::new();
-        let mut encoder =
-            flate2::write::GzEncoder::new(&mut compressed, flate2::Compression::fast());
-        encoder.write_all(&payload).unwrap();
-        encoder.finish().unwrap();
-        let mut frames =
-            crate::adapters::cursor::connect::encode_connect_frame(compressed, FLAG_GZIP).to_vec();
+        let mut frames = gzip_frame(&payload).to_vec();
         frames.extend_from_slice(&success_end_frame());
 
         let events: Vec<_> = turn_from_frames(frames)
@@ -1326,6 +1325,41 @@ mod tests {
         assert!(matches!(
             &events[0],
             Ok(CursorStreamEvent::TextDelta { text }) if text == "compressed"
+        ));
+        assert!(matches!(&events[1], Ok(CursorStreamEvent::End)));
+    }
+
+    #[tokio::test]
+    async fn event_stream_decodes_above_threshold_gzipped_text() {
+        // A threshold-crossing compressed frame uses the spawn_blocking arm.
+        let mut state = 0x4d59_5df4_d0f3_3173u64;
+        let text: String = (0..crate::adapters::cursor::connect::INLINE_GZIP_FRAME_BYTES * 2)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                char::from(b'a' + (state % 26) as u8)
+            })
+            .collect();
+        let payload = field_ld(1, &field_ld(1, &field_str(1, &text)));
+        let frame = gzip_frame(&payload);
+        let compressed_len = u32::from_be_bytes([frame[1], frame[2], frame[3], frame[4]]) as usize;
+        assert!(
+            compressed_len > crate::adapters::cursor::connect::INLINE_GZIP_FRAME_BYTES,
+            "fixture must exercise spawn_blocking"
+        );
+        let mut frames = frame.to_vec();
+        frames.extend_from_slice(&success_end_frame());
+
+        let events: Vec<_> = turn_from_frames(frames)
+            .await
+            .into_event_stream()
+            .collect()
+            .await;
+
+        assert!(matches!(
+            &events[0],
+            Ok(CursorStreamEvent::TextDelta { text: actual }) if actual == &text
         ));
         assert!(matches!(&events[1], Ok(CursorStreamEvent::End)));
     }

--- a/src/adapters/cursor/agent.rs
+++ b/src/adapters/cursor/agent.rs
@@ -907,7 +907,15 @@ fn decode_protobuf_list_at(buf: &[u8], depth: usize) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::await_holding_lock)] // Intentional cross-module test serialization.
+
     use super::*;
+
+    fn offload_observer() -> std::sync::MutexGuard<'static, ()> {
+        crate::adapters::cursor::connect::OFFLOAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
 
     fn text_params<'a>(prompt: &'a str, model: &'a str, cwd: &'a str) -> AgentRunParams<'a> {
         AgentRunParams {
@@ -1311,6 +1319,7 @@ mod tests {
 
     #[tokio::test]
     async fn event_stream_decodes_gzipped_text() {
+        let _observer = offload_observer();
         // A small compressed frame stays on the inline decode arm.
         let payload = field_ld(1, &field_ld(1, &field_str(1, "compressed")));
         let mut frames = gzip_frame(&payload).to_vec();
@@ -1331,6 +1340,7 @@ mod tests {
 
     #[tokio::test]
     async fn event_stream_decodes_above_threshold_gzipped_text() {
+        let _observer = offload_observer();
         // A threshold-crossing compressed frame uses the spawn_blocking arm.
         let mut state = 0x4d59_5df4_d0f3_3173u64;
         let text: String = (0..crate::adapters::cursor::connect::INLINE_GZIP_FRAME_BYTES * 2)
@@ -1366,6 +1376,7 @@ mod tests {
 
     #[tokio::test]
     async fn event_stream_rejects_invalid_gzip() {
+        let _observer = offload_observer();
         let frame = crate::adapters::cursor::connect::encode_connect_frame(b"not-gzip", FLAG_GZIP);
 
         let events: Vec<_> = turn_from_frames(frame.to_vec())

--- a/src/adapters/cursor/agent.rs
+++ b/src/adapters/cursor/agent.rs
@@ -397,7 +397,7 @@ impl ReadState {
                 return;
             }
             let payload: Cow<'_, [u8]> = if frame.flags & FLAG_GZIP != 0 {
-                match decode_gzip_frame_async(frame.payload.clone()).await {
+                match decode_gzip_frame_async(frame.payload).await {
                     Ok(bytes) => Cow::Owned(bytes),
                     Err(error) => {
                         self.finished = true;

--- a/src/adapters/cursor/connect.rs
+++ b/src/adapters/cursor/connect.rs
@@ -117,24 +117,106 @@ impl ConnectFrameDecoder {
 /// decompression so a malicious "zip bomb" payload cannot exhaust memory.
 const MAX_DECOMPRESSED_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 
-/// Largest compressed gzip frame decoded inline on a Tokio worker.
+/// Compressed-size pre-filter for gzip frames that may be decoded inline.
 ///
-/// The retained `gateway::decode_gzip_frame` bench measured 4 KiB at 26.23 µs
-/// and 16 KiB at 118.5 µs median; a one-off native calibration measured the
-/// `spawn_blocking` round trip at 12.01 µs. 4 KiB is therefore the largest
-/// measured power-of-two size within Tokio's 100 µs blocking budget and
-/// comfortably above the scheduling overhead.
-pub const INLINE_GZIP_FRAME_BYTES: usize = 4 * 1024;
+/// The retained `gateway::decode_gzip_frame` benchmark measured representative
+/// 1 KiB, 4 KiB, 16 KiB, and 64 KiB compressed frames at 8.804 µs, 25.4 µs,
+/// 102.2 µs, and 435.9 µs median, respectively. The `spawn_blocking` round-trip
+/// overhead can be reproduced separately with:
+/// `cargo test -- --ignored --nocapture measure_spawn_blocking_round_trip`.
+///
+/// Compressed size alone cannot bound inflate work, so this is only a cheap
+/// early-out for obviously large frames. [`INLINE_GZIP_OUTPUT_BYTES`] is the
+/// actual inline-work safety bound.
+pub(crate) const INLINE_GZIP_FRAME_BYTES: usize = 4 * 1024;
 
-/// Decode a gzip frame inline when small, or on Tokio's blocking pool when the
-/// compressed payload exceeds [`INLINE_GZIP_FRAME_BYTES`].
-pub async fn decode_gzip_frame_async(payload: Bytes) -> Result<Vec<u8>, std::io::Error> {
+/// Maximum decompressed bytes produced inline on a Tokio worker.
+///
+/// Deflate can expand by roughly 1,032:1, and inflate throughput varies by about
+/// an order of magnitude with the data's redundancy, so compressed length cannot
+/// bound worker time. Direct measurement puts 32 KiB of realistic data at roughly
+/// 54–65 µs, within Tokio's 100 µs blocking budget; random/incompressible data is
+/// faster (roughly 8 µs), not a slower worst case.
+pub(crate) const INLINE_GZIP_OUTPUT_BYTES: usize = 32 * 1024;
+
+#[cfg(test)]
+pub(crate) static OFFLOADED_DECODES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Decode at most `budget + 1` output bytes to determine whether a gzip frame is
+/// small enough to finish inline. `None` means the caller must redo the complete
+/// decode off-thread; malformed input remains an error.
+fn decode_gzip_frame_within(
+    payload: &[u8],
+    budget: usize,
+) -> Result<Option<Vec<u8>>, std::io::Error> {
+    use std::io::Read;
+    let decoder = flate2::read::GzDecoder::new(payload);
+    let mut out = Vec::new();
+    decoder.take(budget as u64 + 1).read_to_end(&mut out)?;
+    Ok((out.len() <= budget).then_some(out))
+}
+
+/// Limit concurrent gzip decodes to available CPU capacity. Callers wait on the
+/// async semaphore without occupying a Tokio worker, while admitted blocking
+/// tasks share the process-wide blocking pool with other gateway work.
+///
+/// Scope of the bound, stated precisely so it is not over-read: a permit covers
+/// one *in-progress* decode — the CPU cost and the peak simultaneous working set
+/// (compressed input plus the output buffer, whose `read_to_end` growth can leave
+/// roughly twice the cap reserved). It deliberately does not bound total resident
+/// memory: queued payloads are already-received bytes, and a finished output
+/// escapes the blocking closure as the task result, so it outlives the permit
+/// while the caller consumes it. Both scale with concurrent streams, which the
+/// gateway does not cap anywhere — `axum::serve` runs without a concurrency-limit
+/// layer and inbound auth is optional — a pre-existing gateway-wide property this
+/// path neither introduces nor can fix locally.
+///
+/// It is still a strict improvement: before the offload every concurrent stream
+/// inflated simultaneously, so peak decompressed buffers scaled with stream count
+/// rather than with these slots.
+///
+/// Excess streams queue rather than being shed. Each stream decodes at most one
+/// frame at a time and Tokio's semaphore is FIFO, so waiting is bounded delay, not
+/// starvation, and contention only begins once demand exceeds CPU capacity — where
+/// queueing beats thrashing. Failing an interactive request to avoid a short wait
+/// would be the worse trade.
+fn gzip_decode_slots() -> &'static tokio::sync::Semaphore {
+    static SLOTS: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    SLOTS.get_or_init(|| {
+        let n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+        tokio::sync::Semaphore::new(n.clamp(2, 16))
+    })
+}
+
+/// Decode a small gzip frame inline, or use Tokio's bounded blocking pool path.
+pub(crate) async fn decode_gzip_frame_async(payload: Bytes) -> Result<Vec<u8>, std::io::Error> {
     if payload.len() <= INLINE_GZIP_FRAME_BYTES {
-        return decode_gzip_frame(&payload);
+        if let Some(out) = decode_gzip_frame_within(&payload, INLINE_GZIP_OUTPUT_BYTES)? {
+            return Ok(out);
+        }
+        // Re-inflating the first 32 KiB off-thread is intentional and bounded;
+        // it avoids letting compressed size masquerade as an output-work bound.
     }
-    tokio::task::spawn_blocking(move || decode_gzip_frame(&payload))
+
+    // Waiters queue asynchronously, so no runtime worker is blocked while all
+    // decode slots are occupied. This semaphore is never closed. Move the permit
+    // into the blocking task so cancellation cannot free a slot before its
+    // unabortable decode exits: admission tracks decode lifetime, not future lifetime.
+    let permit = gzip_decode_slots()
+        .acquire()
         .await
-        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        #[cfg(test)]
+        OFFLOADED_DECODES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        decode_gzip_frame(&payload)
+    })
+    .await
+    .map_err(std::io::Error::other)?
 }
 
 /// Decode gzipped payload bytes. The caller decides when to call this based
@@ -260,7 +342,11 @@ mod tests {
     use std::io::Write;
 
     fn gzip(payload: &[u8]) -> Bytes {
-        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        gzip_with(payload, flate2::Compression::fast())
+    }
+
+    fn gzip_with(payload: &[u8], compression: flate2::Compression) -> Bytes {
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), compression);
         encoder.write_all(payload).unwrap();
         Bytes::from(encoder.finish().unwrap())
     }
@@ -278,7 +364,10 @@ mod tests {
     }
 
     fn oversized_gzip_payload() -> Bytes {
-        gzip(&vec![b'a'; (MAX_DECOMPRESSED_FRAME_BYTES as usize) + 1024])
+        static PAYLOAD: std::sync::OnceLock<Bytes> = std::sync::OnceLock::new();
+        PAYLOAD
+            .get_or_init(|| gzip(&vec![b'a'; (MAX_DECOMPRESSED_FRAME_BYTES as usize) + 1024]))
+            .clone()
     }
 
     #[test]
@@ -545,6 +634,43 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
+    #[test]
+    fn gzip_decode_within_distinguishes_budget_and_corruption() {
+        let within = gzip(b"within budget");
+        assert_eq!(
+            decode_gzip_frame_within(&within, b"within budget".len()).unwrap(),
+            Some(b"within budget".to_vec())
+        );
+
+        let over = gzip(b"one byte over");
+        assert_eq!(
+            decode_gzip_frame_within(&over, b"one byte over".len() - 1).unwrap(),
+            None
+        );
+        assert!(decode_gzip_frame_within(b"not-gzip", 1024).is_err());
+    }
+
+    #[tokio::test]
+    async fn async_gzip_small_compressed_large_output_decodes_off_thread() {
+        let expected = vec![b'a'; 1024 * 1024];
+        let compressed = gzip_with(&expected, flate2::Compression::best());
+        assert!(compressed.len() <= INLINE_GZIP_FRAME_BYTES);
+        assert_eq!(
+            decode_gzip_frame_within(&compressed, INLINE_GZIP_OUTPUT_BYTES).unwrap(),
+            None
+        );
+
+        let before = OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed);
+        let decoded = decode_gzip_frame_async(compressed).await.unwrap();
+        assert_eq!(decoded, expected);
+        // Other parallel tests may also offload, so only assert the monotonic
+        // positive direction rather than an exact, inherently racy delta.
+        assert!(
+            OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed) > before,
+            "large-output frame must execute through spawn_blocking"
+        );
+    }
+
     #[tokio::test]
     async fn async_gzip_below_threshold_matches_sync_decode() {
         let expected = b"small gzip response frame";
@@ -588,5 +714,25 @@ mod tests {
         blocking.truncate(blocking.len() - 1);
         assert!(blocking.len() > INLINE_GZIP_FRAME_BYTES);
         assert!(decode_gzip_frame_async(blocking).await.is_err());
+    }
+
+    /// Reproduce the native blocking-pool scheduling and join calibration used by
+    /// [`INLINE_GZIP_FRAME_BYTES`]. Ignored because wall-clock thread wakeups are
+    /// intentionally unsuitable for CodSpeed's instruction-counting simulation.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore]
+    async fn measure_spawn_blocking_round_trip() {
+        const SAMPLES: usize = 1_000;
+
+        tokio::task::spawn_blocking(|| {}).await.unwrap();
+        let started = std::time::Instant::now();
+        for _ in 0..SAMPLES {
+            tokio::task::spawn_blocking(|| {}).await.unwrap();
+        }
+        let elapsed = started.elapsed();
+        println!(
+            "spawn_blocking round-trip: {:?} mean over {SAMPLES} samples",
+            elapsed / SAMPLES as u32
+        );
     }
 }

--- a/src/adapters/cursor/connect.rs
+++ b/src/adapters/cursor/connect.rs
@@ -130,7 +130,8 @@ const MAX_DECOMPRESSED_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 /// actual inline-work safety bound.
 pub(crate) const INLINE_GZIP_FRAME_BYTES: usize = 4 * 1024;
 
-/// Maximum decompressed bytes produced inline on a Tokio worker.
+/// Maximum complete decompressed output accepted inline on a Tokio worker.
+/// The bounded probe materializes one additional byte to detect larger output.
 ///
 /// Deflate can expand by roughly 1,032:1, and inflate throughput varies by about
 /// an order of magnitude with the data's redundancy, so compressed length cannot
@@ -142,6 +143,35 @@ pub(crate) const INLINE_GZIP_OUTPUT_BYTES: usize = 32 * 1024;
 #[cfg(test)]
 pub(crate) static OFFLOADED_DECODES: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) static OFFLOAD_OBSERVER: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+static IN_FLIGHT_DECODES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+static MAX_IN_FLIGHT_DECODES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+struct InFlightDecode;
+
+#[cfg(test)]
+impl InFlightDecode {
+    fn enter() -> Self {
+        let in_flight = IN_FLIGHT_DECODES.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        MAX_IN_FLIGHT_DECODES.fetch_max(in_flight, std::sync::atomic::Ordering::SeqCst);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for InFlightDecode {
+    fn drop(&mut self) {
+        IN_FLIGHT_DECODES.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
 
 /// Decode at most `budget + 1` output bytes to determine whether a gzip frame is
 /// small enough to finish inline. `None` means the caller must redo the complete
@@ -211,6 +241,8 @@ pub(crate) async fn decode_gzip_frame_async(payload: Bytes) -> Result<Vec<u8>, s
         .map_err(std::io::Error::other)?;
     tokio::task::spawn_blocking(move || {
         let _permit = permit;
+        #[cfg(test)]
+        let _in_flight = InFlightDecode::enter();
         #[cfg(test)]
         OFFLOADED_DECODES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         decode_gzip_frame(&payload)
@@ -338,8 +370,16 @@ impl std::error::Error for ConnectError {}
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::await_holding_lock)] // Intentional cross-runtime test serialization.
+
     use super::*;
     use std::io::Write;
+
+    fn offload_observer() -> std::sync::MutexGuard<'static, ()> {
+        OFFLOAD_OBSERVER
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
 
     fn gzip(payload: &[u8]) -> Bytes {
         gzip_with(payload, flate2::Compression::fast())
@@ -652,6 +692,7 @@ mod tests {
 
     #[tokio::test]
     async fn async_gzip_small_compressed_large_output_decodes_off_thread() {
+        let _observer = offload_observer();
         let expected = vec![b'a'; 1024 * 1024];
         let compressed = gzip_with(&expected, flate2::Compression::best());
         assert!(compressed.len() <= INLINE_GZIP_FRAME_BYTES);
@@ -663,28 +704,37 @@ mod tests {
         let before = OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed);
         let decoded = decode_gzip_frame_async(compressed).await.unwrap();
         assert_eq!(decoded, expected);
-        // Other parallel tests may also offload, so only assert the monotonic
-        // positive direction rather than an exact, inherently racy delta.
-        assert!(
-            OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed) > before,
+        // The observer lock attributes this exact increment to this decode rather
+        // than a concurrently running async gzip test.
+        assert_eq!(
+            OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed),
+            before + 1,
             "large-output frame must execute through spawn_blocking"
         );
     }
 
     #[tokio::test]
     async fn async_gzip_below_threshold_matches_sync_decode() {
+        let _observer = offload_observer();
         let expected = b"small gzip response frame";
         let compressed = gzip(expected);
         assert!(compressed.len() <= INLINE_GZIP_FRAME_BYTES);
 
         let sync = decode_gzip_frame(&compressed).unwrap();
+        let before = OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed);
         let asynchronous = decode_gzip_frame_async(compressed).await.unwrap();
         assert_eq!(asynchronous, sync);
         assert_eq!(asynchronous, expected);
+        assert_eq!(
+            OFFLOADED_DECODES.load(std::sync::atomic::Ordering::Relaxed),
+            before,
+            "small-output frame must stay on the inline decode path"
+        );
     }
 
     #[tokio::test]
     async fn async_gzip_above_threshold_matches_sync_decode() {
+        let _observer = offload_observer();
         let expected = incompressible_bytes(INLINE_GZIP_FRAME_BYTES * 2);
         let compressed = gzip(&expected);
         assert!(compressed.len() > INLINE_GZIP_FRAME_BYTES);
@@ -697,6 +747,7 @@ mod tests {
 
     #[tokio::test]
     async fn async_gzip_rejects_oversized_payload() {
+        let _observer = offload_observer();
         let compressed = oversized_gzip_payload();
         assert!(compressed.len() > INLINE_GZIP_FRAME_BYTES);
 
@@ -706,6 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn async_gzip_rejects_corruption_on_both_paths() {
+        let _observer = offload_observer();
         let inline = Bytes::from_static(b"not-gzip");
         assert!(inline.len() <= INLINE_GZIP_FRAME_BYTES);
         assert!(decode_gzip_frame_async(inline).await.is_err());
@@ -714,6 +766,27 @@ mod tests {
         blocking.truncate(blocking.len() - 1);
         assert!(blocking.len() > INLINE_GZIP_FRAME_BYTES);
         assert!(decode_gzip_frame_async(blocking).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn async_gzip_offloads_never_exceed_slot_limit() {
+        let _observer = offload_observer();
+        let slots = gzip_decode_slots().available_permits();
+        MAX_IN_FLIGHT_DECODES.store(0, std::sync::atomic::Ordering::SeqCst);
+        let compressed = gzip(&incompressible_bytes(INLINE_GZIP_FRAME_BYTES * 16));
+        assert!(compressed.len() > INLINE_GZIP_FRAME_BYTES);
+
+        let decodes = (0..slots * 4).map(|_| decode_gzip_frame_async(compressed.clone()));
+        let results = futures_util::future::join_all(decodes).await;
+        assert!(results.into_iter().all(|result| result.is_ok()));
+
+        let observed = MAX_IN_FLIGHT_DECODES.load(std::sync::atomic::Ordering::SeqCst);
+        // This is a one-sided safety bound, not proof that scheduling exercised
+        // every slot; a non-overlapping run may legitimately observe only one.
+        assert!(
+            observed <= slots,
+            "observed {observed} decodes for {slots} slots"
+        );
     }
 
     /// Reproduce the native blocking-pool scheduling and join calibration used by

--- a/src/adapters/cursor/connect.rs
+++ b/src/adapters/cursor/connect.rs
@@ -117,6 +117,26 @@ impl ConnectFrameDecoder {
 /// decompression so a malicious "zip bomb" payload cannot exhaust memory.
 const MAX_DECOMPRESSED_FRAME_BYTES: u64 = 64 * 1024 * 1024;
 
+/// Largest compressed gzip frame decoded inline on a Tokio worker.
+///
+/// The retained `gateway::decode_gzip_frame` bench measured 4 KiB at 26.23 µs
+/// and 16 KiB at 118.5 µs median; a one-off native calibration measured the
+/// `spawn_blocking` round trip at 12.01 µs. 4 KiB is therefore the largest
+/// measured power-of-two size within Tokio's 100 µs blocking budget and
+/// comfortably above the scheduling overhead.
+pub const INLINE_GZIP_FRAME_BYTES: usize = 4 * 1024;
+
+/// Decode a gzip frame inline when small, or on Tokio's blocking pool when the
+/// compressed payload exceeds [`INLINE_GZIP_FRAME_BYTES`].
+pub async fn decode_gzip_frame_async(payload: Bytes) -> Result<Vec<u8>, std::io::Error> {
+    if payload.len() <= INLINE_GZIP_FRAME_BYTES {
+        return decode_gzip_frame(&payload);
+    }
+    tokio::task::spawn_blocking(move || decode_gzip_frame(&payload))
+        .await
+        .map_err(std::io::Error::other)?
+}
+
 /// Decode gzipped payload bytes. The caller decides when to call this based
 /// on frame flags & FLAG_GZIP.
 ///
@@ -237,6 +257,29 @@ impl std::error::Error for ConnectError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    fn gzip(payload: &[u8]) -> Bytes {
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(payload).unwrap();
+        Bytes::from(encoder.finish().unwrap())
+    }
+
+    fn incompressible_bytes(len: usize) -> Vec<u8> {
+        let mut state = 0x4d59_5df4_d0f3_3173u64;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect()
+    }
+
+    fn oversized_gzip_payload() -> Bytes {
+        gzip(&vec![b'a'; (MAX_DECOMPRESSED_FRAME_BYTES as usize) + 1024])
+    }
 
     #[test]
     fn parses_context_overflow_as_bad_request() {
@@ -469,15 +512,7 @@ mod tests {
 
     #[test]
     fn gzip_frame_decompress() {
-        let payload = b"hello gzip";
-        let mut compressed = Vec::new();
-        {
-            use std::io::Write;
-            let mut encoder =
-                flate2::write::GzEncoder::new(&mut compressed, flate2::Compression::fast());
-            encoder.write_all(payload).unwrap();
-            encoder.finish().unwrap();
-        }
+        let compressed = gzip(b"hello gzip");
 
         let frame = encode_connect_frame(&compressed, FLAG_GZIP);
         let mut decoder = ConnectFrameDecoder::new();
@@ -505,17 +540,53 @@ mod tests {
     fn gzip_frame_rejects_oversized_payload() {
         // A payload that decompresses beyond the cap must error rather than
         // silently truncate.
-        let oversized = vec![b'a'; (MAX_DECOMPRESSED_FRAME_BYTES as usize) + 1024];
-        let mut compressed = Vec::new();
-        {
-            use std::io::Write;
-            let mut encoder =
-                flate2::write::GzEncoder::new(&mut compressed, flate2::Compression::fast());
-            encoder.write_all(&oversized).unwrap();
-            encoder.finish().unwrap();
-        }
-
+        let compressed = oversized_gzip_payload();
         let err = decode_gzip_frame(&compressed).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn async_gzip_below_threshold_matches_sync_decode() {
+        let expected = b"small gzip response frame";
+        let compressed = gzip(expected);
+        assert!(compressed.len() <= INLINE_GZIP_FRAME_BYTES);
+
+        let sync = decode_gzip_frame(&compressed).unwrap();
+        let asynchronous = decode_gzip_frame_async(compressed).await.unwrap();
+        assert_eq!(asynchronous, sync);
+        assert_eq!(asynchronous, expected);
+    }
+
+    #[tokio::test]
+    async fn async_gzip_above_threshold_matches_sync_decode() {
+        let expected = incompressible_bytes(INLINE_GZIP_FRAME_BYTES * 2);
+        let compressed = gzip(&expected);
+        assert!(compressed.len() > INLINE_GZIP_FRAME_BYTES);
+
+        let sync = decode_gzip_frame(&compressed).unwrap();
+        let asynchronous = decode_gzip_frame_async(compressed).await.unwrap();
+        assert_eq!(asynchronous, sync);
+        assert_eq!(asynchronous, expected);
+    }
+
+    #[tokio::test]
+    async fn async_gzip_rejects_oversized_payload() {
+        let compressed = oversized_gzip_payload();
+        assert!(compressed.len() > INLINE_GZIP_FRAME_BYTES);
+
+        let err = decode_gzip_frame_async(compressed).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn async_gzip_rejects_corruption_on_both_paths() {
+        let inline = Bytes::from_static(b"not-gzip");
+        assert!(inline.len() <= INLINE_GZIP_FRAME_BYTES);
+        assert!(decode_gzip_frame_async(inline).await.is_err());
+
+        let mut blocking = gzip(&incompressible_bytes(INLINE_GZIP_FRAME_BYTES * 2));
+        blocking.truncate(blocking.len() - 1);
+        assert!(blocking.len() > INLINE_GZIP_FRAME_BYTES);
+        assert!(decode_gzip_frame_async(blocking).await.is_err());
     }
 }

--- a/src/adapters/cursor/connect.rs
+++ b/src/adapters/cursor/connect.rs
@@ -182,7 +182,9 @@ fn decode_gzip_frame_within(
 ) -> Result<Option<Vec<u8>>, std::io::Error> {
     use std::io::Read;
     let decoder = flate2::read::GzDecoder::new(payload);
-    let mut out = Vec::new();
+    // Size the buffer from the compressed length at a realistic ratio, capped by
+    // the budget, so a typical frame decodes without repeated growth.
+    let mut out = Vec::with_capacity(std::cmp::min(payload.len() * 4, budget + 1));
     decoder.take(budget as u64 + 1).read_to_end(&mut out)?;
     Ok((out.len() <= budget).then_some(out))
 }


### PR DESCRIPTION
## Summary

Closes #254.

The Cursor adapter decompressed gzipped Connect response frames synchronously while polling the upstream byte stream, so a large frame occupied a Tokio worker and delayed unrelated sessions.

`decode_gzip_frame_async` now decodes small frames inline and hands larger ones to `spawn_blocking`. `ReadState::ingest` became `async fn` and awaits it at its single call site inside the existing `unfold`; the gzip branch uses a `Cow`, mirroring the idiom already in `client.rs:136-145`. The 64 MiB decompressed cap, the malformed/truncated-frame handling and the `cursor gzip: {error}` surface are unchanged.

`79287c4` implements the offload; `498a50d` fixes what review found in it; `c3dc2ae` makes the offload tests attribute their observations to the decode under test; `3fb3267` and `21598bf` apply the ready-flip review round (drop a redundant `Bytes` clone, pre-size the inline output buffer, assert the bench fixture's single-byte varint).

### The inline path is bounded by output, not by compressed size

The first commit gated the inline path on **compressed** length. That is unsound: deflate reaches ~1032:1, so a valid 4 KiB frame inflates to 4,191,746 bytes and holds a worker ~1.04 ms — roughly 10x the 100 µs budget the threshold existed to respect. Highly repetitive assistant output hits this naturally; it is not only an adversarial case. The original benchmark fixture pinned the compression ratio near 4:1, so it could never have surfaced the problem.

`decode_gzip_frame_within` now inflates at most `budget + 1` bytes and returns `None` when the frame is too large, leaving `INLINE_GZIP_FRAME_BYTES` as nothing more than a cheap pre-filter and `INLINE_GZIP_OUTPUT_BYTES` (32 KiB) as the real safety bound. Corrupt input still errors identically; over-budget frames are redone off-thread under the full 64 MiB cap, and that bounded re-inflate of the first 32 KiB is deliberate.

Worst-case inline work is ~54–65 µs on realistic data. Incompressible data is *faster* (~8 µs), since it inflates via stored blocks — inflate throughput varies about an order of magnitude with redundancy, which is exactly why compressed length cannot bound the work.

### Concurrent offloads are bounded

Tokio's blocking pool defaults to 512 threads over an unbounded queue and is shared with credential I/O, token counting, config reload and state persistence. Unbounded submission would have traded runtime starvation for CPU and memory exhaustion.

A semaphore sized to `available_parallelism` (clamped 2..16) bounds concurrent decodes. The permit lives **inside** the blocking closure: held by the caller's future instead, it would be released on cancellation while the unabortable decode kept running, bounding admission rather than occupancy.

Net effect versus `main`: previously every concurrent stream inflated simultaneously, so peak decompressed buffers scaled with stream count. They now scale with these slots.

### Measurements

`benches/gateway.rs` gains a `decode_gzip_frame` bench over a protobuf-shaped fixture at a realistic ratio. The fixture originally overshot its labelled size by up to 25% — the row labelled "4 KiB" was really 4,275 bytes, above the cutoff it was cited to justify — and now shrinks until `0.75 x target <= compressed <= target`.

| Compressed frame | Median |
| --- | --- |
| 1 KiB | 8.80 µs |
| 4 KiB | 25.4 µs |
| 16 KiB | 102.2 µs |
| 64 KiB | 435.9 µs |

`spawn_blocking` round-trip overhead is reproducible on demand via `cargo test -- --ignored --nocapture measure_spawn_blocking_round_trip`. It is deliberately not a tracked benchmark: `codspeed.yml` runs in Valgrind simulation mode, which counts instructions and so cannot represent thread-wakeup latency.

## Milestone / spec

None — a runtime-behavior fix on the Cursor agent transport (issue #170 lineage). Follows #246 / f4cd619 (`count_tokens` off the runtime) and #250 / a469eab (Codex WS `turn_lock`).

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Source files stay under 500 lines — `connect.rs` is 713 lines, ~400 of which are tests; see below
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — n/a
- [x] User-facing docs updated — n/a, no config key, endpoint, CLI, default or provider semantics changed
- [x] Any new GitHub Action is pinned to a full commit SHA — none added

`connect.rs` exceeds the 500-line preference. Splitting the test module into `connect/tests.rs` would bring production code near 300 lines, but a pure move refactor on this repo trips the SonarCloud `new_coverage` gate (the moved file counts wholesale as new code), so it belongs in its own PR.

## Notes for reviewers

**Test coverage.** gzip is covered at the unit level for inline success, inline corrupt, above-threshold success, above-threshold corrupt, over-limit, and the small-compressed/large-output case that motivated `498a50d`; plus inline, above-threshold and invalid-gzip through the live `into_event_stream` path. Dispatch itself is now guarded in **both** directions: a `#[cfg(test)]` counter plus an observer lock that serializes every gzip-reaching test lets the inline and offload tests assert exact deltas (`== before`, `== before + 1`) instead of a one-sided `> before` that five unrelated tests on the same arm could satisfy. Both directions are confirmed by *unfiltered* mutation runs — forcing everything inline fails with `left: 0, right: 1`, forcing everything off-thread fails with `left: 4, right: 3`. `async_gzip_offloads_never_exceed_slot_limit` stays deliberately one-sided (observed peak never exceeds the slot count; it does not assert the peak is reached), because a lower bound there would depend on scheduler timing. The permit's cancellation invariant is left untested on purpose rather than guarded by a timing-dependent test — see the PR #182 precedent.

**Deliberately not fixed.** Review flagged that `acquire().await` has an unbounded waiter queue and suggested `try_acquire` plus overload errors. Declined: waiters retain already-received payloads rather than allocating, Tokio's semaphore is FIFO so excess streams are delayed rather than starved, and failing an interactive request to avoid a short wait is the worse trade. Total resident memory is bounded only by concurrent stream count, which the gateway does not cap anywhere — `axum::serve` runs without a concurrency-limit layer and inbound auth is optional. That is pre-existing and gateway-wide, tracked as #260 rather than bolted onto this path.

**Scope.** The three related sites in #254 were measured in this pass, as the issue required; the results and the follow-up are on the issue. The remaining gzip call sites in `client.rs` / `stream.rs` / `response.rs` / `sse.rs` stay synchronous — they sit on `#[allow(dead_code)]` modules retained pending the #170 follow-up (`src/adapters/cursor/mod.rs:6-24`) and never touch the async runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move gzip decompression of Cursor Connect response frames off the async runtime to avoid blocking `tokio` workers; small frames decode inline based on output size, larger frames use a bounded `spawn_blocking` path. No behavior changes; the 64 MiB cap and error handling remain the same.

- **Refactors**
  - Added `decode_gzip_frame_async(payload: Bytes)` with an output-size budget (`INLINE_GZIP_OUTPUT_BYTES = 32 KiB`) and a 4 KiB compressed-size prefilter (`INLINE_GZIP_FRAME_BYTES`); larger or over-budget frames offload via `spawn_blocking` gated by a semaphore sized to `available_parallelism` (clamped 2–16).
  - Introduced `decode_gzip_frame_within` to probe decompressed output up to the budget and decide inline vs offload; made `ReadState::ingest` async, switched the gzip branch to `Cow`, and now move the frame payload into the offload to avoid an extra `Bytes` clone.
  - Updated benches with realistic gzip fixtures and sizes; expanded tests for inline/above-threshold/corrupt/oversized gzip with an observer lock to attribute `OFFLOADED_DECODES`, plus a guard that in-flight offloads never exceed the slot count.

<sup>Written for commit 3fb3267d01996c756977812ed53fbf900c7074a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



