### PR TITLE
feat(metrics): add shunt.codex_ws_overflow counter for the Codex WS overflow path

### DIFF
--- a/docs/m7-codex-websocket.md
+++ b/docs/m7-codex-websocket.md
@@ -138,7 +138,10 @@ reproducing attestation.**
   concurrent turn for parallelism. At most 64 overflow connections may be live at
   once; excess turns are refused before any frame is sent and transparently spill
   over to HTTP, preserving the transport's "never worse than plain HTTP" safety net
-  without restoring a turn queue.
+  without restoring a turn queue. A `shunt.codex_ws_overflow` counter (`opened` vs
+  `refused`, per provider) records each admission decision, giving operators a way
+  to see whether concurrent Claude Code agents actually share one
+  `x-claude-code-session-id` pool key and how often that costs continuation reuse.
 - **Invalidation.** Any non-clean end (error/incomplete terminal, close, transport
   error, or a rejected `previous_response_id`) evicts the connection and clears its
   continuation state. A clean `response.completed` re-pools a fresh connection and

--- a/docs/running.md
+++ b/docs/running.md
@@ -182,6 +182,7 @@ Both metric sinks export the same low-cardinality series:
 | `shunt.stream_outcome` | Counter | `provider`, `model`, `outcome` | Exactly one stream result: `completed`, `error_event`, `upstream_cut`, or `client_disconnect`. |
 | `shunt.tokens` | Counter | `provider`, `model`, `kind` | Last reported streaming usage for `input`, `output`, `cache_read`, or `cache_creation`; non-streaming usage is not recorded. |
 | `shunt.codex_continuation` | Counter | `provider`, `outcome` | Codex WebSocket continuation `hit` or full-input `fallback`. |
+| `shunt.codex_ws_overflow` | Counter | `provider`, `outcome` | Codex WebSocket dedicated overflow connection `opened` or ceiling-`refused` (issue #248). |
 | `shunt.upstream_retries` | Counter | `provider`, `reason` | Bounded transient retries. |
 | `shunt.pool.quota_utilization` | Gauge | `provider`, `window` | Minimum utilization across enabled, non-stale accounts for `5h`, `7d`, or `7d_oi`. |
 | `shunt.pool.rotations` | Counter | `provider`, `reason` | Account rotations and pool exhaustion by low-cardinality cause. |

--- a/site/src/content/docs/guides/opentelemetry.mdx
+++ b/site/src/content/docs/guides/opentelemetry.mdx
@@ -53,6 +53,7 @@ Each signal toggles independently via `traces` / `metrics` / `logs`.
 | `shunt.stream_outcome` | Counter | `provider`, `model`, `outcome` | One final SSE result: `completed`, `error_event`, `upstream_cut`, or `client_disconnect`. |
 | `shunt.tokens` | Counter | `provider`, `model`, `kind` | Last reported streaming token usage (`input`, `output`, `cache_read`, `cache_creation`). Non-streaming usage is not recorded. |
 | `shunt.codex_continuation` | Counter | `provider`, `outcome` | Codex WebSocket continuation hit or fallback. |
+| `shunt.codex_ws_overflow` | Counter | `provider`, `outcome` | Codex WebSocket dedicated overflow connection `opened` or ceiling-`refused` for a concurrent turn (issue #248). |
 | `shunt.codex_client_events` | Counter | `event` | Codex CLI analytics events by sanitized event name; payloads and properties are discarded. |
 | `shunt.upstream_retries` | Counter | `provider`, `reason` | Bounded transient upstream retries. |
 | `shunt.failover` | Counter | `provider`, `state` | Ordered-upstream failover transitions: `attempted`, `advanced`, or `exhausted`. |

--- a/site/src/content/docs/ja/guides/opentelemetry.mdx
+++ b/site/src/content/docs/ja/guides/opentelemetry.mdx
@@ -53,6 +53,7 @@ authorization = "Bearer <token>"
 | `shunt.stream_outcome` | カウンター | `provider`, `model`, `outcome` | SSE の最終結果を 1 件記録: `completed`, `error_event`, `upstream_cut`, `client_disconnect`。 |
 | `shunt.tokens` | カウンター | `provider`, `model`, `kind` | 最後に報告されたストリーミング token usage (`input`, `output`, `cache_read`, `cache_creation`)。非ストリーミングは記録しない。 |
 | `shunt.codex_continuation` | カウンター | `provider`, `outcome` | Codex WebSocket continuation の hit または fallback。 |
+| `shunt.codex_ws_overflow` | カウンター | `provider`, `outcome` | 並行 turn が専用 overflow 接続を開いた場合は `opened`、接続上限で拒否された場合は `refused`（issue #248）。 |
 | `shunt.codex_client_events` | カウンター | `event` | サニタイズ済みイベント名ごとの Codex CLI analytics イベント。payload とプロパティは破棄される。 |
 | `shunt.upstream_retries` | カウンター | `provider`, `reason` | 回数制限付きの一時的な upstream retry。 |
 | `shunt.failover` | カウンター | `provider`, `state` | 順序付きアップストリームのフェイルオーバー遷移: `attempted`, `advanced`, `exhausted`。 |

--- a/site/src/content/docs/ko/guides/opentelemetry.mdx
+++ b/site/src/content/docs/ko/guides/opentelemetry.mdx
@@ -53,6 +53,7 @@ authorization = "Bearer <token>"
 | `shunt.stream_outcome` | 카운터 | `provider`, `model`, `outcome` | SSE 최종 결과 하나: `completed`, `error_event`, `upstream_cut`, `client_disconnect`. |
 | `shunt.tokens` | 카운터 | `provider`, `model`, `kind` | 마지막으로 보고된 스트리밍 토큰 사용량(`input`, `output`, `cache_read`, `cache_creation`). 비스트리밍 사용량은 기록하지 않음. |
 | `shunt.codex_continuation` | 카운터 | `provider`, `outcome` | Codex WebSocket continuation hit 또는 fallback. |
+| `shunt.codex_ws_overflow` | 카운터 | `provider`, `outcome` | 동시 turn이 전용 overflow 연결을 열면 `opened`, 연결 상한에서 거부되면 `refused` (issue #248). |
 | `shunt.codex_client_events` | 카운터 | `event` | 정제된 이벤트 이름별 Codex CLI 분석 이벤트. payload와 속성은 폐기됨. |
 | `shunt.upstream_retries` | 카운터 | `provider`, `reason` | 제한된 일시적 업스트림 재시도. |
 | `shunt.failover` | 카운터 | `provider`, `state` | 순서 있는 업스트림 페일오버 전환: `attempted`, `advanced`, `exhausted`. |

--- a/site/src/content/docs/zh-cn/guides/opentelemetry.mdx
+++ b/site/src/content/docs/zh-cn/guides/opentelemetry.mdx
@@ -53,6 +53,7 @@ authorization = "Bearer <token>"
 | `shunt.stream_outcome` | 计数器 | `provider`, `model`, `outcome` | 每个 SSE 记录一个最终结果：`completed`、`error_event`、`upstream_cut` 或 `client_disconnect`。 |
 | `shunt.tokens` | 计数器 | `provider`, `model`, `kind` | 最后报告的流式 token 用量（`input`、`output`、`cache_read`、`cache_creation`）；不记录非流式用量。 |
 | `shunt.codex_continuation` | 计数器 | `provider`, `outcome` | Codex WebSocket continuation 的 hit 或 fallback。 |
+| `shunt.codex_ws_overflow` | 计数器 | `provider`, `outcome` | 并发 turn 使用专用 overflow 连接时记录 `opened`，达到连接上限被拒绝时记录 `refused`（issue #248）。 |
 | `shunt.codex_client_events` | 计数器 | `event` | 按净化后的事件名称统计 Codex CLI 分析事件；payload 和属性会被丢弃。 |
 | `shunt.upstream_retries` | 计数器 | `provider`, `reason` | 有次数限制的临时上游重试。 |
 | `shunt.failover` | 计数器 | `provider`, `state` | 有序上游故障转移状态：`attempted`、`advanced` 或 `exhausted`。 |

--- a/src/adapters/responses/codex_ws.rs
+++ b/src/adapters/responses/codex_ws.rs
@@ -558,10 +558,17 @@ impl Drop for Turn {
 /// falls back to HTTP instead of queueing. A stale pooled connection is evicted and
 /// replaced. A refused handshake (401/403/429) resolves to `Err` with the upstream
 /// status/body so the caller can re-shape it like the HTTP path.
+///
+/// Both overflow admission outcomes are recorded as `shunt.codex_ws_overflow`
+/// (issue #248's deferred follow-up metric, tagged with `provider`): opening a
+/// dedicated socket, and refusal at the ceiling. Neither the pooled-reuse nor
+/// fresh-handshake paths above touch the counter, so it costs nothing beyond
+/// what the overflow branch already pays.
 pub async fn begin(
     ws_url: &str,
     headers: HeaderMap,
     pool_key: Option<&str>,
+    provider: &str,
 ) -> Result<Turn, CodexWsError> {
     let mut overflow = false;
     if let Some(key) = pool_key {
@@ -607,10 +614,18 @@ pub async fn begin(
                 max_overflow_connections = MAX_OVERFLOW_CONNECTIONS,
                 "codex websocket overflow connection ceiling reached; falling back to HTTP"
             );
+            crate::metrics::record_codex_ws_overflow(
+                provider,
+                crate::metrics::CodexWsOverflowOutcome::Refused,
+            );
             CodexWsError::transport(format!(
                 "codex websocket overflow connection ceiling reached ({MAX_OVERFLOW_CONNECTIONS}); falling back to HTTP"
             ))
         })?;
+        crate::metrics::record_codex_ws_overflow(
+            provider,
+            crate::metrics::CodexWsOverflowOutcome::Opened,
+        );
         // Keep an overflow socket entirely outside the session pool:
         // 1. `run_turn` calls `pool_insert` only when `conn.pool_key` is `Some`, so
         //    it cannot replace the healthy pooled entry or drop its continuation;
@@ -1175,7 +1190,7 @@ mod tests {
         frame: &ResponseCreateFrame<'_>,
         pool_key: Option<&str>,
     ) -> Result<CodexWsEvents, CodexWsError> {
-        let turn = begin(url, headers, pool_key).await?;
+        let turn = begin(url, headers, pool_key, "codex").await?;
         turn.stream(frame, RecordPlan::none()).await
     }
 
@@ -1419,7 +1434,7 @@ mod tests {
 
         // Turn 1: fresh connection exposes the successful handshake headers,
         // then drains to completion and enters the pool.
-        let turn1 = begin(&url, HeaderMap::new(), Some("session-1"))
+        let turn1 = begin(&url, HeaderMap::new(), Some("session-1"), "codex")
             .await
             .expect("first turn connects");
         let handshake = turn1
@@ -1442,7 +1457,7 @@ mod tests {
 
         // Turn 2: reuses the pooled socket (the mock only accepts once) and
         // reports no fresh handshake headers.
-        let turn2 = begin(&url, HeaderMap::new(), Some("session-1"))
+        let turn2 = begin(&url, HeaderMap::new(), Some("session-1"), "codex")
             .await
             .expect("second turn reuses connection");
         assert!(
@@ -1471,7 +1486,9 @@ mod tests {
     /// Issue #248: a second turn already streaming on the pooled socket must not
     /// serialize a concurrent request behind its turn slot. The concurrent turn
     /// gets a dedicated one-shot connection, while the original socket remains the
-    /// session's pooled connection and retains subsequent reuse.
+    /// session's pooled connection and retains subsequent reuse. Also proves the
+    /// deferred follow-up metric: `shunt.codex_ws_overflow{outcome="opened"}`
+    /// increments exactly once for the dedicated connection.
     #[tokio::test]
     async fn concurrent_turn_opens_a_dedicated_connection_instead_of_waiting() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1573,9 +1590,15 @@ mod tests {
 
         // Turn 2 reuses connection 1. Consume only response.created; the mock holds
         // response.completed so the reader retains the connection's turn slot.
-        let turn2 = begin(&url, HeaderMap::new(), Some("session-busy"))
-            .await
-            .expect("second turn reuses connection 1");
+        let overflow_test_provider = "codex-overflow-open-test";
+        let turn2 = begin(
+            &url,
+            HeaderMap::new(),
+            Some("session-busy"),
+            overflow_test_provider,
+        )
+        .await
+        .expect("second turn reuses connection 1");
         let mut turn2 = turn2
             .stream(&frame, RecordPlan::none())
             .await
@@ -1589,13 +1612,32 @@ mod tests {
 
         // A concurrent begin must not wait for turn 2's terminal event. It opens
         // connection 2 and carries no continuation because the socket is dedicated.
+        // Issue #248's deferred follow-up: this admission must also be counted as
+        // `shunt.codex_ws_overflow{outcome="opened"}`.
+        let opened_before = crate::metrics::codex_ws_overflow_count_for_tests(
+            overflow_test_provider,
+            crate::metrics::CodexWsOverflowOutcome::Opened,
+        );
         let overflow = tokio::time::timeout(
             Duration::from_secs(5),
-            begin(&url, HeaderMap::new(), Some("session-busy")),
+            begin(
+                &url,
+                HeaderMap::new(),
+                Some("session-busy"),
+                overflow_test_provider,
+            ),
         )
         .await
         .expect("a busy pooled connection must not serialize a concurrent turn")
         .expect("overflow connection opens");
+        assert_eq!(
+            crate::metrics::codex_ws_overflow_count_for_tests(
+                overflow_test_provider,
+                crate::metrics::CodexWsOverflowOutcome::Opened
+            ),
+            opened_before + 1,
+            "opening a dedicated overflow socket increments the opened counter"
+        );
         assert!(
             overflow.stored_continuation().is_none(),
             "the dedicated turn carries no continuation"
@@ -1656,7 +1698,9 @@ mod tests {
     /// Issue #248: once all overflow slots are live, another concurrent turn must
     /// fail before opening a socket instead of waiting. Releasing the slots restores
     /// the dedicated path, proving the ceiling is admission rather than a sticky
-    /// failure state.
+    /// failure state. Also proves the deferred follow-up metric: the refusal
+    /// increments `shunt.codex_ws_overflow{outcome="refused"}` and the recovered
+    /// admission increments `outcome="opened"`, not the other way around.
     #[tokio::test]
     async fn overflow_ceiling_refuses_promptly_then_recovers() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1739,9 +1783,15 @@ mod tests {
         .await
         .expect("first turn connects");
         drain(&mut turn1).await;
-        let turn2 = begin(&url, HeaderMap::new(), Some("session-overflow-ceiling"))
-            .await
-            .expect("second turn reuses pooled connection");
+        let overflow_test_provider = "codex-overflow-ceiling-test";
+        let turn2 = begin(
+            &url,
+            HeaderMap::new(),
+            Some("session-overflow-ceiling"),
+            overflow_test_provider,
+        )
+        .await
+        .expect("second turn reuses pooled connection");
         let mut turn2 = turn2
             .stream(&frame, RecordPlan::none())
             .await
@@ -1761,9 +1811,20 @@ mod tests {
         }
         assert!(OverflowSlot::claim().is_none());
         let accepts_before_refusal = accepted.load(Ordering::SeqCst);
+        // Issue #248's deferred follow-up: a ceiling refusal must be counted as
+        // `shunt.codex_ws_overflow{outcome="refused"}` before any frame is sent.
+        let refused_before = crate::metrics::codex_ws_overflow_count_for_tests(
+            overflow_test_provider,
+            crate::metrics::CodexWsOverflowOutcome::Refused,
+        );
         let error = match tokio::time::timeout(
             Duration::from_secs(5),
-            begin(&url, HeaderMap::new(), Some("session-overflow-ceiling")),
+            begin(
+                &url,
+                HeaderMap::new(),
+                Some("session-overflow-ceiling"),
+                overflow_test_provider,
+            ),
         )
         .await
         .expect("overflow admission refuses promptly instead of waiting")
@@ -1784,11 +1845,28 @@ mod tests {
             accepts_before_refusal,
             "ceiling refusal does not open another socket"
         );
+        assert_eq!(
+            crate::metrics::codex_ws_overflow_count_for_tests(
+                overflow_test_provider,
+                crate::metrics::CodexWsOverflowOutcome::Refused
+            ),
+            refused_before + 1,
+            "ceiling refusal increments the refused counter"
+        );
 
         drop(slots);
+        let opened_before = crate::metrics::codex_ws_overflow_count_for_tests(
+            overflow_test_provider,
+            crate::metrics::CodexWsOverflowOutcome::Opened,
+        );
         let overflow = tokio::time::timeout(
             Duration::from_secs(5),
-            begin(&url, HeaderMap::new(), Some("session-overflow-ceiling")),
+            begin(
+                &url,
+                HeaderMap::new(),
+                Some("session-overflow-ceiling"),
+                overflow_test_provider,
+            ),
         )
         .await
         .expect("released overflow slots restore prompt admission")
@@ -1805,6 +1883,14 @@ mod tests {
             accepted.load(Ordering::SeqCst),
             accepts_before_refusal + 1,
             "released admission opens exactly one dedicated socket"
+        );
+        assert_eq!(
+            crate::metrics::codex_ws_overflow_count_for_tests(
+                overflow_test_provider,
+                crate::metrics::CodexWsOverflowOutcome::Opened
+            ),
+            opened_before + 1,
+            "the recovered admission increments the opened counter, not the refused one"
         );
 
         release_turn2.send(()).expect("release turn 2");
@@ -1853,10 +1939,10 @@ mod tests {
         let url = format!("ws://{addr}/codex/responses");
         // Neither connection has completed a turn yet, so both handshakes model
         // concurrent cold starts that observed no existing pool entry.
-        let first = begin(&url, HeaderMap::new(), Some("session-race"))
+        let first = begin(&url, HeaderMap::new(), Some("session-race"), "codex")
             .await
             .expect("first cold connection opens");
-        let second = begin(&url, HeaderMap::new(), Some("session-race"))
+        let second = begin(&url, HeaderMap::new(), Some("session-race"), "codex")
             .await
             .expect("second cold connection opens");
         let first_conn = first.conn.clone();
@@ -2080,7 +2166,7 @@ mod tests {
         });
 
         // Turn 1: record continuation from a real completion.
-        let turn1 = begin(&url, HeaderMap::new(), Some("sess-cont"))
+        let turn1 = begin(&url, HeaderMap::new(), Some("sess-cont"), "codex")
             .await
             .expect("first turn connects");
         let mut events = turn1
@@ -2096,7 +2182,7 @@ mod tests {
         drain(&mut events).await;
 
         // Turn 2: the reused connection exposes the stored continuation.
-        let turn2 = begin(&url, HeaderMap::new(), Some("sess-cont"))
+        let turn2 = begin(&url, HeaderMap::new(), Some("sess-cont"), "codex")
             .await
             .expect("second turn reuses connection");
         let stored = turn2
@@ -2557,7 +2643,7 @@ mod tests {
         });
 
         let url = format!("ws://{addr}/codex/responses");
-        let turn = begin(&url, HeaderMap::new(), None)
+        let turn = begin(&url, HeaderMap::new(), None, "codex")
             .await
             .expect("handshake connects");
         drop(turn); // abandon the turn without streaming

--- a/src/adapters/responses/websocket.rs
+++ b/src/adapters/responses/websocket.rs
@@ -220,7 +220,7 @@ async fn start_ws_turn(
     allow_continuation: bool,
 ) -> Result<(CodexWsEvents, bool), AdapterError> {
     let headers = websocket_headers(ctx.credential.clone())?;
-    let turn = codex_ws::begin(&ctx.ws_url, headers, ctx.pool_key)
+    let turn = codex_ws::begin(&ctx.ws_url, headers, ctx.pool_key, ctx.provider)
         .await
         .map_err(|error| ws_connect_error(error, ctx.auth))?;
     // Fresh connections carry live handshake headers; reused connections reuse the

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -10,10 +10,10 @@
 //!   provider, so with `[otel]` absent the instruments are inert.
 //!
 //! Request metrics cover request counts/header latency, streaming TTFT/outcomes
-//! and streaming token usage, Codex continuation decisions and sanitized client
-//! analytics event names, retries, and requests shed at the inbound concurrency
-//! limit. Pool metrics expose best-account quota utilization and account
-//! rotations.
+//! and streaming token usage, Codex continuation decisions, Codex WebSocket
+//! dedicated-overflow admission outcomes, and sanitized client analytics event
+//! names, retries, and requests shed at the inbound concurrency limit. Pool
+//! metrics expose best-account quota utilization and account rotations.
 //!
 //! Attributes stay low-cardinality (provider/model/status/outcome/kind/window/
 //! reason, plus the sanitized, cardinality-capped `event` on
@@ -48,6 +48,7 @@ struct OtelInstruments {
     requests_shed: Counter<u64>,
     _pool_utilization: ObservableGauge<f64>,
     pool_rotations: Counter<u64>,
+    codex_ws_overflow: Counter<u64>,
 }
 
 type PoolUtilizationValues = HashMap<(String, &'static str), Option<f64>>;
@@ -132,6 +133,12 @@ fn otel_instruments() -> &'static OtelInstruments {
             pool_rotations: meter
                 .u64_counter("shunt.pool.rotations")
                 .with_description("Account-pool rotations by low-cardinality reason")
+                .build(),
+            codex_ws_overflow: meter
+                .u64_counter("shunt.codex_ws_overflow")
+                .with_description(
+                    "Codex WebSocket dedicated overflow connections (opened vs refused at the ceiling, issue #248)",
+                )
                 .build(),
         }
     })
@@ -358,6 +365,82 @@ pub fn record_request_shed() {
     otel_instruments().requests_shed.add(1, &[]);
 }
 
+/// The outcome of a Codex WebSocket dedicated-overflow admission decision
+/// (issue #248): a concurrent turn found the session's pooled connection
+/// already streaming and either opened a one-shot dedicated socket, or was
+/// refused because the overflow ceiling (`MAX_OVERFLOW_CONNECTIONS` in
+/// `crate::adapters::responses::codex_ws`) was already saturated.
+#[derive(Clone, Copy, Debug)]
+pub enum CodexWsOverflowOutcome {
+    /// The pooled connection was busy; a dedicated overflow socket was opened
+    /// for this turn. It carries no `previous_response_id` continuation, so a
+    /// rising count on a session that expects one shared connection answers
+    /// issue #248's open question: concurrent Claude Code agents are sharing
+    /// one `x-claude-code-session-id` and colliding on the same pooled turn.
+    Opened,
+    /// The overflow ceiling was already saturated; admission was refused
+    /// before any frame was sent and the caller falls back to HTTP.
+    Refused,
+}
+
+impl CodexWsOverflowOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Opened => "opened",
+            Self::Refused => "refused",
+        }
+    }
+}
+
+/// Record one Codex WebSocket dedicated-overflow admission decision: a
+/// `shunt.codex_ws_overflow` count tagged with the provider and `outcome`
+/// (`opened` or `refused`). Emitted to Sentry and OpenTelemetry; each sink is
+/// inert unless configured. See [`CodexWsOverflowOutcome`].
+pub fn record_codex_ws_overflow(provider: &str, outcome: CodexWsOverflowOutcome) {
+    let provider = provider.to_owned();
+    let outcome_str = outcome.as_str();
+    sentry::metrics::counter("shunt.codex_ws_overflow", 1)
+        .attribute("provider", provider.clone())
+        .attribute("outcome", outcome_str.to_owned())
+        .capture();
+
+    let attributes = [
+        KeyValue::new("provider", provider.clone()),
+        KeyValue::new("outcome", outcome_str),
+    ];
+    otel_instruments().codex_ws_overflow.add(1, &attributes);
+
+    #[cfg(test)]
+    {
+        *test_overflow_counts()
+            .lock()
+            .expect("test overflow counter lock poisoned")
+            .entry((provider, outcome_str))
+            .or_insert(0) += 1;
+    }
+}
+
+/// Test-only observation point for [`record_codex_ws_overflow`]: neither sink
+/// (Sentry, OpenTelemetry) is introspectable without a live collector, so
+/// callers that need to prove the counter actually increments (rather than
+/// merely not panicking) read this instead. Keyed by provider so tests using
+/// distinct provider strings do not interfere with each other's counts even
+/// when `cargo test` runs them in parallel within one process.
+#[cfg(test)]
+pub fn codex_ws_overflow_count_for_tests(provider: &str, outcome: CodexWsOverflowOutcome) -> u64 {
+    *test_overflow_counts()
+        .lock()
+        .expect("test overflow counter lock poisoned")
+        .get(&(provider.to_string(), outcome.as_str()))
+        .unwrap_or(&0)
+}
+
+#[cfg(test)]
+fn test_overflow_counts() -> &'static Mutex<HashMap<(String, &'static str), u64>> {
+    static COUNTS: OnceLock<Mutex<HashMap<(String, &'static str), u64>>> = OnceLock::new();
+    COUNTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -419,5 +502,39 @@ mod tests {
         super::record_failover("anthropic", "attempted");
         super::record_failover("openai", "advanced");
         super::record_failover("openai", "exhausted");
+    }
+
+    /// The Codex WebSocket overflow counter honors the same opt-in no-op
+    /// contract, and — unlike the other counters here — the increment is also
+    /// independently observable through the test-only accessor, proving the
+    /// counter actually counts rather than merely not panicking.
+    #[test]
+    fn record_codex_ws_overflow_is_noop_without_sinks_and_counts_for_tests() {
+        use super::{
+            codex_ws_overflow_count_for_tests, record_codex_ws_overflow, CodexWsOverflowOutcome,
+        };
+
+        let provider = "codex-metrics-unit-test";
+        assert_eq!(
+            codex_ws_overflow_count_for_tests(provider, CodexWsOverflowOutcome::Opened),
+            0
+        );
+        assert_eq!(
+            codex_ws_overflow_count_for_tests(provider, CodexWsOverflowOutcome::Refused),
+            0
+        );
+
+        record_codex_ws_overflow(provider, CodexWsOverflowOutcome::Opened);
+        record_codex_ws_overflow(provider, CodexWsOverflowOutcome::Opened);
+        record_codex_ws_overflow(provider, CodexWsOverflowOutcome::Refused);
+
+        assert_eq!(
+            codex_ws_overflow_count_for_tests(provider, CodexWsOverflowOutcome::Opened),
+            2
+        );
+        assert_eq!(
+            codex_ws_overflow_count_for_tests(provider, CodexWsOverflowOutcome::Refused),
+            1
+        );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -404,20 +404,20 @@ pub fn record_codex_ws_overflow(provider: &str, outcome: CodexWsOverflowOutcome)
         .attribute("outcome", outcome_str)
         .capture();
 
-    let attributes = [
-        KeyValue::new("provider", provider.clone()),
-        KeyValue::new("outcome", outcome_str),
-    ];
-    otel_instruments().codex_ws_overflow.add(1, &attributes);
-
     #[cfg(test)]
     {
         *test_overflow_counts()
             .lock()
             .expect("test overflow counter lock poisoned")
-            .entry((provider, outcome_str))
+            .entry((provider.clone(), outcome_str))
             .or_insert(0) += 1;
     }
+
+    let attributes = [
+        KeyValue::new("provider", provider),
+        KeyValue::new("outcome", outcome_str),
+    ];
+    otel_instruments().codex_ws_overflow.add(1, &attributes);
 }
 
 /// Test-only observation point for [`record_codex_ws_overflow`]: neither sink

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -401,7 +401,7 @@ pub fn record_codex_ws_overflow(provider: &str, outcome: CodexWsOverflowOutcome)
     let outcome_str = outcome.as_str();
     sentry::metrics::counter("shunt.codex_ws_overflow", 1)
         .attribute("provider", provider.clone())
-        .attribute("outcome", outcome_str.to_owned())
+        .attribute("outcome", outcome_str)
         .capture();
 
     let attributes = [


### PR DESCRIPTION
## Summary

Fixes #282.

Adds a `shunt.codex_ws_overflow` counter (`provider`, `outcome`) for the Codex WebSocket transport's dedicated-overflow admission path in `codex_ws::begin`, mirroring the existing `shunt.codex_continuation` metric (dual Sentry + OpenTelemetry emission, both sinks inert unless configured).

**Why:** issue #248 added a dedicated-overflow socket so a concurrent turn never waits behind a busy pooled connection. PR #250, which shipped that fix, explicitly deferred adding a counter for it:

> Worth a look: whether a metric (e.g. an overflow counter alongside `shunt.codex_continuation`) should be added to answer the issue's open question about how often concurrent agents actually share one `x-claude-code-session-id`. Left out here to keep the diff to the fix; happy to add as a follow-up.

This PR is that follow-up. It's a diagnostic tool, not a behavior change: it does not alter routing, admission, or fallback logic.

**How to read it:**
- `shunt.codex_ws_overflow{outcome="opened"}` — the pooled connection was busy, so this turn opened a dedicated one-shot socket. It carries no `previous_response_id` continuation. A rising count on a session expected to have one client indicates multiple concurrent Claude Code agents are colliding on the same `x-claude-code-session-id` pool key and losing continuation reuse for those turns.
- `shunt.codex_ws_overflow{outcome="refused"}` — the overflow ceiling (`MAX_OVERFLOW_CONNECTIONS = 64`) was already saturated; the turn was refused before any frame was sent and transparently fell back to HTTP.

Both are recorded only on the already-taken overflow branch inside `begin()`, so the pooled-reuse and fresh-handshake hot paths pay nothing extra.

## Milestone / spec

M7 — `docs/m7-codex-websocket.md` §5 "Connection pool" (Concurrent turns bullet).

## Checklist

- [x] `cargo build` passes
- [x] `cargo test --all-features --workspace` passes (1037 unit tests + all integration groups green; new behavior covered — `metrics::tests::record_codex_ws_overflow_is_noop_without_sinks_and_counts_for_tests`, and the existing `codex_ws::tests::concurrent_turn_opens_a_dedicated_connection_instead_of_waiting` / `overflow_ceiling_refuses_promptly_then_recovers` extended to assert on both outcomes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines — `codex_ws.rs` was already over (2.2k, transport + its test module) before this change; this PR does not add a new oversized file
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated (`docs/m7-codex-websocket.md` §5, `docs/running.md` metrics table)
- [x] User-facing docs updated: `site/src/content/docs/guides/opentelemetry.mdx` across all four locales (en/ja/ko/zh-cn) list the new series, matching the precedent set for `shunt.requests_shed` in #271
- [x] No new GitHub Actions added

## Notes for reviewers

- Neither Sentry nor OpenTelemetry is introspectable in-process without a live collector, so `metrics.rs` gets a small `#[cfg(test)]`-only counter map (`codex_ws_overflow_count_for_tests`) to make the increments actually provable, not just non-panicking — same pattern as `clear_pool_for_tests` / `pool_contains_for_tests` already in `codex_ws.rs`. Test call sites use unique per-test provider strings (`codex-overflow-open-test`, `codex-overflow-ceiling-test`) so parallel `cargo test` runs can't cross-pollute counts.
- `begin()` gained a `provider: &str` parameter to tag the metric like every other per-provider series; this rippled through ~13 existing test call sites (all updated to pass a literal provider string) plus the one production call site in `websocket.rs`, which already threads `ctx.provider` for `record_continuation_outcome`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `shunt.codex_ws_overflow` counter to track Codex WebSocket overflow admissions (`opened` vs `refused`), tagged by `provider`. This is diagnostic only; routing and admission behavior are unchanged.

- **New Features**
  - Emit `shunt.codex_ws_overflow` only on the overflow path in `codex_ws::begin`.
  - Outcomes: `opened` when a dedicated socket is created; `refused` when `MAX_OVERFLOW_CONNECTIONS` is hit and we fall back to HTTP.
  - Sent to both Sentry and OpenTelemetry; docs updated across `docs/` and site guides in all locales.
  - Tests assert both outcomes via a test-only counter map.
  - Perf: avoid an allocation for the Sentry `outcome` tag; move `provider` into OTel attributes to drop an extra clone per call in release builds.

- **Migration**
  - `codex_ws::begin` now takes `provider: &str`. Update direct callers to pass a provider (e.g., `ctx.provider`).

<sup>Written for commit e3cc09cc3ee9f6ff67a3238ebbe16412a86d7d3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

