### PR TITLE
fix(codex): seed input-token estimate on the account-pool path

### DIFF
--- a/src/adapters/responses/context.rs
+++ b/src/adapters/responses/context.rs
@@ -82,13 +82,16 @@ pub(super) struct ForwardOptions {
     pub codex_quota_account: Option<AccountConfig>,
     /// The parsed request to seed `message_start`'s `usage.input_tokens` with a
     /// local tiktoken estimate, or `None` on non-streaming / non-tiktoken turns.
-    /// Single-account only; the account-pool path does not thread it yet.
+    /// Mirrored on the account-pool path by [`PoolForward::estimate_input`].
     pub estimate_input: Option<Arc<Value>>,
 }
 
 /// Everything `forward_chatgpt_oauth` needs beyond `state`/`route`. The account
-/// pool resolves a credential per account (rather than carrying one) and does not
-/// pre-compute an input estimate, so its shape differs from [`ForwardOptions`].
+/// pool resolves a credential per account (rather than carrying one), so its
+/// shape differs from [`ForwardOptions`] there — but it shares the same
+/// `estimate_input`: `forward` computes it once, gated identically for every
+/// auth mode (`client_wants_stream && CountTokens::Tiktoken`), before branching
+/// into the pool vs. single-account dispatch.
 #[derive(Debug)]
 pub(super) struct PoolForward {
     pub pool_key: Option<String>,
@@ -96,4 +99,10 @@ pub(super) struct PoolForward {
     pub upstream_body: Arc<Value>,
     pub accounts_config: Vec<AccountConfig>,
     pub turn: TurnOptions,
+    /// The parsed request to seed `message_start`'s `usage.input_tokens` with a
+    /// local tiktoken estimate, or `None` on non-streaming / non-tiktoken turns.
+    /// Mirrors [`ForwardOptions::estimate_input`]; shared across every account
+    /// attempt in the pool loop (the translated body does not change per
+    /// account), never re-encoded per rotation.
+    pub estimate_input: Option<Arc<Value>>,
 }

--- a/src/adapters/responses/mod.rs
+++ b/src/adapters/responses/mod.rs
@@ -169,6 +169,7 @@ async fn forward(
                     upstream_body,
                     accounts_config: accounts,
                     turn,
+                    estimate_input,
                 },
             )
             .await;

--- a/src/adapters/responses/pool.rs
+++ b/src/adapters/responses/pool.rs
@@ -217,8 +217,7 @@ pub(super) async fn forward_chatgpt_oauth(
                     .accounts
                     .mark_healthy(&route.provider, account, status.is_success());
                 if status.is_success() {
-                    let input_tokens_estimate =
-                        take_estimate(&mut estimate_handle, turn.client_wants_stream).await;
+                    let input_tokens_estimate = take_estimate(&mut estimate_handle).await;
                     let response = relay_success(
                         &state,
                         upstream,
@@ -292,8 +291,7 @@ pub(super) async fn forward_chatgpt_oauth(
                         let retry_status = retry.status();
                         if retry_status.is_success() {
                             state.accounts.mark_healthy(&route.provider, account, true);
-                            let input_tokens_estimate =
-                                take_estimate(&mut estimate_handle, turn.client_wants_stream).await;
+                            let input_tokens_estimate = take_estimate(&mut estimate_handle).await;
                             let response = relay_success(
                                 &state,
                                 retry,
@@ -364,16 +362,10 @@ async fn relay_success(
 /// refresh retry) that must consume the same handle without awaiting it
 /// twice — `JoinHandle` is not `Clone`, so `.take()` leaves a torn-down `None`
 /// behind for whichever arm does not run. Non-streaming turns never seed
-/// `message_start`, so `client_wants_stream == false` always yields `0`
-/// without polling the handle (it is `None` in that case anyway, since
-/// `forward`'s gate only produces `estimate_input` for streaming turns).
-async fn take_estimate(
-    estimate_handle: &mut Option<tokio::task::JoinHandle<u64>>,
-    client_wants_stream: bool,
-) -> u64 {
-    if !client_wants_stream {
-        return 0;
-    }
+/// `message_start`, so `estimate_handle` is always `None` here already
+/// (`forward`'s gate only produces `estimate_input`, and thus a spawned
+/// handle, for streaming turns), which naturally yields `0` below.
+async fn take_estimate(estimate_handle: &mut Option<tokio::task::JoinHandle<u64>>) -> u64 {
     match estimate_handle.take() {
         Some(handle) => handle.await.unwrap_or(0),
         None => 0,

--- a/src/adapters/responses/pool.rs
+++ b/src/adapters/responses/pool.rs
@@ -42,6 +42,7 @@ pub(super) async fn forward_chatgpt_oauth(
         upstream_body,
         accounts_config,
         turn,
+        estimate_input,
     } = forward;
     // An all-`disabled` pool yields an empty order; surface it as a distinct
     // config error rather than the generic "all accounts failed" below.
@@ -79,6 +80,16 @@ pub(super) async fn forward_chatgpt_oauth(
     // a cheap refcount clone. Keep this lazy so a successful websocket turn never
     // pays to serialize an HTTP body it does not send (issue #251).
     let mut http_body: Option<bytes::Bytes> = None;
+    // Mirrors `http_body` above: the tiktoken estimate of the (unchanging)
+    // translated request is spawned onto the blocking pool at most once per
+    // turn and reused across every account attempt and the refresh retry,
+    // rather than re-encoded per rotation. Spawned only for HTTP dispatch —
+    // each websocket attempt gets its own `estimate_input` clone and does its
+    // own internal spawn_blocking in `forward_websocket`, exactly like the
+    // single-account path; a websocket attempt that then falls back to HTTP
+    // pays a second, rare, off-executor encode, which mirrors the accepted
+    // single-account fallback cost documented in `forward_websocket`.
+    let mut estimate_handle: Option<tokio::task::JoinHandle<u64>> = None;
 
     for (position, index) in order.into_iter().enumerate() {
         let account = &accounts_config[index];
@@ -113,9 +124,10 @@ pub(super) async fn forward_chatgpt_oauth(
                     auth,
                     turn,
                     codex_quota_account: Some(account.clone()),
-                    // Pool path does not pre-compute a message_start input estimate
-                    // yet (see relay_success) — follow-up to thread it through here.
-                    estimate_input: None,
+                    // Each account attempt gets its own cheap Arc clone;
+                    // forward_websocket spawns its own blocking encode from it,
+                    // identical to the single-account path (see ForwardOptions).
+                    estimate_input: estimate_input.clone(),
                 },
             )
             .await
@@ -154,6 +166,16 @@ pub(super) async fn forward_chatgpt_oauth(
                 .map(bytes::Bytes::from)
                 .unwrap_or_else(|_| bytes::Bytes::from(upstream_body.as_ref().to_string()))
         });
+        // Spawned once, right before the first HTTP send, so the CPU-bound
+        // tiktoken encode overlaps this attempt's connect/RTT instead of
+        // delaying it (same overlap discipline as forward_http/forward_websocket).
+        if estimate_handle.is_none() {
+            if let Some(request) = estimate_input.clone() {
+                estimate_handle = Some(tokio::task::spawn_blocking(move || {
+                    crate::count_tokens::count_input_tokens_value(&request)
+                }));
+            }
+        }
         let upstream = match http_send(
             &state,
             &route,
@@ -195,11 +217,14 @@ pub(super) async fn forward_chatgpt_oauth(
                     .accounts
                     .mark_healthy(&route.provider, account, status.is_success());
                 if status.is_success() {
+                    let input_tokens_estimate =
+                        take_estimate(&mut estimate_handle, turn.client_wants_stream).await;
                     let response = relay_success(
                         &state,
                         upstream,
                         turn.client_wants_stream,
                         turn.relay(&route),
+                        input_tokens_estimate,
                     )
                     .await?;
                     let response = crate::adapters::with_admission(
@@ -267,11 +292,14 @@ pub(super) async fn forward_chatgpt_oauth(
                         let retry_status = retry.status();
                         if retry_status.is_success() {
                             state.accounts.mark_healthy(&route.provider, account, true);
+                            let input_tokens_estimate =
+                                take_estimate(&mut estimate_handle, turn.client_wants_stream).await;
                             let response = relay_success(
                                 &state,
                                 retry,
                                 turn.client_wants_stream,
                                 turn.relay(&route),
+                                input_tokens_estimate,
                             )
                             .await?;
                             let response = crate::adapters::with_admission(
@@ -315,17 +343,40 @@ async fn relay_success(
     upstream: reqwest::Response,
     client_wants_stream: bool,
     relay: RelayOptions,
+    input_tokens_estimate: u64,
 ) -> Result<axum::response::Response, AdapterError> {
     if client_wants_stream {
         let keepalive = Duration::from_secs(state.config.server.sse_keepalive_seconds);
-        // The pool path does not (yet) pre-compute a tiktoken input estimate to
-        // seed message_start (#112 threads it only through the single-account
-        // forward_http / forward_websocket paths), so pass 0 = "no estimate"
-        // here — identical to those paths when the provider opts out of local
-        // counting. Extending the estimate to pooled codex turns is a follow-up.
-        Ok(stream_response(upstream, relay, 0, keepalive))
+        Ok(stream_response(
+            upstream,
+            relay,
+            input_tokens_estimate,
+            keepalive,
+        ))
     } else {
         json_response(upstream, relay).await
+    }
+}
+
+/// Await the lazily-spawned HTTP-path tiktoken estimate handle exactly once,
+/// mirroring `forward_http`'s inline `match estimate_handle { .. }`. Factored
+/// out because the pool loop has two success arms (first attempt and
+/// refresh retry) that must consume the same handle without awaiting it
+/// twice — `JoinHandle` is not `Clone`, so `.take()` leaves a torn-down `None`
+/// behind for whichever arm does not run. Non-streaming turns never seed
+/// `message_start`, so `client_wants_stream == false` always yields `0`
+/// without polling the handle (it is `None` in that case anyway, since
+/// `forward`'s gate only produces `estimate_input` for streaming turns).
+async fn take_estimate(
+    estimate_handle: &mut Option<tokio::task::JoinHandle<u64>>,
+    client_wants_stream: bool,
+) -> u64 {
+    if !client_wants_stream {
+        return 0;
+    }
+    match estimate_handle.take() {
+        Some(handle) => handle.await.unwrap_or(0),
+        None => 0,
     }
 }
 

--- a/tests/codex_multi_account.rs
+++ b/tests/codex_multi_account.rs
@@ -228,6 +228,27 @@ fn session_id_for_account(index: usize, account_count: usize) -> String {
         .expect("a session id should map to the requested account")
 }
 
+/// Find `message_start`'s `usage.input_tokens` in a gateway SSE response body,
+/// mirroring the identically-named helper in `tests/codex_websocket_fallback.rs`
+/// (integration test binaries do not share code across files, so this is
+/// intentionally duplicated rather than imported).
+fn message_start_input_tokens(sse: &str) -> u64 {
+    for line in sse.lines() {
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(data) else {
+            continue;
+        };
+        if value["type"] == "message_start" {
+            return value["message"]["usage"]["input_tokens"]
+                .as_u64()
+                .expect("message_start usage.input_tokens must be an integer");
+        }
+    }
+    panic!("no message_start event found in gateway SSE:\n{sse}");
+}
+
 async fn post_messages(gateway: &TestGateway, session_id: Option<&str>) -> reqwest::Response {
     let mut request = reqwest::Client::new()
         .post(format!("{}/v1/messages", gateway.base_url))
@@ -949,10 +970,147 @@ async fn websocket_enabled_pool_falls_back_to_http_and_streams() {
         body.contains("ws pool streamed"),
         "the streamed body should carry the upstream's translated text; got: {body}"
     );
+    // Regression for the account-pool path silently dropping the message_start
+    // tiktoken estimate (#112 only threaded it through the single-account
+    // forward_http/forward_websocket paths, not forward_chatgpt_oauth): after a
+    // pre-stream websocket failure falls back to HTTP for this SAME account,
+    // message_start must still carry a nonzero estimate.
+    assert!(
+        message_start_input_tokens(&body) > 0,
+        "message_start must carry the tiktoken estimate on the pool ws->http fallback path; got:\n{body}"
+    );
     upstream.verify().await;
 
     std::env::remove_var("SHUNT_TEST_CODEX_WSPOOL_A");
     std::env::remove_var("SHUNT_TEST_CODEX_WSPOOL_B");
+}
+
+#[tokio::test]
+async fn pool_http_dispatch_seeds_message_start_input_token_estimate() {
+    // Regression for the account-pool path bypassing the message_start
+    // tiktoken estimate #112 added (see `relay_success` in
+    // `src/adapters/responses/pool.rs`, which used to hardcode `0`): a
+    // streaming turn relayed through the plain HTTP pool dispatch (no
+    // websocket involved) must seed a nonzero `usage.input_tokens` in
+    // `message_start`, exactly like the single-account
+    // `forward_http`/`forward_websocket` paths already do (see
+    // `tests/passthrough.rs::message_start_seeds_tiktoken_estimate_for_streaming_responses_model`).
+    if !can_bind_loopback() {
+        return;
+    }
+    let token_a = chatgpt_token(FAR_FUTURE_EXP, "acct-estimate-a");
+    let token_b = chatgpt_token(FAR_FUTURE_EXP, "acct-estimate-b");
+    std::env::set_var("SHUNT_TEST_CODEX_ESTIMATE_A", &token_a);
+    std::env::set_var("SHUNT_TEST_CODEX_ESTIMATE_B", &token_b);
+
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/codex/responses"))
+        .and(BearerToken(token_a.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_string(sse_body("pool http streamed")))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let gateway = start_gateway_with(test_config(
+        &upstream.uri(),
+        account("account-a", "SHUNT_TEST_CODEX_ESTIMATE_A"),
+        account("account-b", "SHUNT_TEST_CODEX_ESTIMATE_B"),
+    ))
+    .await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .header("content-type", "application/json")
+        .body(
+            r#"{"model":"pooled-codex-model","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("x-shunt-account").unwrap(),
+        "account-a"
+    );
+    let body = response.text().await.unwrap();
+    assert!(
+        message_start_input_tokens(&body) > 0,
+        "message_start must carry the tiktoken estimate on the pool HTTP dispatch path; got:\n{body}"
+    );
+    upstream.verify().await;
+
+    std::env::remove_var("SHUNT_TEST_CODEX_ESTIMATE_A");
+    std::env::remove_var("SHUNT_TEST_CODEX_ESTIMATE_B");
+}
+
+#[tokio::test]
+async fn pool_rotation_still_seeds_input_token_estimate_after_401() {
+    // Same regression as `pool_http_dispatch_seeds_message_start_input_token_estimate`,
+    // but exercising the lazily-spawned estimate handle across an account
+    // rotation (pool.rs's `estimate_handle`, mirroring the existing `http_body`
+    // lazy-serialize-once pattern): account-a's 401 rotates to account-b
+    // without a refresh (a `token_env` account has nothing to refresh), and
+    // the SAME shared estimate handle spawned before account-a's request must
+    // still be the one consumed when account-b's retry succeeds.
+    if !can_bind_loopback() {
+        return;
+    }
+    let token_a = chatgpt_token(FAR_FUTURE_EXP, "acct-estimate-rot-a");
+    let token_b = chatgpt_token(FAR_FUTURE_EXP, "acct-estimate-rot-b");
+    std::env::set_var("SHUNT_TEST_CODEX_ESTIMATE_ROT_A", &token_a);
+    std::env::set_var("SHUNT_TEST_CODEX_ESTIMATE_ROT_B", &token_b);
+
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/codex/responses"))
+        .and(BearerToken(token_a.clone()))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_string(r#"{"error":"account a token revoked"}"#),
+        )
+        .expect(1)
+        .mount(&upstream)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/codex/responses"))
+        .and(BearerToken(token_b.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_string(sse_body("account b streamed")))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let gateway = start_gateway_with(test_config(
+        &upstream.uri(),
+        account("account-a", "SHUNT_TEST_CODEX_ESTIMATE_ROT_A"),
+        account("account-b", "SHUNT_TEST_CODEX_ESTIMATE_ROT_B"),
+    ))
+    .await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/messages", gateway.base_url))
+        .header("content-type", "application/json")
+        .body(
+            r#"{"model":"pooled-codex-model","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("x-shunt-account").unwrap(),
+        "account-b"
+    );
+    let body = response.text().await.unwrap();
+    assert!(
+        message_start_input_tokens(&body) > 0,
+        "message_start must carry the tiktoken estimate after a pool account rotation; got:\n{body}"
+    );
+    upstream.verify().await;
+
+    std::env::remove_var("SHUNT_TEST_CODEX_ESTIMATE_ROT_A");
+    std::env::remove_var("SHUNT_TEST_CODEX_ESTIMATE_ROT_B");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes #278: the Codex/ChatGPT OAuth **account-pool** streaming path (`forward_chatgpt_oauth` in `src/adapters/responses/pool.rs`) bypassed the `message_start` input-token estimate that PR #112 added to the single-account `forward_http`/`forward_websocket` paths. A Claude Code subagent routed through a pooled ChatGPT-OAuth account showed `usage.input_tokens: 0` in `message_start`, so its per-subagent context/token display stuck at 0 (the accurate total still lands later, in the terminal `message_delta` — `usage_observed` in `src/model/responses.rs` is untouched by this change).
- `PoolForward` now carries the same `estimate_input: Option<Arc<Value>>` that `mod.rs::forward()` already computed once per request but only threaded into `ForwardOptions`; both `forward_chatgpt_oauth`'s websocket attempt and its HTTP dispatch loop now use it.
- `relay_success` no longer hardcodes the estimate to `0` — it takes an `input_tokens_estimate: u64` parameter from the caller.

## Design / TTFB constraint

- Each websocket attempt (per account) gets its own cheap `Arc` clone of `estimate_input` passed through `ForwardOptions`; `forward_websocket` does its own internal `spawn_blocking`, identical to the single-account path. A websocket attempt that then falls back to HTTP for the same account pays a second, rare, off-executor encode — this mirrors the already-accepted single-account fallback cost documented in `forward_websocket`.
- The HTTP dispatch path lazily spawns **one** shared `JoinHandle<u64>` the first time it's needed (right before the first `http_send`, overlapping the encode with that attempt's connect/RTT rather than delaying it), and reuses it across account rotation and the 401 refresh-retry — mirroring the existing lazy `http_body` serialize-once pattern already in `pool.rs`. It's consumed exactly once, via a small `take_estimate()` helper, at whichever of the two success arms (first-attempt or refresh-retry) actually relays.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace` (all 17 test binaries pass)
- [x] New regression tests in `tests/codex_multi_account.rs`:
  - `pool_http_dispatch_seeds_message_start_input_token_estimate` — plain HTTP pool dispatch, single account, streaming, asserts nonzero `message_start.usage.input_tokens`.
  - `pool_rotation_still_seeds_input_token_estimate_after_401` — account-a 401s (rotates without refresh), account-b succeeds; asserts the shared estimate handle survives the rotation.
  - Extended `websocket_enabled_pool_falls_back_to_http_and_streams` with the same assertion after a pre-stream websocket failure falls back to HTTP for the same account.
- Docs: confirmed no `README.md`/`docs/`/`site/` page documents a pooled-vs-single estimate distinction — nothing to update; `wiki/` is generated and untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds a nonzero input-token estimate for pooled Codex/ChatGPT OAuth streaming requests so message_start.usage.input_tokens is accurate, matching the single-account paths. Fixes zeroed token counts in pooled subagents and keeps TTFB unchanged.

- **Bug Fixes**
  - Threaded `estimate_input` into `PoolForward`; used by both websocket attempts and the HTTP dispatch loop in `forward_chatgpt_oauth`.
  - HTTP: lazily spawn one shared blocking estimate task, reuse it across account rotation and refresh retry, and consume it once via `take_estimate()`; added regression tests for plain HTTP dispatch, ws→http fallback, and 401 rotation.
  - Updated `relay_success` to accept `input_tokens_estimate` instead of hardcoding `0`.
  - Dropped a redundant `client_wants_stream` parameter from `take_estimate` since the estimate handle only exists on streaming turns.

<sup>Written for commit 500a5c2f0afb168fd41ebc2cd6cdbf5ceb12a564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

