### PR TITLE
chore(release): keep breaking changes on a minor bump before 1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "rust",
       "package-name": "shunt-gateway",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Fixes the version release-please is proposing in #266.

## Problem

release-please opened #266 as **`chore(main): release 1.0.0`**, not 0.27.0.

`bump-minor-pre-major` defaults to `false`, so on a `0.x` version release-please treats the first breaking change as the 1.0 trigger. #261 marked `adapters::Adapter` becoming `pub(crate)` as a breaking change — correctly, since it is a source break for the published `shunt-gateway` crate — and release-please jumped 0.26.1 → 1.0.0.

That would declare the crate API-stable as a side effect of an internal visibility change. The trait was never usable externally anyway (adapter dispatch is static and in-crate, with no `dyn Adapter` and no public registration hook), so it is a poor reason to commit to 1.0.

## Change

Set `bump-minor-pre-major: true`, which keeps breaking changes on the pre-1.0 convention of bumping the minor version. #266 then becomes **0.27.0**.

Deliberately **not** setting `bump-patch-for-minor-pre-major` — feature commits should keep bumping the minor, and fixes the patch, exactly as today.

## After merge

release-please re-runs on push to `main` and recomputes its release PR, so #266 should update itself to 0.27.0. Worth confirming before merging it.

1.0.0 should be a deliberate decision about API stability, not a consequence of the first `!` commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `release-please` to bump the minor for breaking changes on 0.x so `shunt-gateway` stays pre-1.0. Set `bump-minor-pre-major: true` in `release-please-config.json`, making the next release 0.27.0 instead of 1.0.0; features still bump minor and fixes bump patch.

<sup>Written for commit c54b3aa2f5aa91611ad80d51e0b090de117fe15f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

