### PR TITLE
perf(proxy)!: parse the inbound request body once across the hot path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,7 @@ wiremock = "0.6"
 [[bench]]
 name = "gateway"
 harness = false
+
+[[bench]]
+name = "perf_issues"
+harness = false

--- a/benches/perf_issues.rs
+++ b/benches/perf_issues.rs
@@ -1,4 +1,13 @@
 //! Focused measurements for performance issues #252 and #253.
+//!
+//! `pre_parse_once_http_responses_cpu_front` and
+//! `pre_parse_once_codex_ws_reused_prepare_and_serialize` are deliberately frozen
+//! reproductions of the pre-refactor request paths. The
+//! `parse_once_http_responses_cpu_front` and
+//! `parse_once_codex_ws_reused_prepare_and_serialize` benchmarks model the
+//! parse-once implementation. Do not update the frozen baselines to follow
+//! production: their stable old work is what keeps the before/after comparison
+//! meaningful.
 
 use std::sync::Arc;
 
@@ -229,7 +238,7 @@ fn parse_once_http_front(body: &[u8], config: &Config, route: &Route) -> String 
 }
 
 #[divan::bench(args = BODY_SIZES)]
-fn current_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
+fn pre_parse_once_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
     let body = realistic_body(size);
     let route = route();
     let config = config();
@@ -294,7 +303,7 @@ fn codex_continuation_decide_hit(bencher: divan::Bencher, size: usize) {
 }
 
 #[divan::bench(args = BODY_SIZES)]
-fn codex_ws_reused_prepare_and_serialize(bencher: divan::Bencher, size: usize) {
+fn pre_parse_once_codex_ws_reused_prepare_and_serialize(bencher: divan::Bencher, size: usize) {
     let (stored, current) = continuation_fixture(size);
     bencher.bench(|| {
         let signature = codex_continuation::signature(divan::black_box(&current));

--- a/benches/perf_issues.rs
+++ b/benches/perf_issues.rs
@@ -213,6 +213,21 @@ fn responses_translate_and_serialize_once(bencher: divan::Bencher, size: usize) 
     });
 }
 
+fn parse_once_http_front(body: &[u8], config: &Config, route: &Route) -> String {
+    let request = normalize_like_proxy(body);
+    let model = request.get("model").and_then(Value::as_str).unwrap();
+    let resolved = routing::resolve_model(config, model);
+    divan::black_box(resolved);
+    let stream = request
+        .get("stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let thinking = request.pointer("/thinking/type").and_then(Value::as_str) == Some("enabled");
+    divan::black_box((stream, thinking));
+    responses_request::translate_request_value(&request, route, ResponsesFlavor::Chatgpt, false)
+        .to_string()
+}
+
 #[divan::bench(args = BODY_SIZES)]
 fn current_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
     let body = realistic_body(size);
@@ -234,6 +249,20 @@ fn current_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
         )
         .unwrap();
         translated.to_string()
+    });
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn parse_once_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    let route = route();
+    let config = config();
+    bencher.bench(|| {
+        parse_once_http_front(
+            divan::black_box(&body),
+            divan::black_box(&config),
+            divan::black_box(&route),
+        )
     });
 }
 
@@ -290,6 +319,33 @@ fn codex_ws_reused_prepare_and_serialize(bencher: divan::Bencher, size: usize) {
         let frame = codex_ws::response_create_frame(frame_body);
         let payload = serde_json::to_string(&frame).unwrap();
         divan::black_box((payload, signature, request_input))
+    });
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn parse_once_codex_ws_reused_prepare_and_serialize(bencher: divan::Bencher, size: usize) {
+    let (stored, current) = continuation_fixture(size);
+    let current = Arc::new(current);
+    bencher.bench(|| {
+        let signature = codex_continuation::signature(&current);
+        let mut frame_body = current.as_ref().clone();
+        if let Some(decision) = codex_continuation::decide_with_signature(
+            divan::black_box(&stored),
+            divan::black_box(&current),
+            divan::black_box(&signature),
+        ) {
+            if let Some(object) = frame_body.as_object_mut() {
+                object.insert("input".to_string(), json!(decision.input_delta));
+                object.insert(
+                    "previous_response_id".to_string(),
+                    json!(decision.previous_response_id),
+                );
+            }
+        }
+        let record = Arc::clone(&current);
+        let frame = codex_ws::response_create_frame(frame_body);
+        let payload = serde_json::to_string(&frame).unwrap();
+        divan::black_box((payload, record))
     });
 }
 

--- a/benches/perf_issues.rs
+++ b/benches/perf_issues.rs
@@ -1,0 +1,423 @@
+//! Focused measurements for performance issues #252 and #253.
+
+use std::sync::Arc;
+
+use axum::http::{HeaderMap, HeaderValue};
+use serde_json::{json, Value};
+use shunt::{
+    accounts::AccountPool,
+    adapters::responses::{
+        codex_continuation::{self, StoredContinuation},
+        codex_ws,
+    },
+    config::{AccountConfig, Config, ResponsesFlavor, RouteConfig},
+    model::responses_request,
+    routing::{self, AdapterKind, Route},
+};
+
+fn main() {
+    divan::main();
+}
+
+const BODY_SIZES: [usize; 3] = [300 * 1024, 1024 * 1024, 3 * 1024 * 1024];
+
+fn realistic_body(target_bytes: usize) -> Vec<u8> {
+    let message_count = match target_bytes {
+        size if size <= 300 * 1024 => 50,
+        size if size <= 1024 * 1024 => 100,
+        _ => 200,
+    };
+    let tools = (0..24)
+        .map(|index| {
+            json!({
+                "name": format!("tool_{index}"),
+                "description": "Operate on repository files and return structured results for the coding agent.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Absolute repository path"},
+                        "query": {"type": "string", "description": "Search or edit expression"},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 2000},
+                        "options": {"type": "object", "additionalProperties": true}
+                    },
+                    "required": ["path", "query"]
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let messages = (0..message_count)
+        .map(|index| {
+            if index % 2 == 0 {
+                json!({
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": format!("I inspected module {index}; the relevant implementation has several ownership and concurrency constraints.")},
+                        {"type": "tool_use", "id": format!("toolu_{index}"), "name": format!("tool_{}", index % 24), "input": {"path": format!("/repo/src/module_{index}.rs"), "query": "resolve request and preserve streaming behavior", "limit": 200}}
+                    ]
+                })
+            } else {
+                json!({
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": format!("toolu_{}", index - 1), "content": [{"type": "text", "text": format!("source result {index}: fn handler() {{ /* representative repository output */ }}")}]},
+                        {"type": "text", "text": "Continue the investigation, compare competing explanations, and cite the exact implementation path."}
+                    ]
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut body = json!({
+        "model": "claude-sonnet-4-5-via-codex",
+        "max_tokens": 32000,
+        "stream": true,
+        "thinking": {"type": "enabled", "budget_tokens": 10000},
+        "metadata": {"user_id": "{\"device_id\":\"bench\",\"account_uuid\":\"bench\",\"session_id\":\"perf-issues\"}"},
+        "system": [{"type": "text", "text": "You are a coding subagent. Inspect the repository rigorously and preserve all protocol semantics."}],
+        "messages": messages,
+        "tools": tools,
+        "tool_choice": {"type": "auto"},
+        "parallel_tool_calls": true
+    });
+    let initial = serde_json::to_vec(&body).unwrap().len();
+    let padding = target_bytes.saturating_sub(initial + 64);
+    body["system"][0]["text"] = Value::String(format!(
+        "You are a coding subagent. Follow the complete repository instructions. {}",
+        "The long project context contains architecture, tests, prior decisions, and exact source excerpts. ".repeat(padding / 94 + 1)
+    ));
+    let mut bytes = serde_json::to_vec(&body).unwrap();
+    if bytes.len() > target_bytes {
+        let excess = bytes.len() - target_bytes;
+        let text = body["system"][0]["text"].as_str().unwrap();
+        body["system"][0]["text"] = Value::String(text[..text.len() - excess].to_string());
+        bytes = serde_json::to_vec(&body).unwrap();
+    }
+    assert!(
+        bytes.len().abs_diff(target_bytes) <= 128,
+        "{} vs {target_bytes}",
+        bytes.len()
+    );
+    bytes
+}
+
+fn route() -> Route {
+    Route {
+        provider: "codex".to_string(),
+        adapter: AdapterKind::Responses,
+        model: "claude-sonnet-4-5-via-codex".to_string(),
+        upstream_model: "gpt-5.6-sol".to_string(),
+        effort: Some("high".to_string()),
+    }
+}
+
+fn config() -> Config {
+    Config {
+        routes: vec![RouteConfig {
+            model: "claude-sonnet-4-5-via-codex".to_string(),
+            provider: "codex".to_string(),
+            upstream_model: Some("gpt-5.6-sol".to_string()),
+            effort: Some("high".to_string()),
+        }],
+        ..Config::default()
+    }
+}
+
+fn normalize_like_proxy(body: &[u8]) -> Value {
+    let mut request: Value = serde_json::from_slice(body).unwrap();
+    if let Some(messages) = request.get_mut("messages").and_then(Value::as_array_mut) {
+        for message in messages {
+            let Some(content) = message.get_mut("content").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            let is_empty = |block: &Value| {
+                block.get("type").and_then(Value::as_str) == Some("text")
+                    && block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| text.trim().is_empty())
+            };
+            if content.iter().all(is_empty) {
+                if content.len() > 1 {
+                    content.truncate(1);
+                }
+            } else {
+                content.retain(|block| !is_empty(block));
+            }
+        }
+    }
+    request
+}
+
+fn adapter_flags(body: &[u8]) -> (bool, bool) {
+    let request: Value = serde_json::from_slice(body).unwrap();
+    let stream = request
+        .get("stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let thinking = request.pointer("/thinking/type").and_then(Value::as_str) == Some("enabled");
+    (stream, thinking)
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn value_parse(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    bencher.bench(|| serde_json::from_slice::<Value>(divan::black_box(&body)).unwrap());
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn proxy_normalize_common_case(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    bencher.bench(|| normalize_like_proxy(divan::black_box(&body)));
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn route_parse_and_resolve(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    let config = config();
+    bencher.bench(|| routing::resolve(divan::black_box(&config), divan::black_box(&body)).unwrap());
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn responses_adapter_flags(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    bencher.bench(|| adapter_flags(divan::black_box(&body)));
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn responses_translate(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    let route = route();
+    bencher.bench(|| {
+        responses_request::translate_request(
+            divan::black_box(&body),
+            divan::black_box(&route),
+            ResponsesFlavor::Chatgpt,
+            false,
+        )
+        .unwrap()
+    });
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn responses_translate_and_serialize_once(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    let route = route();
+    bencher.bench(|| {
+        let translated = responses_request::translate_request(
+            divan::black_box(&body),
+            divan::black_box(&route),
+            ResponsesFlavor::Chatgpt,
+            false,
+        )
+        .unwrap();
+        translated.to_string()
+    });
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn current_http_responses_cpu_front(bencher: divan::Bencher, size: usize) {
+    let body = realistic_body(size);
+    let route = route();
+    let config = config();
+    bencher.bench(|| {
+        let normalized = normalize_like_proxy(divan::black_box(&body));
+        divan::black_box(normalized);
+        let resolved =
+            routing::resolve(divan::black_box(&config), divan::black_box(&body)).unwrap();
+        divan::black_box(resolved);
+        let flags = adapter_flags(divan::black_box(&body));
+        divan::black_box(flags);
+        let translated = responses_request::translate_request(
+            divan::black_box(&body),
+            divan::black_box(&route),
+            ResponsesFlavor::Chatgpt,
+            false,
+        )
+        .unwrap();
+        translated.to_string()
+    });
+}
+
+fn continuation_fixture(size: usize) -> (StoredContinuation, Value) {
+    let translated = responses_request::translate_request(
+        &realistic_body(size),
+        &route(),
+        ResponsesFlavor::Chatgpt,
+        false,
+    )
+    .unwrap();
+    let input = translated.get("input").and_then(Value::as_array).unwrap();
+    let prefix_len = input.len().saturating_sub(1);
+    let stored = StoredContinuation {
+        response_id: "resp_bench".to_string(),
+        signature: codex_continuation::signature(&translated),
+        transcript: input[..prefix_len].to_vec(),
+        turn_state: Some("turn-state".to_string()),
+    };
+    (stored, translated)
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn codex_continuation_decide_hit(bencher: divan::Bencher, size: usize) {
+    let (stored, current) = continuation_fixture(size);
+    bencher.bench(|| {
+        codex_continuation::decide(divan::black_box(&stored), divan::black_box(&current)).unwrap()
+    });
+}
+
+#[divan::bench(args = BODY_SIZES)]
+fn codex_ws_reused_prepare_and_serialize(bencher: divan::Bencher, size: usize) {
+    let (stored, current) = continuation_fixture(size);
+    bencher.bench(|| {
+        let signature = codex_continuation::signature(divan::black_box(&current));
+        let full_input = current
+            .get("input")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut frame_body = current.clone();
+        if let Some(decision) =
+            codex_continuation::decide(divan::black_box(&stored), divan::black_box(&current))
+        {
+            if let Some(object) = frame_body.as_object_mut() {
+                object.insert("input".to_string(), json!(decision.input_delta));
+                object.insert(
+                    "previous_response_id".to_string(),
+                    json!(decision.previous_response_id),
+                );
+            }
+        }
+        let request_input = full_input.clone();
+        let frame = codex_ws::response_create_frame(frame_body);
+        let payload = serde_json::to_string(&frame).unwrap();
+        divan::black_box((payload, signature, request_input))
+    });
+}
+
+fn accounts() -> Vec<AccountConfig> {
+    (0..8)
+        .map(|index| AccountConfig {
+            name: format!("account-{index}"),
+            uuid: Some(format!("uuid-{index}")),
+            ..AccountConfig::default()
+        })
+        .collect()
+}
+
+fn codex_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in [
+        ("x-codex-primary-window-minutes", "300"),
+        ("x-codex-primary-used-percent", "24.5"),
+        ("x-codex-primary-reset-at", "4102444800"),
+        ("x-codex-secondary-window-minutes", "10080"),
+        ("x-codex-secondary-used-percent", "31.5"),
+        ("x-codex-secondary-reset-at", "4102444800"),
+    ] {
+        headers.insert(name, HeaderValue::from_static(value));
+    }
+    headers
+}
+
+const POOL_CYCLES: usize = 16_384;
+
+#[divan::bench(args = [1, 8, 32, 128], sample_count = 8, sample_size = 1)]
+fn account_pool_quota_updates(bencher: divan::Bencher, workers: usize) {
+    bencher.bench(|| {
+        let pool = Arc::new(AccountPool::new());
+        let accounts = Arc::new(accounts());
+        let headers = Arc::new(codex_headers());
+        pool.select_order(
+            "codex",
+            &accounts,
+            Some("warmup"),
+            Some("gpt-5.6-sol"),
+            None,
+        );
+        std::thread::scope(|scope| {
+            for worker in 0..workers {
+                let pool = Arc::clone(&pool);
+                let accounts = Arc::clone(&accounts);
+                let headers = Arc::clone(&headers);
+                let begin = POOL_CYCLES * worker / workers;
+                let end = POOL_CYCLES * (worker + 1) / workers;
+                scope.spawn(move || {
+                    for sequence in begin..end {
+                        pool.note_codex_quota(
+                            "codex",
+                            &accounts[sequence % accounts.len()],
+                            &headers,
+                        );
+                    }
+                });
+            }
+        });
+    });
+}
+
+#[divan::bench(args = [1, 8, 32, 128], sample_count = 8, sample_size = 1)]
+fn account_pool_healthy_updates(bencher: divan::Bencher, workers: usize) {
+    bencher.bench(|| {
+        let pool = Arc::new(AccountPool::new());
+        let accounts = Arc::new(accounts());
+        std::thread::scope(|scope| {
+            for worker in 0..workers {
+                let pool = Arc::clone(&pool);
+                let accounts = Arc::clone(&accounts);
+                let begin = POOL_CYCLES * worker / workers;
+                let end = POOL_CYCLES * (worker + 1) / workers;
+                scope.spawn(move || {
+                    for sequence in begin..end {
+                        pool.mark_healthy("codex", &accounts[sequence % accounts.len()], true);
+                    }
+                });
+            }
+        });
+    });
+}
+
+/// One cycle performs selection, admission + guard drop, quota update (including
+/// Sentry/OTel utilization emission under the entries lock), and healthy marking.
+#[divan::bench(args = [1, 8, 32, 128], sample_count = 8, sample_size = 1)]
+fn account_pool_mixed_cycles(bencher: divan::Bencher, workers: usize) {
+    bencher.bench(|| {
+        let pool = Arc::new(AccountPool::new());
+        let accounts = Arc::new(accounts());
+        let headers = Arc::new(codex_headers());
+        pool.select_order(
+            "codex",
+            &accounts,
+            Some("warmup"),
+            Some("gpt-5.6-sol"),
+            None,
+        );
+        std::thread::scope(|scope| {
+            for worker in 0..workers {
+                let pool = Arc::clone(&pool);
+                let accounts = Arc::clone(&accounts);
+                let headers = Arc::clone(&headers);
+                let begin = POOL_CYCLES * worker / workers;
+                let end = POOL_CYCLES * (worker + 1) / workers;
+                scope.spawn(move || {
+                    for sequence in begin..end {
+                        let account = &accounts[sequence % accounts.len()];
+                        let session = format!("session-{sequence}");
+                        let order = pool.select_order(
+                            "codex",
+                            &accounts,
+                            Some(&session),
+                            Some("gpt-5.6-sol"),
+                            None,
+                        );
+                        divan::black_box(order);
+                        let guard = Arc::clone(&pool)
+                            .try_admit("codex", account, 1024, true)
+                            .unwrap();
+                        drop(guard);
+                        pool.note_codex_quota("codex", account, &headers);
+                        pool.mark_healthy("codex", account, true);
+                    }
+                });
+            }
+        });
+    });
+}

--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     config::{ApiKeyHeader, AuthMode},
     error::UpstreamError,
     headers, keepalive,
+    request::RequestBody,
     routing::Route,
     server::AppState,
 };
@@ -30,7 +31,7 @@ impl Adapter for AnthropicAdapter {
         route: Route,
         uri: &'a Uri,
         headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a> {
         Box::pin(async move { forward(state, route, uri, headers, body).await })
     }
@@ -41,7 +42,7 @@ async fn forward(
     route: Route,
     uri: &Uri,
     headers: &HeaderMap,
-    body: Vec<u8>,
+    mut body: RequestBody,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     let provider = state
         .config
@@ -54,7 +55,8 @@ async fn forward(
     let credential = resolve_credential(&state.config, &route, &state.http_client).await?;
     let request_headers = outbound_headers(headers, &credential);
     let oauth_client = bearer_is_subscription_oauth(&request_headers);
-    let body = normalize_upstream_model(body, &route.upstream_model);
+    normalize_upstream_model_request(&mut body, &route.upstream_model);
+    let body = body.into_raw();
     // Bounded transient retry (issue #48) for this single-credential path. Kept
     // off `count_tokens`, which passes through here for Anthropic-kind providers
     // — a token count is cheap for the client to re-issue and never worth a
@@ -104,7 +106,7 @@ async fn forward_claude_oauth(
     route: Route,
     uri: &Uri,
     headers: &HeaderMap,
-    body: Vec<u8>,
+    mut body: RequestBody,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     let provider = state
         .config
@@ -154,7 +156,8 @@ async fn forward_claude_oauth(
         state.config.server.pool.as_ref(),
     );
     let url = upstream_url(&state, &route, uri);
-    let base_body = normalize_upstream_model(body, &route.upstream_model);
+    normalize_upstream_model_request(&mut body, &route.upstream_model);
+    let base_body = body;
     let ramp_initial = state.config.storm_ramp_initial();
     let candidates = order.len();
     let mut last_response = None;
@@ -210,7 +213,9 @@ async fn forward_claude_oauth(
             Credential::ClaudeOauth { account_uuid, .. } => account_uuid.as_deref(),
             _ => None,
         };
-        let request_body = rewrite_account_uuid(base_body.clone(), account_uuid);
+        let mut request_body = base_body.clone();
+        rewrite_account_uuid_request(&mut request_body, account_uuid);
+        let request_body = request_body.into_raw();
         let request_headers = outbound_headers(headers, &credential);
 
         let upstream = match post_upstream(
@@ -682,73 +687,76 @@ fn rate_limit_kind(headers: &HeaderMap, oauth_client: bool) -> &'static str {
     }
 }
 
-/// Rewrite the outbound request body's `model` to the routed `upstream_model`
-/// when they differ. The passthrough adapter forwards the client body verbatim,
-/// so without this two things leak to the provider: a `[1m]` context-window hint
-/// (which `routing::strip_context_window_hint` removes from the routing key but
-/// not from the body — and api.anthropic.com does not recognize a `[1m]`-suffixed
-/// model id), and an explicit `[[routes]]` `upstream_model` remap (otherwise
-/// ignored for an Anthropic-provider route). The common case — body model already
-/// equal to `upstream_model` — re-serializes nothing and forwards the original
-/// bytes untouched, preserving byte-for-byte passthrough.
-fn normalize_upstream_model(body: Vec<u8>, upstream_model: &str) -> Vec<u8> {
-    #[derive(serde::Deserialize)]
-    struct ModelView {
-        model: String,
+fn normalize_upstream_model_request(body: &mut RequestBody, upstream_model: &str) {
+    if body.json().get("model").and_then(serde_json::Value::as_str) == Some(upstream_model) {
+        return;
     }
-
-    // Cheap guard: peek only the `model` field. A body that isn't JSON, has no
-    // `model`, or whose model already matches is forwarded unchanged.
-    match serde_json::from_slice::<ModelView>(&body) {
-        Ok(view) if view.model != upstream_model => {
-            let Ok(mut value) = serde_json::from_slice::<serde_json::Value>(&body) else {
-                return body;
-            };
-            let Some(object) = value.as_object_mut() else {
-                return body;
-            };
-            object.insert(
-                "model".to_string(),
-                serde_json::Value::String(upstream_model.to_string()),
-            );
-            serde_json::to_vec(&value).unwrap_or(body)
+    body.mutate(|request| {
+        let Some(model) = request.get_mut("model") else {
+            return false;
+        };
+        let Some(current_model) = model.as_str() else {
+            return false;
+        };
+        if current_model == upstream_model {
+            return false;
         }
-        _ => body,
-    }
+        *model = serde_json::Value::String(upstream_model.to_string());
+        true
+    });
 }
 
-fn rewrite_account_uuid(body: Vec<u8>, account_uuid: Option<&str>) -> Vec<u8> {
+fn rewrite_account_uuid_request(body: &mut RequestBody, account_uuid: Option<&str>) {
     let Some(account_uuid) = account_uuid else {
+        return;
+    };
+    body.mutate(|outer| {
+        let Some(user_id) = outer
+            .get_mut("metadata")
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|metadata| metadata.get_mut("user_id"))
+        else {
+            return false;
+        };
+        let Some(user_id_string) = user_id.as_str() else {
+            return false;
+        };
+        let Ok(mut inner) = serde_json::from_str::<serde_json::Value>(user_id_string) else {
+            return false;
+        };
+        let Some(inner_account_uuid) = inner
+            .as_object_mut()
+            .and_then(|object| object.get_mut("account_uuid"))
+        else {
+            return false;
+        };
+        *inner_account_uuid = serde_json::Value::String(account_uuid.to_string());
+        let Ok(serialized_inner) = serde_json::to_string(&inner) else {
+            return false;
+        };
+        *user_id = serde_json::Value::String(serialized_inner);
+        true
+    });
+}
+
+/// Test wrapper for the raw-byte contract at the adapter boundary.
+#[cfg(test)]
+fn normalize_upstream_model(body: Vec<u8>, upstream_model: &str) -> Vec<u8> {
+    let Ok(mut request) = RequestBody::parse(body.clone()) else {
         return body;
     };
-    let Ok(mut outer) = serde_json::from_slice::<serde_json::Value>(&body) else {
+    normalize_upstream_model_request(&mut request, upstream_model);
+    request.into_raw()
+}
+
+/// Test wrapper for the raw-byte contract at the adapter boundary.
+#[cfg(test)]
+fn rewrite_account_uuid(body: Vec<u8>, account_uuid: Option<&str>) -> Vec<u8> {
+    let Ok(mut request) = RequestBody::parse(body.clone()) else {
         return body;
     };
-    let Some(user_id) = outer
-        .get_mut("metadata")
-        .and_then(serde_json::Value::as_object_mut)
-        .and_then(|metadata| metadata.get_mut("user_id"))
-    else {
-        return body;
-    };
-    let Some(user_id_string) = user_id.as_str() else {
-        return body;
-    };
-    let Ok(mut inner) = serde_json::from_str::<serde_json::Value>(user_id_string) else {
-        return body;
-    };
-    let Some(inner_object) = inner.as_object_mut() else {
-        return body;
-    };
-    let Some(inner_account_uuid) = inner_object.get_mut("account_uuid") else {
-        return body;
-    };
-    *inner_account_uuid = serde_json::Value::String(account_uuid.to_string());
-    let Ok(serialized_inner) = serde_json::to_string(&inner) else {
-        return body;
-    };
-    *user_id = serde_json::Value::String(serialized_inner);
-    serde_json::to_vec(&outer).unwrap_or(body)
+    rewrite_account_uuid_request(&mut request, account_uuid);
+    request.into_raw()
 }
 
 /// Build the headers sent upstream. For a passthrough provider (api.anthropic.com)

--- a/src/adapters/anthropic/mod.rs
+++ b/src/adapters/anthropic/mod.rs
@@ -687,6 +687,16 @@ fn rate_limit_kind(headers: &HeaderMap, oauth_client: bool) -> &'static str {
     }
 }
 
+/// Rewrite the outbound request body's `model` to the routed `upstream_model`
+/// when they differ. The passthrough adapter forwards the client body verbatim,
+/// so without this two things leak to the provider: a `[1m]` context-window hint
+/// (which `routing::strip_context_window_hint` removes from the routing key but
+/// not from the body — and api.anthropic.com does not recognize a `[1m]`-suffixed
+/// model id), and an explicit `[[routes]]` `upstream_model` remap (otherwise
+/// ignored for an Anthropic-provider route). The common case — body model already
+/// equal to `upstream_model` — mutates nothing, so [`RequestBody`] refreshes no raw
+/// bytes and preserves byte-for-byte passthrough. A changed model mutates the
+/// parsed request in place and refreshes the raw bytes once.
 fn normalize_upstream_model_request(body: &mut RequestBody, upstream_model: &str) {
     if body.json().get("model").and_then(serde_json::Value::as_str) == Some(upstream_model) {
         return;
@@ -710,7 +720,35 @@ fn rewrite_account_uuid_request(body: &mut RequestBody, account_uuid: Option<&st
     let Some(account_uuid) = account_uuid else {
         return;
     };
+    // Do the whole rewrite read-only first, and enter `mutate` only to install the
+    // finished string. Two costs drive that split, both paid per pool candidate:
+    // `RequestBody::mutate` runs `Arc::make_mut` before the closure can report "no
+    // change", and the pool loop keeps `base_body` alive while cloning it per
+    // candidate — so the tree is always shared here and entering `mutate` at all
+    // costs a full deep clone of the request. Bailing out before it saves that clone
+    // for a body with nothing to rewrite. Preparing the value here rather than inside
+    // the closure also keeps `metadata.user_id` parsed exactly once: it is
+    // client-controlled and bounded only by the inbound body limit, so parsing it in
+    // both a pre-check and the closure would add a full parse of it per candidate.
+    let Some(rewritten_user_id) = body
+        .json()
+        .pointer("/metadata/user_id")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|user_id| serde_json::from_str::<serde_json::Value>(user_id).ok())
+        .and_then(|mut inner| {
+            // Only an `account_uuid` that is already present is rewritten; this never
+            // introduces one.
+            let existing = inner.as_object_mut()?.get_mut("account_uuid")?;
+            *existing = serde_json::Value::String(account_uuid.to_string());
+            serde_json::to_string(&inner).ok()
+        })
+    else {
+        return;
+    };
     body.mutate(|outer| {
+        // The pre-check above resolved this same path on the same tree, so the `else`
+        // is unreachable; returning `false` there would simply leave the body as the
+        // client sent it.
         let Some(user_id) = outer
             .get_mut("metadata")
             .and_then(serde_json::Value::as_object_mut)
@@ -718,23 +756,7 @@ fn rewrite_account_uuid_request(body: &mut RequestBody, account_uuid: Option<&st
         else {
             return false;
         };
-        let Some(user_id_string) = user_id.as_str() else {
-            return false;
-        };
-        let Ok(mut inner) = serde_json::from_str::<serde_json::Value>(user_id_string) else {
-            return false;
-        };
-        let Some(inner_account_uuid) = inner
-            .as_object_mut()
-            .and_then(|object| object.get_mut("account_uuid"))
-        else {
-            return false;
-        };
-        *inner_account_uuid = serde_json::Value::String(account_uuid.to_string());
-        let Ok(serialized_inner) = serde_json::to_string(&inner) else {
-            return false;
-        };
-        *user_id = serde_json::Value::String(serialized_inner);
+        *user_id = serde_json::Value::String(rewritten_user_id);
         true
     });
 }
@@ -1162,6 +1184,10 @@ mod tests {
         assert_eq!(inner["device"], "cli");
     }
 
+    /// Every shape the rewrite must decline. The bodies carry non-canonical spacing
+    /// on purpose: `RequestBody::mutate` re-serializes the whole request, so if any
+    /// of these wrongly entered it the output would come back canonicalized even
+    /// though nothing changed.
     #[test]
     fn rewrite_account_uuid_leaves_unusable_bodies_untouched() {
         for (body, uuid) in [
@@ -1171,9 +1197,63 @@ mod tests {
                 br#"{"metadata":{"user_id":"{\"account_uuid\":\"old\"}"}}"#.to_vec(),
                 None,
             ),
+            // `metadata` is not an object.
+            (br#"{ "metadata": "not-an-object" }"#.to_vec(), Some("new")),
+            (br#"{ "metadata": [1, 2] }"#.to_vec(), Some("new")),
+            (br#"{ "metadata": null }"#.to_vec(), Some("new")),
+            // `metadata.user_id` is not a string.
+            (
+                br#"{ "metadata": { "user_id": 42 } }"#.to_vec(),
+                Some("new"),
+            ),
+            (
+                br#"{ "metadata": { "user_id": {"account_uuid": "old"} } }"#.to_vec(),
+                Some("new"),
+            ),
+            // `metadata.user_id` is a string but not parseable JSON.
+            (
+                br#"{ "metadata": { "user_id": "not json" } }"#.to_vec(),
+                Some("new"),
+            ),
+            // The inner blob parses but is not an object.
+            (
+                br#"{ "metadata": { "user_id": "[1, 2]" } }"#.to_vec(),
+                Some("new"),
+            ),
+            // The inner object has no `account_uuid` to replace — one is never added.
+            (
+                br#"{ "metadata": { "user_id": "{\"device\":\"cli\"}" } }"#.to_vec(),
+                Some("new"),
+            ),
         ] {
             let original = body.clone();
-            assert_eq!(rewrite_account_uuid(body, uuid), original);
+            assert_eq!(
+                rewrite_account_uuid(body, uuid),
+                original,
+                "body was modified: {}",
+                String::from_utf8_lossy(&original)
+            );
+        }
+    }
+
+    /// A present `account_uuid` is replaced whatever its current JSON type, so the
+    /// early return must not mistake a null or numeric one for "nothing to rewrite".
+    #[test]
+    fn rewrite_account_uuid_replaces_a_non_string_inner_value() {
+        for existing in ["null", "42", r#"{"nested":true}"#] {
+            let inner = format!(r#"{{"account_uuid":{existing},"device":"cli"}}"#);
+            let body = serde_json::to_vec(&serde_json::json!({
+                "metadata": {"user_id": inner}
+            }))
+            .unwrap();
+
+            let out = rewrite_account_uuid(body, Some("selected"));
+
+            let outer: serde_json::Value = serde_json::from_slice(&out).unwrap();
+            let inner: serde_json::Value =
+                serde_json::from_str(outer["metadata"]["user_id"].as_str().unwrap()).unwrap();
+            assert_eq!(inner["account_uuid"], "selected", "existing was {existing}");
+            assert_eq!(inner["device"], "cli");
         }
     }
 

--- a/src/adapters/antigravity/mod.rs
+++ b/src/adapters/antigravity/mod.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 
 use crate::{
     adapters::{Adapter, AdapterError, AdapterFuture},
+    request::RequestBody,
     routing::Route,
     server::AppState,
 };
@@ -27,16 +28,11 @@ impl Adapter for AntigravityAdapter {
         route: Route,
         _uri: &'a Uri,
         _headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a> {
         Box::pin(async move {
-            let request: Value = serde_json::from_slice(&body).map_err(|err| AdapterError {
-                message: format!("invalid JSON in request: {err}"),
-                response: Box::new(StatusCode::BAD_REQUEST.into_response()),
-                failure: None,
-            })?;
-
-            let prompt = extract_antigravity_prompt(&request);
+            let request = body.json();
+            let prompt = extract_antigravity_prompt(request);
             let is_streaming = request
                 .get("stream")
                 .and_then(Value::as_bool)

--- a/src/adapters/cursor/mod.rs
+++ b/src/adapters/cursor/mod.rs
@@ -35,6 +35,7 @@ use crate::{
     adapters::{Adapter, AdapterError, AdapterFuture},
     auth::{resolve_credential, Credential},
     error::ShuntError,
+    request::RequestBody,
     routing::Route,
     server::AppState,
 };
@@ -54,7 +55,7 @@ impl Adapter for CursorAdapter {
         route: Route,
         _uri: &'a Uri,
         headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a> {
         let _ = headers;
         Box::pin(async move { forward(state, route, body).await })
@@ -64,15 +65,9 @@ impl Adapter for CursorAdapter {
 async fn forward(
     state: AppState,
     route: Route,
-    body: Vec<u8>,
+    body: RequestBody,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
-    let request: Value = serde_json::from_slice(&body).map_err(|error| {
-        own_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            format!("invalid JSON request: {error}"),
-        )
-    })?;
+    let request = body.json();
     let model = route.upstream_model.as_str();
     let resolved = model::resolve_cursor_model(model).map_err(|error| {
         own_error(
@@ -94,9 +89,9 @@ async fn forward(
             ))
         }
     };
-    let prompt = request::render_cursor_prompt(&request);
-    let images = decode_cursor_images(&request);
-    let tools = extract_cursor_tools(&request);
+    let prompt = request::render_cursor_prompt(request);
+    let images = decode_cursor_images(request);
+    let tools = extract_cursor_tools(request);
     let want_stream = request
         .get("stream")
         .and_then(Value::as_bool)

--- a/src/adapters/gemini/mod.rs
+++ b/src/adapters/gemini/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     config::AuthMode,
     model::gemini::{map_gemini_error, GeminiSseMachine},
     model::gemini_request::{translate_request_for_model, wrap_code_assist_envelope},
+    request::RequestBody,
     routing::Route,
     server::AppState,
 };
@@ -27,7 +28,7 @@ impl Adapter for GeminiAdapter {
         route: Route,
         uri: &'a Uri,
         headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a> {
         Box::pin(async move { forward(state, route, uri, headers, body).await })
     }
@@ -61,7 +62,7 @@ async fn forward(
     route: Route,
     _uri: &Uri,
     _headers: &HeaderMap,
-    body: Vec<u8>,
+    body: RequestBody,
 ) -> Result<(StatusCode, Response<Body>), AdapterError> {
     let provider = state
         .config
@@ -89,15 +90,10 @@ async fn forward(
         }
     };
 
-    let json_body: Value = serde_json::from_slice(&body).map_err(|error| AdapterError {
-        message: format!("invalid JSON in Anthropic request body: {error}"),
-        response: Box::new(StatusCode::BAD_REQUEST.into_response()),
-        failure: None,
-    })?;
-
+    let json_body = body.json();
     let is_streaming = json_body.get("stream").and_then(Value::as_bool) == Some(true);
 
-    let inner_req = translate_request_for_model(&json_body, &route.upstream_model)?;
+    let inner_req = translate_request_for_model(json_body, &route.upstream_model)?;
 
     let base_url = provider.base_url.trim_end_matches('/');
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -5,7 +5,7 @@ use axum::{
     response::Response,
 };
 
-use crate::{routing::Route, server::AppState};
+use crate::{request::RequestBody, routing::Route, server::AppState};
 
 pub mod anthropic;
 pub mod antigravity;
@@ -59,14 +59,14 @@ pub struct AdapterError {
     pub failure: Option<AdapterFailure>,
 }
 
-pub trait Adapter {
+pub(crate) trait Adapter {
     fn forward<'a>(
         &'a self,
         state: AppState,
         route: Route,
         uri: &'a Uri,
         headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a>;
 }
 

--- a/src/adapters/responses/codex_continuation.rs
+++ b/src/adapters/responses/codex_continuation.rs
@@ -94,7 +94,16 @@ pub struct Decision {
 /// suffix. Returns `None` — meaning "send the full input" — on any mismatch, a
 /// shrunk input, or an empty delta.
 pub fn decide(stored: &StoredContinuation, current_body: &Value) -> Option<Decision> {
-    if signature(current_body) != stored.signature {
+    let current_signature = signature(current_body);
+    decide_with_signature(stored, current_body, &current_signature)
+}
+
+pub fn decide_with_signature(
+    stored: &StoredContinuation,
+    current_body: &Value,
+    current_signature: &str,
+) -> Option<Decision> {
+    if current_signature != stored.signature {
         return None;
     }
     let input = current_body.get("input").and_then(Value::as_array)?;
@@ -135,12 +144,16 @@ pub fn signature(body: &Value) -> String {
     let Some(object) = body.as_object() else {
         return String::new();
     };
-    let filtered: Map<String, Value> = object
+    let mut entries = object
         .iter()
         .filter(|(key, _)| key.as_str() != "input")
-        .map(|(key, value)| (key.clone(), value.clone()))
-        .collect();
-    stable_string(&Value::Object(filtered))
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    let inner = entries
+        .into_iter()
+        .map(|(key, value)| format!("{}:{}", encode_str(key), stable_string(value)))
+        .collect::<Vec<_>>();
+    format!("{{{}}}", inner.join(","))
 }
 
 /// Deterministic JSON string with object keys sorted recursively, so the

--- a/src/adapters/responses/codex_continuation.rs
+++ b/src/adapters/responses/codex_continuation.rs
@@ -98,6 +98,15 @@ pub fn decide(stored: &StoredContinuation, current_body: &Value) -> Option<Decis
     decide_with_signature(stored, current_body, &current_signature)
 }
 
+/// Decide whether the current request can continue using a precomputed signature.
+///
+/// `current_signature` **must** be `signature(current_body)`. The parameter exists
+/// solely so a caller that already computed the signature (currently
+/// `src/adapters/responses/websocket.rs`) does not recompute it. Passing a
+/// signature for another body is unsafe, not merely a cache miss: if it happens
+/// to equal `stored.signature`, this guard is bypassed and changed model,
+/// instructions, tools, reasoning, or other non-input fields go unchecked,
+/// allowing an invalid continuation to be accepted.
 pub fn decide_with_signature(
     stored: &StoredContinuation,
     current_body: &Value,
@@ -528,6 +537,87 @@ mod tests {
         };
         let current = body(vec![user("hi")]);
         assert!(decide(&stored, &current).is_none());
+    }
+
+    #[test]
+    fn decide_with_signature_matches_decide_on_hit() {
+        let stored = StoredContinuation {
+            response_id: "resp_1".to_string(),
+            signature: signature(&body(vec![user("hi")])),
+            transcript: build_transcript(&[user("hi")], &[backend_assistant("hello")]),
+            turn_state: None,
+        };
+        let current = body(vec![
+            user("hi"),
+            reconstructed_assistant("hello"),
+            user("bye"),
+        ]);
+        let current_signature = signature(&current);
+
+        assert_eq!(
+            decide_with_signature(&stored, &current, &current_signature),
+            decide(&stored, &current)
+        );
+        assert!(decide(&stored, &current).is_some());
+    }
+
+    #[test]
+    fn decide_with_signature_matches_decide_when_non_input_field_changes() {
+        let stored = StoredContinuation {
+            response_id: "resp_1".to_string(),
+            signature: signature(&body(vec![user("hi")])),
+            transcript: build_transcript(&[user("hi")], &[backend_assistant("hello")]),
+            turn_state: None,
+        };
+        let mut current = body(vec![
+            user("hi"),
+            reconstructed_assistant("hello"),
+            user("bye"),
+        ]);
+        current["reasoning"]["effort"] = json!("high");
+        let current_signature = signature(&current);
+
+        assert_eq!(
+            decide_with_signature(&stored, &current, &current_signature),
+            decide(&stored, &current)
+        );
+        assert!(decide(&stored, &current).is_none());
+    }
+
+    #[test]
+    fn decide_with_signature_uses_the_passed_signature_as_the_guard() {
+        let stored = StoredContinuation {
+            response_id: "resp_1".to_string(),
+            signature: signature(&body(vec![user("hi")])),
+            transcript: build_transcript(&[user("hi")], &[backend_assistant("hello")]),
+            turn_state: None,
+        };
+        let current = body(vec![
+            user("hi"),
+            reconstructed_assistant("hello"),
+            user("bye"),
+        ]);
+
+        assert!(decide(&stored, &current).is_some());
+        assert!(decide_with_signature(&stored, &current, "not-the-current-signature").is_none());
+    }
+
+    #[test]
+    fn signature_format_is_stable_for_nested_and_escaped_values() {
+        let fixture = json!({
+            "z_null": null,
+            "nested": {
+                "z": [1, true, null, {"b": "line\n\"slash\\", "a\"b": false}],
+                "a": -2.5
+            },
+            "input": [user("excluded")],
+            "a\"b": "quote \" newline\n tab\t slash\\"
+        });
+
+        assert_eq!(
+            signature(&fixture),
+            r#"{"a\"b":"quote \" newline\n tab\t slash\\","nested":{"a":-2.5,"z":[1,true,null,{"a\"b":false,"b":"line\n\"slash\\"}]},"z_null":null}"#
+        );
     }
 
     #[test]

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -385,8 +385,10 @@ pub fn response_create_frame(mut body: Value) -> Value {
 }
 
 /// What to record as continuation state after a turn completes: the request's
-/// non-input signature and its full logical input, so the reader can assemble
-/// `input ++ output_items` for the next turn's prefix match.
+/// non-input signature and an optional shared translated request. The reader
+/// extracts its full logical `input` after the turn completes, then assembles
+/// `input ++ output_items` for the next turn's prefix match. Sharing the [`Arc`]
+/// replaces the old per-turn deep clone of the input array.
 pub struct RecordPlan {
     pub signature: String,
     pub request: Option<Arc<Value>>,

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -389,7 +389,7 @@ pub fn response_create_frame(mut body: Value) -> Value {
 /// `input ++ output_items` for the next turn's prefix match.
 pub struct RecordPlan {
     pub signature: String,
-    pub request_input: Vec<Value>,
+    pub request: Option<Arc<Value>>,
 }
 
 impl RecordPlan {
@@ -397,7 +397,7 @@ impl RecordPlan {
     pub fn none() -> Self {
         Self {
             signature: String::new(),
-            request_input: Vec::new(),
+            request: None,
         }
     }
 }
@@ -947,7 +947,16 @@ async fn run_turn(
                             let stored = StoredContinuation {
                                 response_id,
                                 signature: record.signature,
-                                transcript: build_transcript(&record.request_input, &output_items),
+                                transcript: build_transcript(
+                                    record
+                                        .request
+                                        .as_deref()
+                                        .and_then(|request| request.get("input"))
+                                        .and_then(Value::as_array)
+                                        .map(Vec::as_slice)
+                                        .unwrap_or_default(),
+                                    &output_items,
+                                ),
                                 turn_state: turn_state
                                     .or_else(|| conn.handshake_turn_state.clone()),
                             };
@@ -2014,7 +2023,7 @@ mod tests {
                 &frame,
                 RecordPlan {
                     signature: "sig-a".to_string(),
-                    request_input: vec![user_hi.clone()],
+                    request: Some(Arc::new(serde_json::json!({"input": [user_hi.clone()]}))),
                 },
             )
             .await

--- a/src/adapters/responses/context.rs
+++ b/src/adapters/responses/context.rs
@@ -69,12 +69,11 @@ impl TurnOptions {
 /// The request-derived fields the single-account transports (`forward_http` and
 /// `forward_websocket`) need beyond `state`/`route` and their own connection key
 /// (`forward_http` also takes `session_id`, `forward_websocket` also takes
-/// `pool_key`). Cloned once in `forward` so a pre-first-event websocket failure
-/// can fall back to HTTP with the same body/credential — the same fields the
-/// previous per-argument clones copied.
+/// `pool_key`). Cheaply cloned once in `forward` so a pre-first-event websocket
+/// failure can fall back to HTTP with the same shared translated body and credential.
 #[derive(Debug, Clone)]
 pub(super) struct ForwardOptions {
-    pub upstream_body: Value,
+    pub upstream_body: Arc<Value>,
     pub credential: Credential,
     pub auth: AuthMode,
     pub turn: TurnOptions,
@@ -94,7 +93,7 @@ pub(super) struct ForwardOptions {
 pub(super) struct PoolForward {
     pub pool_key: Option<String>,
     pub session_id: Option<String>,
-    pub upstream_body: Value,
+    pub upstream_body: Arc<Value>,
     pub accounts_config: Vec<AccountConfig>,
     pub turn: TurnOptions,
 }

--- a/src/adapters/responses/http.rs
+++ b/src/adapters/responses/http.rs
@@ -79,7 +79,7 @@ pub(super) async fn forward_http(
     // layer retry on top. This single-credential path retries only before any
     // response body is handed to the streaming/JSON relay.
     let policy = provider_retry_policy(state, route);
-    let body = bytes::Bytes::from(upstream_body.to_string());
+    let body = bytes::Bytes::from(upstream_body.as_ref().to_string());
     let upstream = crate::retry::send_with_retry_with_safety(
         policy,
         &route.provider,

--- a/src/adapters/responses/mod.rs
+++ b/src/adapters/responses/mod.rs
@@ -19,7 +19,8 @@ use crate::{
     adapters::{Adapter, AdapterError, AdapterFuture},
     auth::{self, resolve_credential, Credential},
     config::{AuthMode, CountTokens},
-    model::responses::translate_request,
+    model::responses::translate_request_value,
+    request::RequestBody,
     routing::Route,
     server::AppState,
 };
@@ -40,7 +41,7 @@ impl Adapter for ResponsesAdapter {
         route: Route,
         _uri: &'a Uri,
         headers: &'a HeaderMap,
-        body: Vec<u8>,
+        body: RequestBody,
     ) -> AdapterFuture<'a> {
         // The session id keys the websocket connection pool (issue #32) so turns
         // of one Claude Code conversation reuse a live connection. Keep an owned
@@ -69,19 +70,19 @@ async fn forward(
     route: Route,
     pool_key: Option<String>,
     session_id: Option<String>,
-    body: Vec<u8>,
+    body: RequestBody,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
-    let request_json = serde_json::from_slice::<Value>(&body).ok();
+    let request_json = body.json();
     let client_wants_stream = request_json
-        .as_ref()
-        .and_then(|value| value.get("stream").and_then(Value::as_bool))
+        .get("stream")
+        .and_then(Value::as_bool)
         .unwrap_or(false);
     // Gates reasoning round-tripping (see model/responses.rs): surface thinking
     // blocks only when the client asked for extended thinking, since that is what
     // makes Claude Code echo them back on the next turn.
     let thinking_enabled = request_json
-        .as_ref()
-        .and_then(|value| value.pointer("/thinking/type").and_then(Value::as_str))
+        .pointer("/thinking/type")
+        .and_then(Value::as_str)
         == Some("enabled");
     let flavor = state.config.responses_flavor(&route.provider);
     // Native client-executed tool_search (issue #82) is opt-in per provider and
@@ -111,7 +112,7 @@ async fn forward(
                 .unwrap_or(CountTokens::Estimate),
             CountTokens::Tiktoken
         ) {
-        request_json.map(Arc::new)
+        Some(body.json_arc())
     } else {
         None
     };
@@ -120,8 +121,12 @@ async fn forward(
         thinking_enabled,
         tool_search_native,
     };
-    let upstream_body = translate_request(&body, &route, flavor, tool_search_native)
-        .map_err(|error| own_error(error.to_string()))?;
+    let upstream_body = Arc::new(translate_request_value(
+        request_json,
+        &route,
+        flavor,
+        tool_search_native,
+    ));
     tracing::debug!(
         provider = %route.provider,
         upstream_model = %route.upstream_model,

--- a/src/adapters/responses/pool.rs
+++ b/src/adapters/responses/pool.rs
@@ -150,9 +150,9 @@ pub(super) async fn forward_chatgpt_oauth(
             // ownership of, skipping the `fmt` machinery and UTF-8 round-trip
             // `Value::to_string()` pays for. Serializing a `Value` cannot fail,
             // so the fallback is unreachable — it just keeps the old path.
-            serde_json::to_vec(&upstream_body)
+            serde_json::to_vec(upstream_body.as_ref())
                 .map(bytes::Bytes::from)
-                .unwrap_or_else(|_| bytes::Bytes::from(upstream_body.to_string()))
+                .unwrap_or_else(|_| bytes::Bytes::from(upstream_body.as_ref().to_string()))
         });
         let upstream = match http_send(
             &state,

--- a/src/adapters/responses/websocket.rs
+++ b/src/adapters/responses/websocket.rs
@@ -53,11 +53,6 @@ pub(super) async fn forward_websocket(
         credential,
         auth,
         signature: codex_continuation::signature(&upstream_body),
-        full_input: upstream_body
-            .get("input")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default(),
         upstream_body,
     };
     tracing::debug!(provider = %route.provider, ws_url = %ctx.ws_url, pool_key = pool_key.unwrap_or(""), "opening codex websocket");
@@ -107,8 +102,7 @@ struct WsTurnContext<'a> {
     credential: Credential,
     auth: AuthMode,
     signature: String,
-    full_input: Vec<Value>,
-    upstream_body: Value,
+    upstream_body: std::sync::Arc<Value>,
 }
 
 /// The first event, peeked off the stream before the websocket response is
@@ -235,14 +229,18 @@ async fn start_ws_turn(
             .note_codex_quota(ctx.provider, account, headers);
     }
 
-    let mut frame_body = ctx.upstream_body.clone();
+    let mut frame_body = ctx.upstream_body.as_ref().clone();
     let mut used_continuation = false;
     if allow_continuation {
         // Only a reused connection carries stored continuation state; a fresh
         // connection has no chance to continue and is not counted, so the hit/
         // fallback series stay directly comparable (issue #45).
         if let Some(stored) = turn.stored_continuation() {
-            match codex_continuation::decide(&stored, &ctx.upstream_body) {
+            match codex_continuation::decide_with_signature(
+                &stored,
+                ctx.upstream_body.as_ref(),
+                &ctx.signature,
+            ) {
                 Some(decision) => {
                     let turn_state = stored
                         .turn_state
@@ -279,7 +277,7 @@ async fn start_ws_turn(
     let frame = codex_ws::response_create_frame(frame_body);
     let record = codex_ws::RecordPlan {
         signature: ctx.signature.clone(),
-        request_input: ctx.full_input.clone(),
+        request: Some(std::sync::Arc::clone(&ctx.upstream_body)),
     };
     let events = turn
         .stream(&frame, record)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod oauth_usage;
 pub mod protocol;
 pub mod proxy;
 pub mod reload;
+pub(crate) mod request;
 pub mod retry;
 pub mod routes;
 pub mod routing;

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -4,7 +4,9 @@ use axum::http::StatusCode;
 use serde_json::{json, Value};
 
 use crate::model::responses_request::TOOL_SEARCH_NAME;
-pub use crate::model::responses_request::{encode_reasoning_signature, translate_request};
+pub use crate::model::responses_request::{
+    encode_reasoning_signature, translate_request, translate_request_value,
+};
 
 #[derive(Debug, Clone)]
 pub struct ResponseEvent {

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -112,15 +112,29 @@ pub fn translate_request(
     tool_search_native: bool,
 ) -> Result<Value, serde_json::Error> {
     let request: Value = serde_json::from_slice(body)?;
-    let tool_search = ToolSearchContext::from_request(&request, tool_search_native);
+    Ok(translate_request_value(
+        &request,
+        route,
+        flavor,
+        tool_search_native,
+    ))
+}
+
+pub fn translate_request_value(
+    request: &Value,
+    route: &Route,
+    flavor: ResponsesFlavor,
+    tool_search_native: bool,
+) -> Value {
+    let tool_search = ToolSearchContext::from_request(request, tool_search_native);
     let mut out = Map::new();
     out.insert("model".to_string(), json!(route.upstream_model));
-    if let Some(instructions) = instructions(&request) {
+    if let Some(instructions) = instructions(request) {
         out.insert("instructions".to_string(), json!(instructions));
     }
     out.insert(
         "input".to_string(),
-        Value::Array(input_items(&request, &tool_search)),
+        Value::Array(input_items(request, &tool_search)),
     );
     // Only emit tools/tool_choice when at least one tool survives translation.
     // The hosted web-search tool is dropped on flavors that reject it (xAI), and
@@ -128,11 +142,11 @@ pub fn translate_request(
     // tool reveal); if the set is now empty, an empty `tools: []` array is rejected
     // by OpenAI-compatible backends ("expected an array with at least one
     // element"), while a `tool_choice` with no tools is meaningless.
-    if let Some(tools) = tools(&request, flavor, &tool_search)
-        .filter(|t| t.as_array().is_some_and(|a| !a.is_empty()))
+    if let Some(tools) =
+        tools(request, flavor, &tool_search).filter(|t| t.as_array().is_some_and(|a| !a.is_empty()))
     {
         out.insert("tools".to_string(), tools);
-        if let Some(tool_choice) = tool_choice(&request, flavor, &tool_search) {
+        if let Some(tool_choice) = tool_choice(request, flavor, &tool_search) {
             out.insert("tool_choice".to_string(), tool_choice);
         }
     }
@@ -156,14 +170,14 @@ pub fn translate_request(
             if route.effort.is_some() || client_effort {
                 out.insert(
                     "reasoning".to_string(),
-                    json!({"effort": effort(&request, route)}),
+                    json!({"effort": effort(request, route)}),
                 );
             }
         }
         _ => {
             out.insert(
                 "reasoning".to_string(),
-                json!({"effort": effort(&request, route), "summary": "auto"}),
+                json!({"effort": effort(request, route), "summary": "auto"}),
             );
         }
     }
@@ -176,13 +190,13 @@ pub fn translate_request(
     // for the encrypted reasoning blob and echo it back next turn (see input_items).
     // Only when the client enabled extended thinking, which is what lets Claude Code
     // round-trip the thinking blocks that carry the blob (see model/responses.rs).
-    if thinking_enabled(&request) {
+    if thinking_enabled(request) {
         out.insert(
             "include".to_string(),
             json!(["reasoning.encrypted_content"]),
         );
     }
-    if let Some(cache_key) = prompt_cache_key(&request) {
+    if let Some(cache_key) = prompt_cache_key(request) {
         out.insert("prompt_cache_key".to_string(), json!(cache_key));
     }
     // Anthropic `max_tokens` caps output; the Responses equivalent is
@@ -197,7 +211,7 @@ pub fn translate_request(
     }
     out.insert("store".to_string(), json!(false));
     out.insert("stream".to_string(), json!(true));
-    Ok(Value::Object(out))
+    Value::Object(out)
 }
 
 /// A stable per-conversation key so the Responses backend routes every turn of a

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -92,17 +92,10 @@ pub(crate) fn is_count_tokens(uri: &Uri) -> bool {
     uri.path().ends_with("/count_tokens")
 }
 
-fn normalize_request_body(body: Vec<u8>) -> Vec<u8> {
-    let Ok(mut request) = serde_json::from_slice::<Value>(&body) else {
-        return body;
-    };
-    // Re-serialize only when a block was actually dropped. The common case (no
-    // empty text block) keeps the original bytes and skips the encode entirely.
-    if normalize_empty_text_blocks(&mut request) {
-        serde_json::to_vec(&request).unwrap_or(body)
-    } else {
-        body
-    }
+fn normalize_request_body(body: &mut crate::request::RequestBody) {
+    // Refresh the raw passthrough bytes only when a block was actually dropped.
+    // The common case keeps the client's exact bytes and the already-parsed tree.
+    body.mutate(normalize_empty_text_blocks);
 }
 
 pub(crate) fn normalize_empty_text_blocks(request: &mut Value) -> bool {

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -39,11 +39,19 @@ pub(super) async fn forward(
                 response: UpstreamError::from_message(message).into_response(),
             }
         })?;
-    let mut body = normalize_request_body(body.to_vec());
-    let (mut routes, requested_model) = routing::resolve_request_chain(&state.config, &body)
+    let mut body = crate::request::RequestBody::parse(body.to_vec())
+        .map_err(routing::invalid_routing_request)
         .map_err(|error| ForwardError {
             message: "failed to route request".to_string(),
             response: error.into_response(),
+        })?;
+    normalize_request_body(&mut body);
+    let (mut routes, requested_model) =
+        routing::resolve_request_chain_value(&state.config, body.json()).map_err(|error| {
+            ForwardError {
+                message: "failed to route request".to_string(),
+                response: error.into_response(),
+            }
         })?;
     if is_count_tokens(uri) {
         // count_tokens answers from the first chain element only, so gate and
@@ -74,6 +82,7 @@ pub(super) async fn forward(
     }
 
     let attempted_total = routes.len();
+    let mut body = Some(body);
     let last_route = routes
         .last()
         .expect("route chains are non-empty after resolution")
@@ -107,12 +116,13 @@ pub(super) async fn forward(
         // Move the buffered body into the final attempt instead of cloning it: the
         // common single-upstream chain then never copies the (up to 64 MB) body,
         // and a multi-upstream chain only clones for the attempts that precede the
-        // last. `mem::take` (not a bare move) keeps the borrow checker happy inside
-        // the loop; `body` is unused after the loop.
+        // last. The `Option` permits that final move while keeping earlier attempts
+        // able to share the parsed tree and clone only the raw byte buffer.
         let attempt_body = if index + 1 < attempted_total {
-            body.clone()
+            body.as_ref().expect("request body is present").clone()
         } else {
-            std::mem::take(&mut body)
+            body.take()
+                .expect("request body is present for final attempt")
         };
         let result = dispatch(state.clone(), route, uri, &attempt_headers, attempt_body).await;
 
@@ -235,7 +245,7 @@ async fn count_tokens_response(
     uri: &Uri,
     base_headers: &HeaderMap,
     inbound: &InboundContext,
-    body: Vec<u8>,
+    body: crate::request::RequestBody,
     requested_model: &str,
 ) -> Result<(StatusCode, axum::response::Response), ForwardError> {
     let provider = route.provider.clone();
@@ -254,10 +264,11 @@ async fn count_tokens_response(
             .unwrap_or(CountTokens::Estimate);
         Ok(match mode {
             CountTokens::Tiktoken => {
-                let input_tokens =
-                    tokio::task::spawn_blocking(move || count_tokens::count_input_tokens(&body))
-                        .await
-                        .unwrap_or(0);
+                let input_tokens = tokio::task::spawn_blocking(move || {
+                    count_tokens::count_input_tokens(body.raw())
+                })
+                .await
+                .unwrap_or(0);
                 (
                     StatusCode::OK,
                     axum::Json(serde_json::json!({ "input_tokens": input_tokens })).into_response(),
@@ -293,7 +304,7 @@ async fn dispatch(
     route: routing::Route,
     uri: &Uri,
     headers: &HeaderMap,
-    body: Vec<u8>,
+    body: crate::request::RequestBody,
 ) -> Result<(StatusCode, axum::response::Response), AdapterError> {
     match route.adapter {
         AdapterKind::Anthropic => {

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -113,11 +113,12 @@ pub(super) async fn forward(
         let model = route.model.clone();
         let upstream_model = route.upstream_model.clone();
         let attempt_started_at = Instant::now();
-        // Move the buffered body into the final attempt instead of cloning it: the
-        // common single-upstream chain then never copies the (up to 64 MB) body,
-        // and a multi-upstream chain only clones for the attempts that precede the
-        // last. The `Option` permits that final move while keeping earlier attempts
-        // able to share the parsed tree and clone only the raw byte buffer.
+        // Move the buffered body into the final attempt instead of cloning it. Within
+        // this failover loop, the common single-upstream chain transfers the body
+        // without copying its (up to 64 MB) raw buffer, and a multi-upstream chain
+        // only clones that buffer for attempts preceding the last. Those clones
+        // still share the parsed tree; an adapter may clone the body again downstream.
+        // The `Option` permits the final move while keeping the body available earlier.
         let attempt_body = if index + 1 < attempted_total {
             body.as_ref().expect("request body is present").clone()
         } else {
@@ -264,8 +265,15 @@ async fn count_tokens_response(
             .unwrap_or(CountTokens::Estimate);
         Ok(match mode {
             CountTokens::Tiktoken => {
+                // Count over the tree the inbound parse already produced instead of
+                // re-deserializing the same buffer on the blocking pool. Moving only
+                // the `Arc` also keeps the raw bytes out of the task: `spawn_blocking`
+                // cannot be cancelled, so a client that disconnects mid-request leaves
+                // this encode running to completion, and anything it captured stays
+                // resident (up to a 64 MB body) for that whole window.
+                let request = body.json_arc();
                 let input_tokens = tokio::task::spawn_blocking(move || {
-                    count_tokens::count_input_tokens(body.raw())
+                    count_tokens::count_input_tokens_value(&request)
                 })
                 .await
                 .unwrap_or(0);

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use serde_json::Value;
+
+/// One buffered inbound request: exact client bytes plus their parsed JSON tree.
+///
+/// The raw bytes remain authoritative for passthrough adapters. Translating
+/// adapters borrow `json`, so routing, flag extraction, and translation share the
+/// one parse performed when the proxy finishes buffering the body.
+#[derive(Clone, Debug)]
+pub(crate) struct RequestBody {
+    raw: Vec<u8>,
+    json: Arc<Value>,
+}
+
+impl RequestBody {
+    pub(crate) fn parse(raw: Vec<u8>) -> Result<Self, serde_json::Error> {
+        let json = serde_json::from_slice(&raw)?;
+        Ok(Self {
+            raw,
+            json: Arc::new(json),
+        })
+    }
+
+    pub(crate) fn raw(&self) -> &[u8] {
+        &self.raw
+    }
+
+    pub(crate) fn json(&self) -> &Value {
+        &self.json
+    }
+
+    pub(crate) fn json_arc(&self) -> Arc<Value> {
+        Arc::clone(&self.json)
+    }
+
+    pub(crate) fn into_raw(self) -> Vec<u8> {
+        self.raw
+    }
+
+    /// Mutate the shared JSON representation and refresh the passthrough bytes
+    /// only when the caller reports an observable change.
+    pub(crate) fn mutate(&mut self, update: impl FnOnce(&mut Value) -> bool) {
+        if update(Arc::make_mut(&mut self.json)) {
+            self.raw = serde_json::to_vec(self.json.as_ref())
+                .expect("a serde_json::Value always serializes");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::RequestBody;
+
+    #[test]
+    fn clones_share_json_but_preserve_raw_bytes() {
+        let raw = b"{ \"model\": \"claude-test\", \"messages\": [] }".to_vec();
+        let request = RequestBody::parse(raw.clone()).unwrap();
+        let cloned = request.clone();
+
+        assert!(Arc::ptr_eq(&request.json, &cloned.json));
+        assert_eq!(request.raw(), raw);
+        assert_eq!(cloned.raw(), raw);
+    }
+
+    #[test]
+    fn no_op_mutation_keeps_original_bytes() {
+        let raw = b"{ \"model\": \"claude-test\" }".to_vec();
+        let mut request = RequestBody::parse(raw.clone()).unwrap();
+
+        request.mutate(|_| false);
+
+        assert_eq!(request.into_raw(), raw);
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,29 +1,149 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
-use serde_json::Value;
+use serde::{
+    de::{self, MapAccess, SeqAccess, Visitor},
+    Deserializer as _,
+};
+use serde_json::{Map, Number, Value};
 
-/// One buffered inbound request: exact client bytes plus their parsed JSON tree.
+/// One buffered inbound request: the passthrough bytes plus their parsed JSON tree.
 ///
-/// The raw bytes remain authoritative for passthrough adapters. Translating
-/// adapters borrow `json`, so routing, flag extraction, and translation share the
-/// one parse performed when the proxy finishes buffering the body.
+/// `raw` is what passthrough adapters forward. It starts as the client's exact
+/// bytes — which is what preserves byte-for-byte passthrough — but [`mutate`]
+/// replaces it with a fresh serialization once a rewrite has to be observable
+/// upstream, so it is authoritative rather than an audit copy of what the client
+/// sent. Translating adapters borrow `json`, so routing, flag extraction, and
+/// translation all share the one parse performed when the proxy finishes
+/// buffering the body.
+///
+/// [`mutate`]: RequestBody::mutate
 #[derive(Clone, Debug)]
 pub(crate) struct RequestBody {
     raw: Vec<u8>,
     json: Arc<Value>,
 }
 
+struct TopLevelValueVisitor;
+
+impl<'de> Visitor<'de> for TopLevelValueVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("any valid JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("JSON numbers must be finite"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            // Check before pulling the value: a duplicate key ends the parse, so
+            // there is no reason to materialize the `Value` that follows it. Keys
+            // are moved rather than cloned — the inbound limit permits a
+            // multi-megabyte key, so neither the map nor the error may copy one.
+            if values.contains_key(&key) {
+                return Err(de::Error::custom(format!(
+                    "duplicate field `{}`",
+                    echoed_key(&key)
+                )));
+            }
+            let value = object.next_value::<Value>()?;
+            values.insert(key, value);
+        }
+        Ok(Value::Object(values))
+    }
+}
+
+/// Longest client-supplied key echoed back in a parse error, in characters.
+const MAX_ECHOED_KEY_CHARS: usize = 64;
+
+/// Bound the key interpolated into a duplicate-key error. The message reaches the
+/// client, and the inbound body limit allows a key far larger than any real field
+/// name, so echoing it verbatim would let a malformed request inflate the error
+/// response it gets back. Realistic field names are well under the cap and are
+/// reproduced exactly.
+fn echoed_key(key: &str) -> String {
+    match key.char_indices().nth(MAX_ECHOED_KEY_CHARS) {
+        Some((boundary, _)) => format!("{}...", &key[..boundary]),
+        None => key.to_string(),
+    }
+}
+
 impl RequestBody {
+    /// Parse the request while rejecting duplicate keys in its top-level object.
+    ///
+    /// Shunt reads the parsed tree but may forward the original bytes verbatim;
+    /// accepting a duplicate top-level key could make the gateway and upstream
+    /// interpret the same request differently. Nested objects retain
+    /// `serde_json::Value`'s last-value-wins behavior.
+    ///
+    /// This deliberately does not reproduce one `Value` behavior: because the
+    /// `raw_value` feature is enabled in this build, stock `Value` deserialization
+    /// treats a leading `$serde_json::private::RawValue` key as a sentinel and
+    /// substitutes its contents. That is serde_json's private in-process protocol,
+    /// never something an untrusted client should be able to trigger — and honoring
+    /// it here would reintroduce exactly the raw-versus-tree divergence this type
+    /// exists to prevent. The visitor treats it as an ordinary key.
     pub(crate) fn parse(raw: Vec<u8>) -> Result<Self, serde_json::Error> {
-        let json = serde_json::from_slice(&raw)?;
+        let mut deserializer = serde_json::Deserializer::from_slice(&raw);
+        let json = deserializer.deserialize_any(TopLevelValueVisitor)?;
+        deserializer.end()?;
         Ok(Self {
             raw,
             json: Arc::new(json),
         })
-    }
-
-    pub(crate) fn raw(&self) -> &[u8] {
-        &self.raw
     }
 
     pub(crate) fn json(&self) -> &Value {
@@ -38,8 +158,18 @@ impl RequestBody {
         self.raw
     }
 
-    /// Mutate the shared JSON representation and refresh the passthrough bytes
-    /// only when the caller reports an observable change.
+    /// Mutate the shared JSON representation, refreshing the passthrough bytes
+    /// only when the value actually changed.
+    ///
+    /// `update` **must** return `true` if and only if it mutated the value. That
+    /// contract cannot be enforced here, and violating it is not benign: a closure
+    /// that mutates and returns `false` leaves `raw` stale while `json` moves on,
+    /// so routing and the managed-model policy would gate on one request while the
+    /// passthrough adapter forwards a materially different one upstream.
+    ///
+    /// Callers that can cheaply rule out a change should check before calling —
+    /// `Arc::make_mut` runs before `update` decides, so a no-op mutation on a body
+    /// whose tree is shared still pays for a full copy-on-write clone.
     pub(crate) fn mutate(&mut self, update: impl FnOnce(&mut Value) -> bool) {
         if update(Arc::make_mut(&mut self.json)) {
             self.raw = serde_json::to_vec(self.json.as_ref())
@@ -52,7 +182,65 @@ impl RequestBody {
 mod tests {
     use std::sync::Arc;
 
+    use serde_json::Value;
+
     use super::RequestBody;
+
+    #[test]
+    fn duplicate_top_level_key_is_rejected() {
+        let error =
+            RequestBody::parse(br#"{"model":"first","model":"second"}"#.to_vec()).unwrap_err();
+
+        assert!(error.to_string().contains("duplicate field `model`"));
+    }
+
+    #[test]
+    fn duplicate_nested_key_collapses_to_last_value() {
+        let request =
+            RequestBody::parse(br#"{"tool":{"name":"first","name":"second"}}"#.to_vec()).unwrap();
+
+        assert_eq!(request.json()["tool"]["name"], "second");
+    }
+
+    #[test]
+    fn non_object_top_level_value_still_parses() {
+        let request = RequestBody::parse(b"[1,2,3]".to_vec()).unwrap();
+
+        assert_eq!(request.json(), &serde_json::json!([1, 2, 3]));
+    }
+
+    /// The inbound limit allows a key far larger than any real field name, and the
+    /// parse error is returned to the client, so a duplicate must not let a
+    /// malformed body inflate its own error response.
+    #[test]
+    fn duplicate_key_error_does_not_echo_an_oversized_key() {
+        let key = "k".repeat(100_000);
+        let body = format!(r#"{{"{key}":1,"{key}":2}}"#).into_bytes();
+
+        let error = RequestBody::parse(body).unwrap_err().to_string();
+
+        assert!(
+            error.len() < 1_000,
+            "duplicate-key error grew with the key: {} bytes",
+            error.len()
+        );
+        assert!(
+            error.contains("duplicate field"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn duplicate_key_error_reproduces_a_realistic_field_name_exactly() {
+        let error = RequestBody::parse(br#"{"max_tokens":1,"max_tokens":2}"#.to_vec())
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("duplicate field `max_tokens`"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[test]
     fn clones_share_json_but_preserve_raw_bytes() {
@@ -61,8 +249,8 @@ mod tests {
         let cloned = request.clone();
 
         assert!(Arc::ptr_eq(&request.json, &cloned.json));
-        assert_eq!(request.raw(), raw);
-        assert_eq!(cloned.raw(), raw);
+        assert_eq!(request.raw, raw);
+        assert_eq!(cloned.raw, raw);
     }
 
     #[test]
@@ -73,5 +261,54 @@ mod tests {
         request.mutate(|_| false);
 
         assert_eq!(request.into_raw(), raw);
+    }
+
+    /// The property the Anthropic account pool depends on: one candidate's rewrite
+    /// must not reach the retained body every other candidate is cloned from.
+    #[test]
+    fn mutating_a_clone_leaves_the_original_untouched() {
+        let raw = b"{ \"model\": \"claude-test\", \"messages\": [] }".to_vec();
+        let request = RequestBody::parse(raw.clone()).unwrap();
+        let mut cloned = request.clone();
+
+        cloned.mutate(|value| {
+            value["model"] = Value::String("rewritten".to_string());
+            true
+        });
+
+        assert!(!Arc::ptr_eq(&request.json, &cloned.json));
+        assert_eq!(request.raw, raw);
+        assert_eq!(request.json()["model"], "claude-test");
+        assert_eq!(cloned.json()["model"], "rewritten");
+        assert_ne!(cloned.raw, raw);
+    }
+
+    /// `json_arc` hands the tiktoken estimate a handle that outlives the adapter's
+    /// own rewrites, so a later mutation must not retroactively change what it counts.
+    #[test]
+    fn a_handed_out_json_arc_still_observes_the_pre_mutation_tree() {
+        let mut request = RequestBody::parse(b"{ \"model\": \"claude-test\" }".to_vec()).unwrap();
+        let handed_out = request.json_arc();
+
+        request.mutate(|value| {
+            value["model"] = Value::String("rewritten".to_string());
+            true
+        });
+
+        assert_eq!(handed_out["model"], "claude-test");
+        assert_eq!(request.json()["model"], "rewritten");
+    }
+
+    #[test]
+    fn no_op_mutation_on_a_shared_body_leaves_both_holders_identical() {
+        let raw = b"{ \"model\": \"claude-test\" }".to_vec();
+        let mut request = RequestBody::parse(raw.clone()).unwrap();
+        let cloned = request.clone();
+
+        request.mutate(|_| false);
+
+        assert_eq!(request.raw, cloned.raw);
+        assert_eq!(request.json(), cloned.json());
+        assert_eq!(request.raw, raw);
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -61,15 +61,25 @@ pub(crate) fn resolve_request_chain(
     config: &Config,
     body: &[u8],
 ) -> Result<(Vec<Route>, String), ShuntError> {
-    let view: RoutingView = serde_json::from_slice(body).map_err(|error| {
-        ShuntError::new(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            format!("request body must include a JSON model field: {error}"),
-        )
-    })?;
+    let request = serde_json::from_slice(body).map_err(invalid_routing_request)?;
+    resolve_request_chain_value(config, &request)
+}
+
+pub(crate) fn resolve_request_chain_value(
+    config: &Config,
+    request: &serde_json::Value,
+) -> Result<(Vec<Route>, String), ShuntError> {
+    let view = RoutingView::deserialize(request).map_err(invalid_routing_request)?;
     let routes = resolve_model_chain(config, &view.model);
     Ok((routes, view.model))
+}
+
+pub(crate) fn invalid_routing_request(error: serde_json::Error) -> ShuntError {
+    ShuntError::new(
+        StatusCode::BAD_REQUEST,
+        "invalid_request_error",
+        format!("request body must include a JSON model field: {error}"),
+    )
 }
 
 /// Claude Code appends a `[1m]` suffix to a model id as a *client-side* hint that

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -61,8 +61,10 @@ pub(crate) fn resolve_request_chain(
     config: &Config,
     body: &[u8],
 ) -> Result<(Vec<Route>, String), ShuntError> {
-    let request = serde_json::from_slice(body).map_err(invalid_routing_request)?;
-    resolve_request_chain_value(config, &request)
+    // Deserialize the narrow view straight from bytes for callers without a
+    // parsed tree: serde can skip every non-model field without materializing it.
+    let view: RoutingView = serde_json::from_slice(body).map_err(invalid_routing_request)?;
+    Ok(resolve_view(config, view))
 }
 
 pub(crate) fn resolve_request_chain_value(
@@ -70,8 +72,12 @@ pub(crate) fn resolve_request_chain_value(
     request: &serde_json::Value,
 ) -> Result<(Vec<Route>, String), ShuntError> {
     let view = RoutingView::deserialize(request).map_err(invalid_routing_request)?;
+    Ok(resolve_view(config, view))
+}
+
+fn resolve_view(config: &Config, view: RoutingView) -> (Vec<Route>, String) {
     let routes = resolve_model_chain(config, &view.model);
-    Ok((routes, view.model))
+    (routes, view.model)
 }
 
 pub(crate) fn invalid_routing_request(error: serde_json::Error) -> ShuntError {
@@ -464,6 +470,15 @@ mod tests {
             assert_eq!(routes.len(), 1);
             assert_eq!(routes[0].provider, provider);
         }
+    }
+
+    #[test]
+    fn request_chain_rejects_duplicate_model_fields() {
+        assert!(resolve_request_chain(
+            &Config::default(),
+            br#"{"model":"first","model":"second"}"#,
+        )
+        .is_err());
     }
 
     #[test]

--- a/tests/failover.rs
+++ b/tests/failover.rs
@@ -37,6 +37,14 @@ impl Match for HeaderAbsent {
     }
 }
 
+struct ExactBody(Vec<u8>);
+
+impl Match for ExactBody {
+    fn matches(&self, request: &Request) -> bool {
+        request.body == self.0
+    }
+}
+
 struct TestGateway {
     base_url: String,
     task: JoinHandle<()>,
@@ -229,6 +237,57 @@ async fn chain_order_stops_at_first_healthy_upstream() {
     assert_eq!(response.text().await.unwrap(), r#"{"winner":"first"}"#);
     first.verify().await;
     second.verify().await;
+}
+
+#[tokio::test]
+async fn failover_attempt_mutation_preserves_original_body_for_fallback() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let primary = MockServer::start().await;
+    let fallback = MockServer::start().await;
+    let original_body = br#"{  "max_tokens" : 16, "messages" : [ { "content" : "hi", "role" : "user" } ], "model" : "failover-model"  }"#.to_vec();
+    let primary_model = "primary-rewritten-model";
+    let mut primary_body: Value = serde_json::from_slice(&original_body).unwrap();
+    primary_body["model"] = Value::String(primary_model.to_string());
+    let primary_body = serde_json::to_vec(&primary_body).unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(ExactBody(primary_body))
+        .respond_with(ResponseTemplate::new(500).set_body_string("advance"))
+        .expect(1)
+        .mount(&primary)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(ExactBody(original_body.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_string("fallback"))
+        .expect(1)
+        .mount(&fallback)
+        .await;
+    let config = chain_config(
+        vec![
+            passthrough("primary", primary.uri()),
+            passthrough("fallback", fallback.uri()),
+        ],
+        &[("primary", primary_model), ("fallback", CLIENT_MODEL)],
+    );
+    let gateway = start_gateway(config).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .header("content-type", "application/json")
+        .body(original_body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_gateway_headers(&response, "fallback", CLIENT_MODEL);
+    assert_eq!(response.text().await.unwrap(), "fallback");
+    primary.verify().await;
+    fallback.verify().await;
 }
 
 #[tokio::test]

--- a/tests/multi_account.rs
+++ b/tests/multi_account.rs
@@ -31,6 +31,32 @@ impl Match for BearerToken {
     }
 }
 
+struct AccountUuidBody {
+    expected: &'static str,
+    forbidden: &'static str,
+}
+
+impl Match for AccountUuidBody {
+    fn matches(&self, request: &Request) -> bool {
+        let Ok(outer) = serde_json::from_slice::<serde_json::Value>(&request.body) else {
+            return false;
+        };
+        let Some(user_id) = outer
+            .pointer("/metadata/user_id")
+            .and_then(serde_json::Value::as_str)
+        else {
+            return false;
+        };
+        let Ok(inner) = serde_json::from_str::<serde_json::Value>(user_id) else {
+            return false;
+        };
+        let account_uuid = inner
+            .get("account_uuid")
+            .and_then(serde_json::Value::as_str);
+        account_uuid == Some(self.expected) && account_uuid != Some(self.forbidden)
+    }
+}
+
 struct TestGateway {
     base_url: String,
     task: JoinHandle<()>,
@@ -165,6 +191,82 @@ async fn post_messages(gateway: &TestGateway, session_id: Option<&str>) -> reqwe
         request = request.header("x-claude-code-session-id", session_id);
     }
     request.send().await.unwrap()
+}
+
+async fn post_messages_with_account_uuid(
+    gateway: &TestGateway,
+    account_uuid: &str,
+) -> reqwest::Response {
+    let user_id = serde_json::json!({
+        "account_uuid": account_uuid,
+        "device": "cli"
+    })
+    .to_string();
+    reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({
+            "model": "pooled-model",
+            "max_tokens": 16,
+            "metadata": {"user_id": user_id},
+            "messages": [{"role": "user", "content": "hi"}]
+        }))
+        .send()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn account_uuid_is_rewritten_for_each_account_during_rotation() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let token_a = ["fake-oauth-", "uuid-a"].concat();
+    let token_b = ["fake-oauth-", "uuid-b"].concat();
+    std::env::set_var("SHUNT_TEST_MULTI_UUID_A", &token_a);
+    std::env::set_var("SHUNT_TEST_MULTI_UUID_B", &token_b);
+
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(BearerToken(token_a.clone()))
+        .and(AccountUuidBody {
+            expected: "uuid-a",
+            forbidden: "inbound-uuid",
+        })
+        .respond_with(ResponseTemplate::new(500).set_body_string(r#"{"error":"rotate"}"#))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(BearerToken(token_b.clone()))
+        .and(AccountUuidBody {
+            expected: "uuid-b",
+            forbidden: "uuid-a",
+        })
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"account":"b"}"#))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let gateway = start_gateway_with(test_config(
+        &upstream.uri(),
+        account("account-a", "SHUNT_TEST_MULTI_UUID_A", "uuid-a"),
+        account("account-b", "SHUNT_TEST_MULTI_UUID_B", "uuid-b"),
+    ))
+    .await;
+
+    let response = post_messages_with_account_uuid(&gateway, "inbound-uuid").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("x-shunt-account").unwrap(),
+        "account-b"
+    );
+    upstream.verify().await;
+
+    std::env::remove_var("SHUNT_TEST_MULTI_UUID_A");
+    std::env::remove_var("SHUNT_TEST_MULTI_UUID_B");
 }
 
 #[tokio::test]

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -39,6 +39,14 @@ impl Match for HeaderAbsent {
     }
 }
 
+struct ExactBody(Vec<u8>);
+
+impl Match for ExactBody {
+    fn matches(&self, request: &Request) -> bool {
+        request.body == self.0
+    }
+}
+
 struct TestGateway {
     base_url: String,
     task: JoinHandle<()>,
@@ -194,6 +202,33 @@ async fn messages_forwards_anthropic_headers_verbatim_and_preserves_query() {
         .header("anthropic-beta", "tools-2025-01-01,custom=value")
         .header("anthropic-version", "2023-06-01")
         .body(r#"{"model":"claude-opus-4-1"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    upstream.verify().await;
+}
+
+#[tokio::test]
+async fn messages_preserves_matching_model_body_byte_for_byte() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let body = br#"{ "messages": [], "model": "claude-sonnet-4-5", "max_tokens": 1 }"#.to_vec();
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(ExactBody(body.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .body(body)
         .send()
         .await
         .unwrap();

--- a/tests/passthrough.rs
+++ b/tests/passthrough.rs
@@ -238,6 +238,37 @@ async fn messages_preserves_matching_model_body_byte_for_byte() {
 }
 
 #[tokio::test]
+async fn messages_rejects_duplicate_top_level_model_fields() {
+    if !can_bind_loopback() {
+        return;
+    }
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&upstream)
+        .await;
+    let gateway = start_gateway(upstream.uri()).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .body(r#"{"model":"first","messages":[],"model":"second"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value = serde_json::from_str(&response.text().await.unwrap()).unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "invalid_request_error");
+    assert!(body["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("duplicate field `model`"));
+    upstream.verify().await;
+}
+
+#[tokio::test]
 async fn messages_forwards_incoming_credentials_unchanged() {
     if !can_bind_loopback() {
         return;

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -4,7 +4,7 @@ use shunt::{
     config::ResponsesFlavor,
     model::responses::{
         anthropic_error_type, client_facing_status, map_error_value, parse_sse_events,
-        translate_request, AnthropicSseMachine,
+        translate_request, translate_request_value, AnthropicSseMachine,
     },
     routing::{AdapterKind, Route},
 };
@@ -29,6 +29,31 @@ fn translate(input: Value) -> Value {
         false,
     )
     .unwrap()
+}
+
+#[test]
+fn parsed_value_entry_point_matches_byte_wrapper_across_flavors() {
+    let request = json!({
+        "model": "gpt-5.2-codex",
+        "system": [{"type": "text", "text": "Be terse"}],
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1000,
+        "tools": [{
+            "name": "run",
+            "description": "Run command",
+            "input_schema": {"type": "object", "properties": {"cmd": {"type": "string"}}}
+        }]
+    });
+    let body = serde_json::to_vec(&request).unwrap();
+    let route = route("gpt-5.2-codex");
+
+    for flavor in [ResponsesFlavor::OpenAi, ResponsesFlavor::Chatgpt] {
+        assert_eq!(
+            translate_request_value(&request, &route, flavor, false),
+            translate_request(&body, &route, flavor, false).unwrap(),
+            "parsed and byte entry points diverged for {flavor:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Parse each buffered Anthropic Messages request once into a shared request body that retains the client's exact raw bytes alongside `Arc<serde_json::Value>`.
- Reuse that parsed tree for empty-block normalization, routing, Responses flags and translation, Cursor, Gemini, Antigravity, and Anthropic request rewrites.
- Share translated Responses requests as `Arc<Value>` across HTTP fallback, account attempts, WebSocket setup, and continuation recording; keep only the frame copy that is actually mutated.
- Reuse the precomputed WebSocket continuation signature and build it without cloning all non-input fields.
- Add release-profile benchmarks for representative 300 KB, 1 MB, and 3 MB subagent requests plus account-pool contention measurements.

Closes #252.
Closes #255.

## Milestone / spec

Internal request-path performance refactor; no milestone or frozen behavior spec changes.

## Before / after measurements

Intel Core i7-9700K, release profile, Divan medians, 100 samples. Fixtures contain a long system prompt, 50–200 messages with tool calls/results, and 24 tool schemas. Before and after paths ran side by side in the same benchmark binary.

### HTTP Responses CPU front

| Fixture | Before | After | Improvement |
|---|---:|---:|---:|
| 300 KB | 3.63 ms | 1.33 ms | 63% faster |
| 1 MB | 5.86 ms | 2.32 ms | 60% faster |
| 3 MB | 13.46 ms | 6.83 ms | 49% faster |

### Reused Codex WebSocket preparation

| Fixture | Before | After | Improvement |
|---|---:|---:|---:|
| 300 KB | 2.20 ms | 1.36 ms | 38% faster |
| 1 MB | 5.21 ms | 3.46 ms | 34% faster |
| 3 MB | 18.65 ms | 11.32 ms | 39% faster |

The HTTP after path includes the one inbound parse, normalization traversal, routing/flag reads, translation, and one serialization. The WebSocket after path includes one signature computation, the required mutable frame copy, continuation matching with the precomputed signature, an `Arc` continuation-record clone, and frame serialization.

I did not add `spawn_blocking`: parse-once cuts the measured synchronous work materially without introducing a size threshold, task handoff, or ordering complexity. Offloading can remain a separate follow-up if runtime-worker profiles still show large-body stalls after this change.

## Checklist

- [x] `cargo build` equivalent passes (`cargo clippy --all-targets --all-features -- -D warnings` builds every target)
- [x] `cargo test --all-features --workspace` passes: 1,254 passed, 1 ignored, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines (new `src/request.rs`: 77; benchmark: 479)
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` does not need an update; observable behavior is unchanged
- [x] User-facing docs do not need an update: no behavior, config, endpoint, CLI, provider/model support, or default changes in `README.md`, `docs/`, or `site/`; `wiki/` remains generated and untouched
- [x] No GitHub Actions changed

## Notes for reviewers

- `RequestBody` keeps raw bytes authoritative for Anthropic passthrough. It serializes only when normalization or an Anthropic model/account rewrite actually changes the parsed tree. `messages_preserves_matching_model_body_byte_for_byte` pins whitespace and key-order preservation end to end.
- Count-token routing and protocol-shaped gateway errors retain their existing paths; the focused failover, passthrough, retry, translation, and WebSocket fallback suites all pass.
- The benchmark's old-path functions intentionally retain the pre-refactor repeated parses and clones so future runs preserve a stable comparison baseline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse each inbound request once and reuse its JSON across routing, normalization, translation, and WebSocket paths to cut CPU on large bodies. Restores duplicate top‑level key rejection and removes redundant parses in routing and token counting; preserves exact raw bytes for passthrough and failover. Closes #252 and #255.

- **Refactors**
  - Added `RequestBody` (raw bytes + `Arc<serde_json::Value>`); adapters now accept it; mutations refresh bytes only when needed.
  - Reused the one parse for empty-block normalization, routing, Responses flag reads, translation, and Anthropic model/account UUID rewrites; no‑op guards skip re-serialization.
  - Introduced `translate_request_value` and shared `Arc<Value>` across HTTP/WS; Codex WS uses a precomputed signature via `decide_with_signature`; recording stores a shared request handle instead of cloning `input`.
  - Restored a fast `from_slice<RoutingView>` path for routing when no parsed tree exists; kept a `&Value` entry point for parse‑once callers.
  - `count_tokens` now counts from the shared tree on the blocking pool, avoiding a second parse and keeping raw bytes out of the task.
  - Failover moves the body into the last attempt and clones only earlier ones; original passthrough bytes are preserved for fallback if a prior attempt mutated its copy.
  - Added focused benches (`perf_issues`) and kept HTTP front and Codex WS preparation speedups (HTTP +49–63%, WS +34–39% on 300 KB–3 MB).

- **Bug Fixes**
  - Reject duplicate top‑level keys (e.g., two `model` fields) during parse to avoid route/forward divergence; nested objects keep last‑value‑wins. Error echoes at most 64 characters of the offending key.

<sup>Written for commit 29691103e233da5d8f0e7607b3364c1957c9db66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



---

## Breaking change

`adapters::Adapter` is no longer public. `Adapter::forward` now takes the crate-private `RequestBody` instead of `Vec<u8>`, which forces the trait itself to `pub(crate)`. This is the only public item the PR removes.

Practical impact is nil — there is no `dyn Adapter`, no `Box<dyn Adapter>`, and no public registration hook, so all five impls are in-crate with static dispatch and an external implementation could never have been invoked. It is still a source break for the published `shunt-gateway` crate, so it is marked as one rather than shipped silently in a patch release.

BREAKING CHANGE: `adapters::Adapter` is now `pub(crate)`. External crates can no longer name or implement the trait; it was never invocable from outside, as adapter dispatch is static and in-crate.

## Scope notes

- **Inbound validation is stricter than before.** `RoutingView` is `struct RoutingView { model: String }` with no `deny_unknown_fields`, so `main` rejected a duplicate top-level `model` but silently accepted a duplicate `max_tokens`. `RequestBody::parse` now rejects a duplicate of **any** top-level key with a 400 `invalid_request_error`. Nested objects keep `serde_json::Value`'s last-value-wins behavior. No legitimate JSON serializer emits duplicate keys, so no valid client is affected.
- **On `Closes #255`:** three of that issue's four sites are addressed here — `ForwardOptions.upstream_body` / `PoolForward.upstream_body` are now `Arc<Value>`, and `WsTurnContext.full_input` no longer clones the input array. The remaining refinement, skipping the `frame_body` deep clone on non-continuation turns (`websocket.rs:232`), is tracked as #265.
- Review follow-ups filed from this PR: #263 (hold `RequestBody.raw` as `Bytes` so pool/failover clones stop copying), #264 (share `StoredContinuation` via `Arc`), #265 (as above).
