### PR TITLE
feat(observability): surface mid-stream SSE failures in spans and Sentry (#287)

### DIFF
--- a/docs/m1-responses-translation.md
+++ b/docs/m1-responses-translation.md
@@ -114,12 +114,13 @@ Upstream Responses events to handle (names as emitted by the Codex backend / Res
 | `response.function_call_arguments.delta` | `delta` (JSON fragment) | `content_block_delta {index, delta:{type:"input_json_delta", partial_json:delta}}`. |
 | `response.function_call_arguments.done` / `response.output_item.done` | full `arguments` | `content_block_stop {index}`; advance index. |
 | `response.reasoning_summary_text.delta` (optional) | `delta` | either a `thinking` block delta (if we surface thinking) or drop. MVP: drop. |
-| `response.completed` / `response.done` | full `response` + `usage`, `stop_reason` | `message_delta {delta:{stop_reason, stop_sequence:null}, usage:{output_tokens,...}}` then `message_stop`. `stop_reason` = `tool_use` if any function_call emitted, else `end_turn`. |
+| `response.completed` / `response.done` / `response.incomplete` | full `response` + `usage`, `stop_reason` | `message_delta {delta:{stop_reason, stop_sequence:null}, usage:{output_tokens,...}}` then `message_stop`. `stop_reason` = `tool_use` if any function_call emitted, else `end_turn`. `response.incomplete` (a clean, if truncated, terminal — mirrors the WebSocket transport's terminal set, `m7-codex-websocket.md` §4) is treated identically to `completed`/`done`, so a stream that ends right after it does **not** trigger the Robustness fallback below. |
 | `error` / `response.failed` | error object | translate to an Anthropic error (§8); terminate the stream. |
 
 Robustness: unknown event types are ignored. If the stream ends without a terminal
-`completed`, fall back to closing any open block, emit `message_delta` (`end_turn`) +
-`message_stop` from accumulated text (insightflo's fallback shape).
+event (`completed` / `done` / `incomplete`), fall back to closing any open block, emit
+`message_delta` (`end_turn`) + `message_stop` from accumulated text (insightflo's fallback
+shape).
 
 Non-streaming client: run the same machine but collect blocks instead of emitting; return
 `transformCodexToAnthropic`-equivalent JSON: `{id,type:"message",role:"assistant",model:<original>,content,stop_reason,stop_sequence:null,usage}`.

--- a/docs/running.md
+++ b/docs/running.md
@@ -125,12 +125,16 @@ provider = "openai"
 # warn/info as breadcrumbs — plus, unconditionally once a DSN is set, an
 # error/warning event whenever an upstream provider itself returns a failure:
 # error for a 5xx response, warning for 429/529 (rate limit/overload), each
-# tagged with model, provider, and upstream_status only. Request/response
-# bodies, headers, credentials, and the host name are never sent: breadcrumbs
-# keep only the log message (field values are stripped), and tracing spans
-# attach only when you opt into tracing via traces_sample_rate below. An empty
-# DSN (e.g. SHUNT_SENTRY__DSN="") disables reporting again; an invalid DSN or
-# an out-of-range traces_sample_rate is a startup error.
+# tagged with model, provider, and upstream_status only. A streaming request
+# that answers 200 and then fails mid-stream (an `event: error` frame, or the
+# connection cut before a terminal event) also reports: error for the former,
+# warning for the latter, tagged with model, provider, and outcome only
+# (issue #287). Request/response bodies, headers, credentials, and the host
+# name are never sent: breadcrumbs keep only the log message (field values are
+# stripped), and tracing spans attach only when you opt into tracing via
+# traces_sample_rate below. An empty DSN (e.g. SHUNT_SENTRY__DSN="") disables
+# reporting again; an invalid DSN or an out-of-range traces_sample_rate is a
+# startup error.
 # [sentry]
 # dsn = "https://<key>@<org>.ingest.sentry.io/<project>"
 # environment = "home-lab"   # optional environment tag on events

--- a/site/src/content/docs/guides/opentelemetry.mdx
+++ b/site/src/content/docs/guides/opentelemetry.mdx
@@ -37,7 +37,7 @@ Setting `endpoint = ""` (e.g. `SHUNT_OTEL__ENDPOINT=""`) disables export again w
 
 | Signal | What's exported | Notes |
 | :-- | :-- | :-- |
-| **Traces** | The per-request `proxy_request` span (and `codex_endpoint_request` on the inbound Codex endpoint), tagged with `gen_ai.request.model`, `shunt.provider`, `http.response.status_code`, and `otel.status_code` (`error` on 5xx) | Head-based sampling via `sample_ratio`. Low-cardinality; no request/response bodies, headers, or credentials. |
+| **Traces** | The per-request `proxy_request` span (and `codex_endpoint_request` on the inbound Codex endpoint), tagged with `gen_ai.request.model`, `shunt.provider`, `http.response.status_code`, and `otel.status_code` (`error` on a 5xx response, or on a streaming request that fails mid-stream after a `200` header — an `event: error` frame or a connection cut before a terminal event, issue #287) | Head-based sampling via `sample_ratio`. Low-cardinality; no request/response bodies, headers, or credentials. |
 | **Metrics** | The low-cardinality series listed below | The same series shunt sends to Sentry when `[sentry] metrics = true`. |
 | **Logs** | shunt's `tracing` log events, bridged to OTLP | The stderr logs are unaffected. |
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -381,7 +381,7 @@ codex = "gpt-5.2"
 
 ## `[sentry]` (optional)
 
-Opt-in error reporting to your own Sentry project. Off unless `dsn` is set; independent of `[otel]`. Reports gateway-owned diagnostics — fatal gateway startup/serve errors, panics, and `error`-level log events (`warn`/`info` as breadcrumbs, message only) — plus, unconditionally once `dsn` is set, an error/warning event whenever an upstream provider itself returns a failure: `error` for a 5xx response, `warning` for 429/529 (rate limit/overload), each tagged with `model`, `provider`, and `upstream_status` only. Request/response bodies, headers, and credentials are never sent. Metrics and tracing are each a further, separate opt-in.
+Opt-in error reporting to your own Sentry project. Off unless `dsn` is set; independent of `[otel]`. Reports gateway-owned diagnostics — fatal gateway startup/serve errors, panics, and `error`-level log events (`warn`/`info` as breadcrumbs, message only) — plus, unconditionally once `dsn` is set, an error/warning event whenever an upstream provider itself returns a failure: `error` for a 5xx response, `warning` for 429/529 (rate limit/overload), each tagged with `model`, `provider`, and `upstream_status` only. A streaming request that answers `200` and then fails mid-stream — an `event: error` frame, or the connection cut before a terminal event — also reports an event (`error`/`warning` respectively), tagged with `model`, `provider`, and `outcome` only, and marks the request span `otel.status_code = error` (issue #287). Request/response bodies, headers, and credentials are never sent. Metrics and tracing are each a further, separate opt-in.
 
 | Key | Default | Meaning |
 | :-- | :-- | :-- |

--- a/src/adapters/responses/http.rs
+++ b/src/adapters/responses/http.rs
@@ -170,7 +170,23 @@ pub(super) fn stream_response(
                     if data.is_empty() {
                         return None;
                     }
-                    return Some((Ok(Bytes::from(data)), (bytes, parser, machine, finished)));
+                    // `machine.finish()` only produced output here because
+                    // the upstream connection ended before a real
+                    // terminal/error event (see `AnthropicSseMachine::finish`):
+                    // prefix the synthesized completion with an SSE comment
+                    // marker so `stream_metrics::observe_response` can still
+                    // classify this as an upstream cut instead of a normal
+                    // completion. Real clients ignore `:`-prefixed comment
+                    // lines per the WHATWG EventSource spec, so the
+                    // client-visible stream stays exactly as well-formed as
+                    // before.
+                    let mut marked = Vec::with_capacity(
+                        crate::stream_metrics::UPSTREAM_TRUNCATED_MARKER.len() + 2 + data.len(),
+                    );
+                    marked.extend_from_slice(crate::stream_metrics::UPSTREAM_TRUNCATED_MARKER);
+                    marked.extend_from_slice(b"\n\n");
+                    marked.extend_from_slice(data.as_bytes());
+                    return Some((Ok(Bytes::from(marked)), (bytes, parser, machine, finished)));
                 }
             }
         }
@@ -353,6 +369,82 @@ mod tests {
         let body = response_body_json(response).await;
         assert_eq!(body["type"], "message");
         assert_eq!(body["content"][0]["text"], "hello");
+    }
+
+    /// The streaming path prefixes a synthesized completion with
+    /// `stream_metrics::UPSTREAM_TRUNCATED_MARKER` when the upstream
+    /// connection ends before a real terminal event, so the observer can
+    /// still classify the stream as an upstream cut instead of a normal
+    /// completion (see that constant's doc comment for the full rationale).
+    #[tokio::test]
+    async fn stream_response_marks_a_synthesized_completion_from_a_truncated_upstream() {
+        let sse = concat!(
+            "event: response.created\n",
+            "data: {\"response\":{\"id\":\"resp_1\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"item\":{\"type\":\"message\"}}\n\n",
+            "event: response.output_text.delta\n",
+            "data: {\"delta\":\"partial\"}\n\n",
+        );
+        let upstream = upstream_response(200, sse).await;
+        let response = stream_response(
+            upstream,
+            relay_opts(),
+            0,
+            std::time::Duration::from_secs(30),
+        );
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("streamed body should be readable");
+        let body = std::str::from_utf8(&bytes).expect("body is utf8");
+        let marker = std::str::from_utf8(crate::stream_metrics::UPSTREAM_TRUNCATED_MARKER).unwrap();
+
+        // The marker sits immediately before the synthesized completion
+        // `AnthropicSseMachine::finish` builds once the mock body ends
+        // without a `response.completed` — not at the very start of the
+        // stream, since the real `content_block_delta` already flowed.
+        let expected_synthetic_completion = format!("{marker}\n\nevent: content_block_stop");
+        assert!(
+            body.contains(&expected_synthetic_completion),
+            "truncated stream must carry the marker right before the synthesized completion, got: {body}"
+        );
+        assert!(body.contains("event: message_stop"));
+    }
+
+    /// A clean turn that reaches `response.completed` must not carry the
+    /// truncation marker — it exists only for the EOF-before-terminal path.
+    #[tokio::test]
+    async fn stream_response_does_not_mark_a_genuine_completion() {
+        let sse = concat!(
+            "event: response.created\n",
+            "data: {\"response\":{\"id\":\"resp_1\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"item\":{\"type\":\"message\"}}\n\n",
+            "event: response.output_text.delta\n",
+            "data: {\"delta\":\"hello\"}\n\n",
+            "event: response.output_text.done\n",
+            "data: {}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n",
+        );
+        let upstream = upstream_response(200, sse).await;
+        let response = stream_response(
+            upstream,
+            relay_opts(),
+            0,
+            std::time::Duration::from_secs(30),
+        );
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("streamed body should be readable");
+        let body = std::str::from_utf8(&bytes).expect("body is utf8");
+        let marker = std::str::from_utf8(crate::stream_metrics::UPSTREAM_TRUNCATED_MARKER).unwrap();
+
+        assert!(
+            !body.contains(marker),
+            "clean completion must not carry the marker, got: {body}"
+        );
+        assert!(body.contains("event: message_stop"));
     }
 
     /// A multi-byte code point split across two transport chunks must survive

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,7 +499,11 @@ fn check(config_path: Option<PathBuf>) -> anyhow::Result<()> {
 /// plus, unconditionally once a client is bound, an upstream-failure event
 /// (`error` for a 5xx response, `warning` for 429/529 quota/overload) tagged
 /// only with `model`, `provider`, and `upstream_status` (see
-/// `observability::capture_upstream_outcome`). Never request/response
+/// `observability::capture_upstream_outcome`), and a mid-stream failure event
+/// for a streaming request that answered `200` and then failed (`error` for an
+/// `event: error` frame, `warning` for the connection cut before a terminal
+/// event) tagged only with `model`, `provider`, and `outcome` (see
+/// `observability::record_stream_failure`). Never request/response
 /// bodies, headers, or credentials. Performance tracing is a further opt-in
 /// via `[sentry] traces_sample_rate`; the span filter installed by
 /// [`init_tracing`] admits spans only after this pins an enabled policy.

--- a/src/model/responses.rs
+++ b/src/model/responses.rs
@@ -161,7 +161,19 @@ impl AnthropicSseMachine {
             "response.function_call_arguments.delta" => self.arguments_delta(&event.data),
             "response.function_call_arguments.done" => self.close_current(BlockKind::Tool),
             "response.output_item.done" => self.output_item_done(&event.data),
-            "response.completed" | "response.done" => self.complete(&event.data),
+            // `response.incomplete` is a clean (if truncated) terminal, not a
+            // transport cut — mirrors the WebSocket transport's terminal set
+            // (`adapters::responses::codex_ws::TERMINAL_EVENTS`, also
+            // docs/m7-codex-websocket.md) and `stream_metrics::observe_responses`'s
+            // own terminal match. Routing it through the same `complete` path as
+            // `response.completed`/`response.done` sets `stopped`, so a stream
+            // that ends right after this event no longer hits `finish`'s
+            // cut-before-terminal fallback (`http.rs`'s `UPSTREAM_TRUNCATED_MARKER`
+            // injection) — and it keeps the existing `tool_use`/`end_turn`
+            // stop_reason convention rather than introducing a new one.
+            "response.completed" | "response.done" | "response.incomplete" => {
+                self.complete(&event.data)
+            }
             "error" | "response.failed" => {
                 self.stopped = true;
                 let value = map_error_value(&event.data, StatusCode::BAD_GATEWAY);

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -288,7 +288,13 @@ pub(crate) enum StreamFailureKind {
 }
 
 impl StreamFailureKind {
-    fn as_str(self) -> &'static str {
+    /// The Sentry `outcome` tag for this failure. Must stay identical to
+    /// `stream_metrics::Outcome::as_str` for the corresponding outcome, so
+    /// the tag joins against the `outcome` attribute of the
+    /// `shunt.stream_outcome` metric; the test
+    /// `stream_metrics::tests::stream_failure_labels_match_outcome_labels`
+    /// pins that.
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::ErrorEvent => "error_event",
             Self::UpstreamCut => "upstream_cut",

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,11 +1,20 @@
-//! Per-request span tagging and upstream-failure signal for Sentry (#281).
+//! Per-request span tagging and upstream-failure signal for Sentry (#281, #287).
 //!
-//! Goal: an upstream failure (5xx, or 429/529 quota/overload) is root-causeable
-//! from Sentry alone — which model, which provider, what status — without
-//! cross-referencing local logs.
+//! Goal: an upstream failure is root-causeable from Sentry alone — which
+//! model, which provider, what happened — without cross-referencing local
+//! logs. That covers two distinct kinds of failure:
 //!
-//! Two independent mechanisms, because they reach Sentry through different
-//! paths:
+//! - One known at response-header time: 5xx, or 429/529 quota/overload.
+//! - One discovered only mid-stream, after the upstream already answered
+//!   `200` and started an SSE stream: an `event: error` frame, or the
+//!   connection cut before a terminal event (#287). Without this, such a
+//!   request is recorded as a plain success forever — `stream_metrics`
+//!   already detects it (`ObserverState::finish`, for the
+//!   `shunt_stream_outcome_total` metric) but, before #287, never told
+//!   `observability` about it.
+//!
+//! Three mechanisms, because they reach Sentry through different paths and,
+//! for the mid-stream case, at a different point in the request lifecycle:
 //!
 //! - **Span tagging** ([`record_requested_model`], [`record_span_outcome`]):
 //!   fills in `tracing::field::Empty` fields declared on the `proxy_request` /
@@ -19,7 +28,8 @@
 //!   `otel.status_code` — so it is set directly via
 //!   `sentry::configure_scope(..).get_span()` in [`mark_sentry_span_status`].
 //!   This is a no-op whenever no Sentry span is active (client absent, or span
-//!   export disabled), so it costs nothing beyond the existing opt-in.
+//!   export disabled), so it costs nothing beyond the existing opt-in. This
+//!   only ever runs at response-header time, once, from the handler.
 //! - **Event capture** ([`capture_upstream_outcome`]): a Sentry error/warning
 //!   *event* for 5xx and 429/529 responses, built with `sentry::capture_message`
 //!   directly rather than a `tracing::error!`/`warn!` macro. Sentry events are
@@ -29,12 +39,40 @@
 //!   `EventFilter` (WARN → breadcrumb, not an event) to be overridden. Calling
 //!   the Sentry API directly avoids depending on that filter and keeps this
 //!   change from touching `main.rs`'s subscriber wiring.
+//! - **Mid-stream failure** ([`record_stream_failure`]): the same two ideas —
+//!   span field + Sentry event — applied from *inside the response body's
+//!   stream poll*, well after the handler that created the span has already
+//!   returned. This split is why it cannot simply call
+//!   [`record_span_outcome`]/[`mark_sentry_span_status`] again: by the time a
+//!   streamed body is being polled, `sentry-tracing`'s `on_exit` has already
+//!   popped the `HubSwitchGuard` that made the request's Sentry span reachable
+//!   via `sentry::configure_scope(..).get_span()` — that accessor now returns
+//!   `None` (or some unrelated span), and there is no public API to reach a
+//!   *specific*, no-longer-current tracing span's Sentry span/transaction
+//!   handle. So Sentry's own span-status enum genuinely cannot be set for a
+//!   mid-stream failure; this is a real, structural limitation of
+//!   `sentry-tracing` 0.48, not a shortcut taken here. What *does* still work:
+//!   `crate::stream_metrics::ObserverState` holds a cloned `tracing::Span`
+//!   handle for the request span from the moment the stream is wrapped
+//!   (`stream_metrics::observe_response`) until the stream itself finishes —
+//!   tracing spans are ref-counted, so this clone defers the span's `on_close`
+//!   (and, transitively, `sentry_span.finish()` and the OTel bridge's export)
+//!   until then. Re-recording `otel.status_code` on that held clone therefore
+//!   still reaches every layer's `on_record` while the span is open, including
+//!   `sentry-tracing`'s, which mirrors recorded fields onto the still-open
+//!   Sentry span's `data` (not its `status` enum, but still visible/searchable
+//!   there) — so the OTel export and Sentry's span `data` both correctly end
+//!   up `error` for a stream that opened `ok`. The event capture, unlike the
+//!   span-status call, was never scope-dependent (it sets its own tags via
+//!   `sentry::with_scope` rather than reading ambient state) and works
+//!   identically here.
 //!
-//! Both mechanisms carry only the requested model id, resolved provider name,
-//! and the numeric upstream status — never request/response bodies, headers,
-//! or credentials. The model id is client-supplied free text (the inbound
-//! Codex endpoint in particular forwards its request body verbatim and only
-//! reads `model` for this label, see `codex_endpoint.rs`), so it is
+//! All three carry only the requested model id, resolved provider name, and
+//! (for the header-time and mid-stream paths respectively) the numeric
+//! upstream status or the stream outcome — never request/response bodies,
+//! headers, or credentials. The model id is client-supplied free text (the
+//! inbound Codex endpoint in particular forwards its request body verbatim and
+//! only reads `model` for this label, see `codex_endpoint.rs`), so it is
 //! length-bounded and stripped of control characters before export by
 //! [`sanitize_model_tag`] — otherwise an oversized or control-character-laden
 //! value would reach a Sentry tag/span field unchanged.
@@ -230,6 +268,88 @@ pub(crate) fn capture_upstream_outcome(provider: &str, model: &str, status: Stat
     );
 }
 
+/// The two `stream_metrics::Outcome` variants that represent an upstream
+/// *failure* discovered mid-stream — the only ones [`record_stream_failure`]
+/// is ever called for (`stream_metrics::Outcome::Completed` and
+/// `::ClientDisconnect` are not failures of the upstream: a natural end and a
+/// client hangup are not root-causeable events). The label strings mirror
+/// (without importing — `stream_metrics::Outcome` is private to that module)
+/// the ones already used for the `shunt_stream_outcome_total` metric, so a
+/// `stream_outcome="error_event"` in Prometheus and an `outcome=error_event`
+/// tag on a Sentry event refer to the same thing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StreamFailureKind {
+    /// The upstream sent an `event: error` SSE frame before any terminal
+    /// event — an operational failure the upstream itself reported.
+    ErrorEvent,
+    /// The connection was cut (by the upstream, or a network intermediary)
+    /// before a terminal event or an error event ever arrived.
+    UpstreamCut,
+}
+
+impl StreamFailureKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ErrorEvent => "error_event",
+            Self::UpstreamCut => "upstream_cut",
+        }
+    }
+}
+
+/// Mid-stream counterpart to [`record_span_outcome`] + [`capture_upstream_outcome`]:
+/// an upstream that answered `200` and only failed *after* headers were
+/// already sent — an `event: error` SSE frame, or the connection cut before a
+/// terminal event — never reaches either of those, since both run at
+/// response-header time and by definition see only the `200`
+/// (`crate::stream_metrics::ObserverState::finish` is the sole caller, gated
+/// to exactly the two [`StreamFailureKind`] variants, #287).
+///
+/// `span` must be the request's own span (`proxy_request` /
+/// `codex_endpoint_request`), captured via `tracing::Span::current()` while
+/// still inside the `.instrument(span)` future
+/// (`stream_metrics::observe_response`) and held until the stream finishes —
+/// see the module docs for why recording on it still works, and why that is
+/// *not* true for Sentry's own span-status enum (only the standalone event
+/// below reaches that reliably).
+pub(crate) fn record_stream_failure(
+    span: &tracing::Span,
+    provider: &str,
+    model: &str,
+    outcome: StreamFailureKind,
+) {
+    // Overwrites whatever `record_span_outcome` already recorded at
+    // response-header time (`"ok"`, since a stream failure by definition
+    // starts with a `200`) — `tracing` permits re-recording a declared field,
+    // and every layer that mirrors it (the OTel bridge, `sentry-tracing`'s
+    // span-data mirror) takes the latest value observed before the span
+    // closes, which this is: `ObserverState` holds the only extra clone of
+    // `span`, `finish` runs at most once (`self.finished` guard), and that
+    // clone is not dropped until after this call returns.
+    span.record("otel.status_code", "error");
+
+    let (level, message) = match outcome {
+        StreamFailureKind::ErrorEvent => (
+            Level::Error,
+            "upstream SSE stream sent an error event mid-stream",
+        ),
+        StreamFailureKind::UpstreamCut => (
+            Level::Warning,
+            "upstream SSE stream was cut before a terminal event",
+        ),
+    };
+    let model = sanitize_model_tag(model);
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("model", model.as_ref());
+            scope.set_tag("provider", provider);
+            scope.set_tag("outcome", outcome.as_str());
+        },
+        || {
+            sentry::capture_message(message, level);
+        },
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -240,8 +360,9 @@ mod tests {
     use tracing_subscriber::Layer;
 
     use super::{
-        capture_upstream_outcome, record_requested_model, record_span_outcome, sanitize_model_tag,
-        sentry_span_status, should_capture_upstream_status, MAX_MODEL_TAG_LEN,
+        capture_upstream_outcome, record_requested_model, record_span_outcome,
+        record_stream_failure, sanitize_model_tag, sentry_span_status,
+        should_capture_upstream_status, StreamFailureKind, MAX_MODEL_TAG_LEN,
     };
 
     #[test]
@@ -609,6 +730,133 @@ mod tests {
         let oversized_model = format!("{}-with-a-trailing-newline\n", "m".repeat(200));
         let events = sentry::test::with_captured_events(|| {
             capture_upstream_outcome("anthropic", &oversized_model, StatusCode::BAD_GATEWAY);
+        });
+
+        assert_eq!(events.len(), 1);
+        let tag = events[0]
+            .tags
+            .get("model")
+            .expect("model tag must be present");
+        assert_eq!(tag.chars().count(), MAX_MODEL_TAG_LEN);
+        assert!(!tag.contains('\n'), "control characters must be stripped");
+    }
+
+    // `record_stream_failure` is the mid-stream counterpart to
+    // `record_span_outcome` + `capture_upstream_outcome` (see the module
+    // docs for why it is a separate function rather than reusing those). The
+    // wiring that only calls it for the right `stream_metrics::Outcome`
+    // variants is exercised in `stream_metrics::tests`; these tests cover the
+    // function itself in isolation, mirroring the two blocks above.
+
+    #[test]
+    fn record_stream_failure_overwrites_an_already_recorded_otel_status_code() {
+        // A mid-stream failure always follows a `200`, which
+        // `record_span_outcome` already recorded as `otel.status_code = "ok"`
+        // at response-header time — this proves the second, later call
+        // actually overwrites that value rather than being silently ignored
+        // as a duplicate.
+        let captured = CapturingLayer::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "test_stream_request",
+                otel.status_code = tracing::field::Empty
+            );
+            let _entered = span.enter();
+            span.record("otel.status_code", "ok");
+            record_stream_failure(
+                &span,
+                "anthropic",
+                "claude-opus-5",
+                StreamFailureKind::ErrorEvent,
+            );
+        });
+
+        let map = captured.0.lock().unwrap();
+        assert_eq!(
+            map.get("otel.status_code").map(String::as_str),
+            Some("error")
+        );
+    }
+
+    #[test]
+    fn record_stream_failure_emits_an_error_event_for_an_error_event_outcome() {
+        let span = tracing::Span::none();
+        let events = sentry::test::with_captured_events(|| {
+            record_stream_failure(
+                &span,
+                "anthropic",
+                "claude-opus-5",
+                StreamFailureKind::ErrorEvent,
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, sentry::Level::Error);
+        assert_eq!(
+            events[0].message.as_deref(),
+            Some("upstream SSE stream sent an error event mid-stream")
+        );
+    }
+
+    #[test]
+    fn record_stream_failure_emits_a_warning_event_for_an_upstream_cut_outcome() {
+        let span = tracing::Span::none();
+        let events = sentry::test::with_captured_events(|| {
+            record_stream_failure(
+                &span,
+                "anthropic",
+                "claude-opus-5",
+                StreamFailureKind::UpstreamCut,
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, sentry::Level::Warning);
+        assert_eq!(
+            events[0].message.as_deref(),
+            Some("upstream SSE stream was cut before a terminal event")
+        );
+    }
+
+    #[test]
+    fn record_stream_failure_event_carries_exactly_model_provider_and_outcome_tags() {
+        let span = tracing::Span::none();
+        let events = sentry::test::with_captured_events(|| {
+            record_stream_failure(
+                &span,
+                "anthropic",
+                "claude-opus-5",
+                StreamFailureKind::UpstreamCut,
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        let tags = &events[0].tags;
+        // Exactly these three keys — nothing else (no body, header, or credential
+        // ever gets attached to this event; this is the no-PII guarantee, locked
+        // down structurally rather than by spot-checking a couple of fields).
+        assert_eq!(tags.len(), 3, "unexpected tags: {tags:?}");
+        assert_eq!(tags.get("model").map(String::as_str), Some("claude-opus-5"));
+        assert_eq!(tags.get("provider").map(String::as_str), Some("anthropic"));
+        assert_eq!(
+            tags.get("outcome").map(String::as_str),
+            Some("upstream_cut")
+        );
+    }
+
+    #[test]
+    fn record_stream_failure_sanitizes_an_oversized_client_supplied_model_tag() {
+        let span = tracing::Span::none();
+        let oversized_model = format!("{}-with-a-trailing-newline\n", "m".repeat(200));
+        let events = sentry::test::with_captured_events(|| {
+            record_stream_failure(
+                &span,
+                "anthropic",
+                &oversized_model,
+                StreamFailureKind::ErrorEvent,
+            );
         });
 
         assert_eq!(events.len(), 1);

--- a/src/stream_metrics.rs
+++ b/src/stream_metrics.rs
@@ -352,7 +352,17 @@ fn observe_responses(event: Option<&[u8]>, data: Option<&[u8]>) -> FrameObservat
     // Mirrors the translator's terminal handling (`"response.completed" |
     // "response.done"`, see also `docs/m1-responses-translation.md`): both
     // names carry the full `response` + `usage` and end the stream normally.
-    if !matches!(event, Some(b"response.completed") | Some(b"response.done")) {
+    // `response.incomplete` is terminal too, matching the terminal set the
+    // WebSocket transport already uses
+    // (`adapters::responses::codex_ws::TERMINAL_EVENTS`,
+    // `docs/m7-codex-websocket.md`): the backend explicitly concluded the
+    // stream, just with truncated content, not a transport cut — classifying
+    // it as `UpstreamCut` would misreport a genuine (if incomplete) response
+    // as a mid-stream failure.
+    if !matches!(
+        event,
+        Some(b"response.completed") | Some(b"response.done") | Some(b"response.incomplete")
+    ) {
         return FrameObservation::default();
     }
     let mut tokens = TokenUsage::default();

--- a/src/stream_metrics.rs
+++ b/src/stream_metrics.rs
@@ -21,6 +21,18 @@ use serde_json::Value;
 
 const MAX_EVENT_BYTES: usize = 256 * 1024;
 
+/// Injected by `adapters::responses::http::stream_response` as a standalone
+/// SSE comment frame immediately before a synthesized completion, whenever
+/// `AnthropicSseMachine::finish` only produced output because the upstream
+/// connection ended before a real terminal/error event was seen (that
+/// adapter is the only caller of `finish()` on the streaming path). SSE
+/// comment lines (`:`-prefixed) are ignored by every conforming client per
+/// the WHATWG EventSource spec, so real clients never see this — only this
+/// observer's own frame parser does, letting `outcome` classify the result
+/// as `UpstreamCut` instead of `Completed` despite the well-formed
+/// `message_stop` that follows it.
+pub(crate) const UPSTREAM_TRUNCATED_MARKER: &[u8] = b":shunt-upstream-truncated";
+
 /// Client-facing SSE protocol used to interpret terminal and usage events.
 #[derive(Clone, Copy, Debug)]
 pub enum Protocol {
@@ -95,6 +107,10 @@ struct ObserverState {
     skip_tail_len: usize,
     terminal_seen: bool,
     error_seen: bool,
+    /// Set once the [`UPSTREAM_TRUNCATED_MARKER`] frame is observed; forces
+    /// `outcome` to classify the stream as `UpstreamCut` even though the
+    /// synthesized completion that follows also sets `terminal_seen`.
+    truncated_seen: bool,
     tokens: TokenUsage,
     finished: bool,
 }
@@ -122,6 +138,7 @@ impl ObserverState {
             skip_tail_len: 0,
             terminal_seen: false,
             error_seen: false,
+            truncated_seen: false,
             tokens: TokenUsage::default(),
             finished: false,
         }
@@ -165,6 +182,7 @@ impl ObserverState {
             let observation = observe_frame(self.protocol, &self.buffer[..boundary]);
             self.terminal_seen |= observation.terminal;
             self.error_seen |= observation.error;
+            self.truncated_seen |= observation.truncated;
             merge_tokens(&mut self.tokens, observation.tokens);
             self.buffer.drain(..end);
         }
@@ -202,6 +220,13 @@ impl ObserverState {
     fn outcome(&self, natural_end: bool) -> Outcome {
         if self.error_seen {
             Outcome::ErrorEvent
+        } else if self.truncated_seen {
+            // Checked ahead of `terminal_seen`: the adapter-synthesized
+            // completion that follows the marker also sets `terminal_seen`,
+            // but the marker's presence means this "terminal" event was
+            // manufactured to keep the client stream well-formed after a
+            // real upstream cut, not a genuine backend completion.
+            Outcome::UpstreamCut
         } else if self.terminal_seen {
             Outcome::Completed
         } else if natural_end {
@@ -250,10 +275,19 @@ impl ObserverState {
 struct FrameObservation {
     terminal: bool,
     error: bool,
+    /// Set only for the [`UPSTREAM_TRUNCATED_MARKER`] comment frame.
+    truncated: bool,
     tokens: TokenUsage,
 }
 
 fn observe_frame(protocol: Protocol, frame: &[u8]) -> FrameObservation {
+    if frame == UPSTREAM_TRUNCATED_MARKER {
+        return FrameObservation {
+            truncated: true,
+            ..Default::default()
+        };
+    }
+
     let (event, data) = event_and_data(frame);
     if event == Some(b"ping") || data == Some(b"{\"type\": \"ping\"}") {
         return FrameObservation::default();

--- a/src/stream_metrics.rs
+++ b/src/stream_metrics.rs
@@ -14,7 +14,7 @@ use std::{
 
 use axum::{
     body::{Body, Bytes},
-    http::{header::CONTENT_TYPE, Response},
+    http::{header::CONTENT_TYPE, Response, StatusCode},
 };
 use futures_util::{Stream, StreamExt};
 use serde_json::Value;
@@ -73,6 +73,14 @@ struct ObserverState {
     provider: String,
     model: String,
     started_at: Instant,
+    // The upstream response status the stream opened with. `finish` gates
+    // `record_stream_failure` on this being 2xx: a non-2xx SSE response was
+    // already recorded/captured at header time
+    // (`observability::record_span_outcome` / `capture_upstream_outcome`), so
+    // a mid-stream failure event on top of it would double-report the same
+    // failure and contradicts the "answered 200 then failed" scope this
+    // module documents (see the module docs).
+    status: StatusCode,
     // Held for the lifetime of the stream so a mid-stream failure can still
     // record onto the request's own span (`crate::observability::record_stream_failure`)
     // — cloning a `tracing::Span` bumps its ref count, deferring `on_close`
@@ -94,6 +102,7 @@ struct ObserverState {
 impl ObserverState {
     fn new(
         protocol: Protocol,
+        status: StatusCode,
         provider: String,
         model: String,
         started_at: Instant,
@@ -104,6 +113,7 @@ impl ObserverState {
             provider,
             model,
             started_at,
+            status,
             span,
             first_chunk_seen: false,
             buffer: Vec::with_capacity(4096),
@@ -208,13 +218,20 @@ impl ObserverState {
         self.finished = true;
         let outcome = self.outcome(natural_end);
         crate::metrics::record_stream_outcome(&self.provider, &self.model, outcome.as_str());
-        if let Some(failure) = outcome.as_stream_failure() {
-            crate::observability::record_stream_failure(
-                &self.span,
-                &self.provider,
-                &self.model,
-                failure,
-            );
+        // Only a stream that actually opened `200` can have "failed mid-stream"
+        // in the sense this reports: a non-2xx response was already recorded
+        // at header time (`record_span_outcome` / `capture_upstream_outcome`),
+        // so reporting again here would double the Sentry signal for the same
+        // upstream failure (see the `status` field doc comment).
+        if self.status.is_success() {
+            if let Some(failure) = outcome.as_stream_failure() {
+                crate::observability::record_stream_failure(
+                    &self.span,
+                    &self.provider,
+                    &self.model,
+                    failure,
+                );
+            }
         }
         for (kind, count) in [
             ("input", self.tokens.input),
@@ -289,13 +306,19 @@ fn observe_responses(event: Option<&[u8]>, data: Option<&[u8]>) -> FrameObservat
             ..Default::default()
         };
     }
-    if event == Some(b"response.failed") {
+    // Mirrors the Responses translator's own error handling
+    // (`model::responses::AnthropicSseMachine::apply`, `"error" | "response.failed"`):
+    // both event names terminate the backend stream with an error.
+    if matches!(event, Some(b"error") | Some(b"response.failed")) {
         return FrameObservation {
             error: true,
             ..Default::default()
         };
     }
-    if event != Some(b"response.completed") {
+    // Mirrors the translator's terminal handling (`"response.completed" |
+    // "response.done"`, see also `docs/m1-responses-translation.md`): both
+    // names carry the full `response` + `usage` and end the stream normally.
+    if !matches!(event, Some(b"response.completed") | Some(b"response.done")) {
         return FrameObservation::default();
     }
     let mut tokens = TokenUsage::default();
@@ -370,6 +393,7 @@ pub fn observe_response(
     if !is_sse(&response) {
         return response;
     }
+    let status = response.status();
     // Captured here, synchronously inside the caller's `.instrument(span)`
     // future (`proxy::post` / `codex_endpoint::post`), so this resolves to
     // the request's own span — by the time the stream is actually polled,
@@ -379,7 +403,7 @@ pub fn observe_response(
     let (parts, body) = response.into_parts();
     let observed = ObservedStream {
         upstream: body.into_data_stream().boxed(),
-        state: ObserverState::new(protocol, provider, model, started_at, span),
+        state: ObserverState::new(protocol, status, provider, model, started_at, span),
     };
     Response::from_parts(parts, Body::from_stream(observed))
 }

--- a/src/stream_metrics.rs
+++ b/src/stream_metrics.rs
@@ -45,6 +45,19 @@ impl Outcome {
             Self::ClientDisconnect => "client_disconnect",
         }
     }
+
+    /// The [`crate::observability::StreamFailureKind`] counterpart to this
+    /// outcome, for [`crate::observability::record_stream_failure`] — `None`
+    /// for `Completed`/`ClientDisconnect`, which are not upstream failures (a
+    /// natural end and a client hangup are not root-causeable events; see
+    /// `ObserverState::finish`).
+    fn as_stream_failure(self) -> Option<crate::observability::StreamFailureKind> {
+        match self {
+            Self::ErrorEvent => Some(crate::observability::StreamFailureKind::ErrorEvent),
+            Self::UpstreamCut => Some(crate::observability::StreamFailureKind::UpstreamCut),
+            Self::Completed | Self::ClientDisconnect => None,
+        }
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -60,6 +73,13 @@ struct ObserverState {
     provider: String,
     model: String,
     started_at: Instant,
+    // Held for the lifetime of the stream so a mid-stream failure can still
+    // record onto the request's own span (`crate::observability::record_stream_failure`)
+    // — cloning a `tracing::Span` bumps its ref count, deferring `on_close`
+    // (and the OTel/Sentry export it triggers) until this state is dropped.
+    // See `crate::observability`'s module docs for why this is the only
+    // reliable way to reach the span from here.
+    span: tracing::Span,
     first_chunk_seen: bool,
     buffer: Vec<u8>,
     skipping_oversized: bool,
@@ -72,12 +92,19 @@ struct ObserverState {
 }
 
 impl ObserverState {
-    fn new(protocol: Protocol, provider: String, model: String, started_at: Instant) -> Self {
+    fn new(
+        protocol: Protocol,
+        provider: String,
+        model: String,
+        started_at: Instant,
+        span: tracing::Span,
+    ) -> Self {
         Self {
             protocol,
             provider,
             model,
             started_at,
+            span,
             first_chunk_seen: false,
             buffer: Vec::with_capacity(4096),
             skipping_oversized: false,
@@ -179,11 +206,16 @@ impl ObserverState {
             return;
         }
         self.finished = true;
-        crate::metrics::record_stream_outcome(
-            &self.provider,
-            &self.model,
-            self.outcome(natural_end).as_str(),
-        );
+        let outcome = self.outcome(natural_end);
+        crate::metrics::record_stream_outcome(&self.provider, &self.model, outcome.as_str());
+        if let Some(failure) = outcome.as_stream_failure() {
+            crate::observability::record_stream_failure(
+                &self.span,
+                &self.provider,
+                &self.model,
+                failure,
+            );
+        }
         for (kind, count) in [
             ("input", self.tokens.input),
             ("output", self.tokens.output),
@@ -338,10 +370,16 @@ pub fn observe_response(
     if !is_sse(&response) {
         return response;
     }
+    // Captured here, synchronously inside the caller's `.instrument(span)`
+    // future (`proxy::post` / `codex_endpoint::post`), so this resolves to
+    // the request's own span — by the time the stream is actually polled,
+    // that future has already returned and `tracing::Span::current()` would
+    // no longer find it. See `crate::observability`'s module docs.
+    let span = tracing::Span::current();
     let (parts, body) = response.into_parts();
     let observed = ObservedStream {
         upstream: body.into_data_stream().boxed(),
-        state: ObserverState::new(protocol, provider, model, started_at),
+        state: ObserverState::new(protocol, provider, model, started_at, span),
     };
     Response::from_parts(parts, Body::from_stream(observed))
 }

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -7,7 +7,7 @@ use std::{
 
 use axum::{
     body::{to_bytes, Body, Bytes},
-    http::{header::CONTENT_TYPE, Response},
+    http::{header::CONTENT_TYPE, Response, StatusCode},
 };
 use futures_util::{future::FutureExt, stream, StreamExt};
 use serde_json::json;
@@ -21,6 +21,7 @@ use super::{observe_response, ObserverState, Outcome, Protocol, MAX_EVENT_BYTES}
 fn state(protocol: Protocol) -> ObserverState {
     ObserverState::new(
         protocol,
+        StatusCode::OK,
         "provider".to_string(),
         "model".to_string(),
         Instant::now(),
@@ -196,6 +197,40 @@ fn responses_failure_is_an_error_event() {
 }
 
 #[test]
+fn responses_error_event_is_an_error_event() {
+    // `AnthropicSseMachine::apply` (src/model/responses.rs) treats `"error"`
+    // and `"response.failed"` identically — both terminate the backend
+    // stream with an error, so the observer must too.
+    let mut observer = state(Protocol::Responses);
+    observer.push_bytes(b"event: error\ndata: {\"type\":\"error\"}\n\n");
+    assert_eq!(observer.outcome(true), Outcome::ErrorEvent);
+}
+
+#[test]
+fn responses_done_event_is_terminal_and_carries_usage() {
+    // `AnthropicSseMachine::apply` treats `"response.completed"` and
+    // `"response.done"` identically (see also
+    // docs/m1-responses-translation.md) — both carry the full `response` +
+    // `usage` and end the stream normally.
+    let mut observer = state(Protocol::Responses);
+    observer.push_bytes(
+        format!(
+            "event: response.done\ndata: {}\n\n",
+            json!({"type": "response.done", "response": {"usage": {
+                "input_tokens": 30,
+                "output_tokens": 12,
+                "input_tokens_details": {"cached_tokens": 7}
+            }}})
+        )
+        .as_bytes(),
+    );
+    assert_eq!(observer.tokens.input, Some(30));
+    assert_eq!(observer.tokens.output, Some(12));
+    assert_eq!(observer.tokens.cache_read, Some(7));
+    assert_eq!(observer.outcome(true), Outcome::Completed);
+}
+
+#[test]
 fn ping_and_content_deltas_are_ignored() {
     let mut observer = state(Protocol::Anthropic);
     observer.push_bytes(b"event: ping\ndata: {\"type\": \"ping\"}\n\n");
@@ -321,10 +356,15 @@ struct FinishWiring {
     event: Option<(sentry::Level, &'static str)>,
 }
 
-/// Runs one wiring case: wrap an SSE response carrying `sse`, drive its body
-/// per `drive`, and assert the span field and the Sentry capture match
-/// `expected`.
-fn assert_finish_wiring(sse: &'static [u8], drive: Drive, expected: FinishWiring) {
+/// Runs one wiring case: wrap an SSE response with the given `status`
+/// carrying `sse`, drive its body per `drive`, and assert the span field and
+/// the Sentry capture match `expected`.
+fn assert_finish_wiring(
+    status: StatusCode,
+    sse: &'static [u8],
+    drive: Drive,
+    expected: FinishWiring,
+) {
     let captured = CapturingLayer::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
 
@@ -336,7 +376,10 @@ fn assert_finish_wiring(sse: &'static [u8], drive: Drive, expected: FinishWiring
             );
             let entered = span.enter();
             // Mirrors what `record_span_outcome` already recorded at
-            // response-header time for the 200 that opened this stream.
+            // response-header time for the status that opened this stream —
+            // `"ok"` for every case here, matching real `record_span_outcome`
+            // behavior for any non-5xx status (including the non-2xx case
+            // exercised below, e.g. 400).
             span.record("otel.status_code", "ok");
             let chunk = Ok::<_, Infallible>(Bytes::from_static(sse));
             let body = match drive {
@@ -346,6 +389,7 @@ fn assert_finish_wiring(sse: &'static [u8], drive: Drive, expected: FinishWiring
                 }
             };
             let response = Response::builder()
+                .status(status)
                 .header(CONTENT_TYPE, "text/event-stream")
                 .body(body)
                 .unwrap();
@@ -401,6 +445,7 @@ fn assert_finish_wiring(sse: &'static [u8], drive: Drive, expected: FinishWiring
 #[test]
 fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_event() {
     assert_finish_wiring(
+        StatusCode::OK,
         b"event: error\ndata: {}\n\n",
         Drive::ToEnd,
         FinishWiring {
@@ -418,6 +463,7 @@ fn finish_records_otel_error_and_emits_a_sentry_event_for_an_upstream_cut() {
     // A content delta with no terminal/error event, then the upstream simply
     // ends the stream (`natural_end = true`) — `UpstreamCut`.
     assert_finish_wiring(
+        StatusCode::OK,
         b"event: content_block_delta\ndata: {}\n\n",
         Drive::ToEnd,
         FinishWiring {
@@ -435,6 +481,7 @@ fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
     // Untouched since header time: `record_stream_failure` never runs, so the
     // field still holds whatever the (simulated) header-time call recorded.
     assert_finish_wiring(
+        StatusCode::OK,
         b"event: message_stop\ndata: {}\n\n",
         Drive::ToEnd,
         FinishWiring {
@@ -447,8 +494,27 @@ fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
 #[test]
 fn finish_does_not_touch_the_span_or_emit_an_event_for_a_client_disconnect() {
     assert_finish_wiring(
+        StatusCode::OK,
         b"event: content_block_delta\ndata: {}\n\n",
         Drive::DropAfterFirstChunk,
+        FinishWiring {
+            span_status: "ok",
+            event: None,
+        },
+    );
+}
+
+#[test]
+fn finish_does_not_report_a_stream_failure_for_a_non_2xx_response() {
+    // A non-2xx SSE response is already recorded/captured at header time
+    // (`record_span_outcome` / `capture_upstream_outcome`); reporting a
+    // mid-stream failure on top of it would double-report the same failure.
+    // Content that would otherwise read as `UpstreamCut` must not touch the
+    // span or emit a Sentry event when the response never opened `200`.
+    assert_finish_wiring(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        b"event: content_block_delta\ndata: {}\n\n",
+        Drive::ToEnd,
         FinishWiring {
             span_status: "ok",
             event: None,

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -1,11 +1,20 @@
-use std::{convert::Infallible, time::Instant};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 use axum::{
     body::{to_bytes, Body, Bytes},
     http::{header::CONTENT_TYPE, Response},
 };
-use futures_util::{stream, StreamExt};
+use futures_util::{future::FutureExt, stream, StreamExt};
 use serde_json::json;
+use tracing_subscriber::{
+    layer::{Context as LayerContext, SubscriberExt},
+    Layer,
+};
 
 use super::{observe_response, ObserverState, Outcome, Protocol, MAX_EVENT_BYTES};
 
@@ -15,7 +24,46 @@ fn state(protocol: Protocol) -> ObserverState {
         "provider".to_string(),
         "model".to_string(),
         Instant::now(),
+        tracing::Span::none(),
     )
+}
+
+/// A `Visit` that stringifies every recorded field into a shared map — the
+/// same pattern `observability::tests` uses to assert on `Span::record`
+/// calls independent of any particular exporter. Duplicated here rather than
+/// shared: `observability`'s copy is private to its own `#[cfg(test)]`
+/// module.
+struct CapturingVisitor<'a>(&'a mut HashMap<String, String>);
+
+impl tracing::field::Visit for CapturingVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+}
+
+/// A minimal `Layer` that records every `Span::record(...)` call into a
+/// shared map, so a test can assert `ObserverState::finish` actually reached
+/// `crate::observability::record_stream_failure`'s `span.record(...)` call
+/// through the real `observe_response` → stream-poll → `finish` path, not
+/// just by calling the function directly.
+#[derive(Clone, Default)]
+struct CapturingLayer(Arc<Mutex<HashMap<String, String>>>);
+
+impl<S: tracing::Subscriber> Layer<S> for CapturingLayer {
+    fn on_record(
+        &self,
+        _id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        _ctx: LayerContext<'_, S>,
+    ) {
+        let mut map = self.0.lock().expect("capturing layer mutex poisoned");
+        values.record(&mut CapturingVisitor(&mut map));
+    }
 }
 
 fn anth_event(name: &str, data: serde_json::Value) -> String {
@@ -233,6 +281,241 @@ async fn dropping_body_mid_stream_exercises_client_disconnect_path() {
         Bytes::from_static(b"event: content_block_delta\ndata: {}\n\n")
     );
     drop(body_stream);
+}
+
+// `ObserverState::finish` is the only caller of
+// `crate::observability::record_stream_failure` (see `finish` and
+// `Outcome::as_stream_failure`); these tests exercise it through the real
+// `observe_response` → stream-poll → `finish` path (not by calling the
+// observability function directly — that is covered in
+// `observability::tests`) to prove the wiring itself: the hook fires for
+// `ErrorEvent`/`UpstreamCut` and not for `Completed`/`ClientDisconnect`. Each
+// test uses a plain `#[test]` (not `#[tokio::test]`) and drains the mock body
+// with `.now_or_never()`: none of these mock streams ever produce a genuine
+// `Poll::Pending`, so a single poll always resolves them, which keeps the
+// capturing tracing subscriber and the captured-Sentry-events hub in scope
+// for the whole synchronous call — both are thread-local / dynamic-scoped,
+// so nesting an `.await` inside would require a second, real executor.
+
+#[test]
+fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_event() {
+    let captured = CapturingLayer::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+    let events = tracing::subscriber::with_default(subscriber, || {
+        sentry::test::with_captured_events(|| {
+            let span = tracing::info_span!(
+                "test_stream_request",
+                otel.status_code = tracing::field::Empty
+            );
+            let entered = span.enter();
+            // Mirrors what `record_span_outcome` already recorded at
+            // response-header time for the 200 that opened this stream.
+            span.record("otel.status_code", "ok");
+            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
+                b"event: error
+data: {}
+
+",
+            ))];
+            let response = Response::builder()
+                .header(CONTENT_TYPE, "text/event-stream")
+                .body(Body::from_stream(stream::iter(chunks)))
+                .unwrap();
+            let wrapped = observe_response(
+                response,
+                Protocol::Anthropic,
+                "provider".to_string(),
+                "model".to_string(),
+                Instant::now(),
+            );
+            drop(entered);
+
+            to_bytes(wrapped.into_body(), usize::MAX)
+                .now_or_never()
+                .expect("mock stream resolves without a real pending state")
+                .unwrap();
+        })
+    });
+
+    let fields = captured.0.lock().unwrap();
+    assert_eq!(
+        fields.get("otel.status_code").map(String::as_str),
+        Some("error"),
+        "a mid-stream error event must overwrite the header-time \"ok\""
+    );
+    drop(fields);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].level, sentry::Level::Error);
+    assert_eq!(
+        events[0].message.as_deref(),
+        Some("upstream SSE stream sent an error event mid-stream")
+    );
+}
+
+#[test]
+fn finish_records_otel_error_and_emits_a_sentry_event_for_an_upstream_cut() {
+    let captured = CapturingLayer::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+    let events = tracing::subscriber::with_default(subscriber, || {
+        sentry::test::with_captured_events(|| {
+            let span = tracing::info_span!(
+                "test_stream_request",
+                otel.status_code = tracing::field::Empty
+            );
+            let entered = span.enter();
+            span.record("otel.status_code", "ok");
+            // A content delta with no terminal/error event, then the upstream
+            // simply ends the stream (`natural_end = true`) — `UpstreamCut`.
+            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
+                b"event: content_block_delta
+data: {}
+
+",
+            ))];
+            let response = Response::builder()
+                .header(CONTENT_TYPE, "text/event-stream")
+                .body(Body::from_stream(stream::iter(chunks)))
+                .unwrap();
+            let wrapped = observe_response(
+                response,
+                Protocol::Anthropic,
+                "provider".to_string(),
+                "model".to_string(),
+                Instant::now(),
+            );
+            drop(entered);
+
+            to_bytes(wrapped.into_body(), usize::MAX)
+                .now_or_never()
+                .expect("mock stream resolves without a real pending state")
+                .unwrap();
+        })
+    });
+
+    let fields = captured.0.lock().unwrap();
+    assert_eq!(
+        fields.get("otel.status_code").map(String::as_str),
+        Some("error")
+    );
+    drop(fields);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].level, sentry::Level::Warning);
+    assert_eq!(
+        events[0].message.as_deref(),
+        Some("upstream SSE stream was cut before a terminal event")
+    );
+}
+
+#[test]
+fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
+    let captured = CapturingLayer::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+    let events = tracing::subscriber::with_default(subscriber, || {
+        sentry::test::with_captured_events(|| {
+            let span = tracing::info_span!(
+                "test_stream_request",
+                otel.status_code = tracing::field::Empty
+            );
+            let entered = span.enter();
+            span.record("otel.status_code", "ok");
+            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
+                b"event: message_stop
+data: {}
+
+",
+            ))];
+            let response = Response::builder()
+                .header(CONTENT_TYPE, "text/event-stream")
+                .body(Body::from_stream(stream::iter(chunks)))
+                .unwrap();
+            let wrapped = observe_response(
+                response,
+                Protocol::Anthropic,
+                "provider".to_string(),
+                "model".to_string(),
+                Instant::now(),
+            );
+            drop(entered);
+
+            to_bytes(wrapped.into_body(), usize::MAX)
+                .now_or_never()
+                .expect("mock stream resolves without a real pending state")
+                .unwrap();
+        })
+    });
+
+    let fields = captured.0.lock().unwrap();
+    // Untouched since header time: `record_stream_failure` never ran, so the
+    // field still holds whatever the (simulated) header-time call recorded.
+    assert_eq!(
+        fields.get("otel.status_code").map(String::as_str),
+        Some("ok")
+    );
+    drop(fields);
+
+    assert!(events.is_empty());
+}
+
+#[test]
+fn finish_does_not_touch_the_span_or_emit_an_event_for_a_client_disconnect() {
+    let captured = CapturingLayer::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+    let events = tracing::subscriber::with_default(subscriber, || {
+        sentry::test::with_captured_events(|| {
+            let span = tracing::info_span!(
+                "test_stream_request",
+                otel.status_code = tracing::field::Empty
+            );
+            let entered = span.enter();
+            span.record("otel.status_code", "ok");
+            let first = Ok::<_, Infallible>(Bytes::from_static(
+                b"event: content_block_delta
+data: {}
+
+",
+            ));
+            let upstream = stream::once(async { first }).chain(stream::pending());
+            let response = Response::builder()
+                .header(CONTENT_TYPE, "text/event-stream")
+                .body(Body::from_stream(upstream))
+                .unwrap();
+            let wrapped = observe_response(
+                response,
+                Protocol::Anthropic,
+                "provider".to_string(),
+                "model".to_string(),
+                Instant::now(),
+            );
+            drop(entered);
+
+            let mut body_stream = wrapped.into_body().into_data_stream();
+            body_stream
+                .next()
+                .now_or_never()
+                .expect("first chunk is ready without a real pending state")
+                .unwrap()
+                .unwrap();
+            // Dropped before the upstream ever ends (`stream::pending()` never
+            // resolves) — this is the client-disconnect path, exercised via
+            // `ObservedStream`'s `Drop` impl calling `finish(false)`.
+            drop(body_stream);
+        })
+    });
+
+    let fields = captured.0.lock().unwrap();
+    assert_eq!(
+        fields.get("otel.status_code").map(String::as_str),
+        Some("ok")
+    );
+    drop(fields);
+
+    assert!(events.is_empty());
 }
 
 #[tokio::test]

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -248,6 +248,34 @@ fn responses_done_event_is_terminal_and_carries_usage() {
 }
 
 #[test]
+fn responses_incomplete_event_is_terminal_and_carries_usage() {
+    // The WebSocket transport's terminal set
+    // (`adapters::responses::codex_ws::TERMINAL_EVENTS`, also
+    // docs/m7-codex-websocket.md) treats `"response.incomplete"` as a clean
+    // (if truncated) end of the stream, not a transport cut — the observer
+    // must classify it as `Completed`, not `UpstreamCut`.
+    let mut observer = state(Protocol::Responses);
+    observer.push_bytes(
+        format!(
+            "event: response.incomplete
+data: {}
+
+",
+            json!({"type": "response.incomplete", "response": {"usage": {
+                "input_tokens": 30,
+                "output_tokens": 12,
+                "input_tokens_details": {"cached_tokens": 7}
+            }}})
+        )
+        .as_bytes(),
+    );
+    assert_eq!(observer.tokens.input, Some(30));
+    assert_eq!(observer.tokens.output, Some(12));
+    assert_eq!(observer.tokens.cache_read, Some(7));
+    assert_eq!(observer.outcome(true), Outcome::Completed);
+}
+
+#[test]
 fn ping_and_content_deltas_are_ignored() {
     let mut observer = state(Protocol::Anthropic);
     observer.push_bytes(b"event: ping\ndata: {\"type\": \"ping\"}\n\n");
@@ -373,10 +401,16 @@ struct FinishWiring {
     event: Option<(sentry::Level, &'static str)>,
 }
 
-/// Runs one wiring case: wrap an SSE response with the given `status`
-/// carrying `sse`, drive its body per `drive`, and assert the span field and
-/// the Sentry capture match `expected`.
-fn assert_finish_wiring(status: StatusCode, sse: &[u8], drive: Drive, expected: FinishWiring) {
+/// Runs one wiring case: wrap an SSE response with the given `protocol` and
+/// `status` carrying `sse`, drive its body per `drive`, and assert the span
+/// field and the Sentry capture match `expected`.
+fn assert_finish_wiring(
+    protocol: Protocol,
+    status: StatusCode,
+    sse: &[u8],
+    drive: Drive,
+    expected: FinishWiring,
+) {
     let captured = CapturingLayer::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
 
@@ -407,7 +441,7 @@ fn assert_finish_wiring(status: StatusCode, sse: &[u8], drive: Drive, expected: 
                 .unwrap();
             let wrapped = observe_response(
                 response,
-                Protocol::Anthropic,
+                protocol,
                 "provider".to_string(),
                 "model".to_string(),
                 Instant::now(),
@@ -457,6 +491,7 @@ fn assert_finish_wiring(status: StatusCode, sse: &[u8], drive: Drive, expected: 
 #[test]
 fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_event() {
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::OK,
         b"event: error\ndata: {}\n\n",
         Drive::ToEnd,
@@ -475,6 +510,7 @@ fn finish_records_otel_error_and_emits_a_sentry_event_for_an_upstream_cut() {
     // A content delta with no terminal/error event, then the upstream simply
     // ends the stream (`natural_end = true`) — `UpstreamCut`.
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::OK,
         b"event: content_block_delta\ndata: {}\n\n",
         Drive::ToEnd,
@@ -502,6 +538,7 @@ fn finish_reports_an_upstream_cut_for_a_marked_synthetic_completion() {
     ]
     .concat();
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::OK,
         &sse,
         Drive::ToEnd,
@@ -520,6 +557,7 @@ fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
     // Untouched since header time: `record_stream_failure` never runs, so the
     // field still holds whatever the (simulated) header-time call recorded.
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::OK,
         b"event: message_stop\ndata: {}\n\n",
         Drive::ToEnd,
@@ -533,6 +571,7 @@ fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
 #[test]
 fn finish_does_not_touch_the_span_or_emit_an_event_for_a_client_disconnect() {
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::OK,
         b"event: content_block_delta\ndata: {}\n\n",
         Drive::DropAfterFirstChunk,
@@ -551,8 +590,27 @@ fn finish_does_not_report_a_stream_failure_for_a_non_2xx_response() {
     // Content that would otherwise read as `UpstreamCut` must not touch the
     // span or emit a Sentry event when the response never opened `200`.
     assert_finish_wiring(
+        Protocol::Anthropic,
         StatusCode::INTERNAL_SERVER_ERROR,
         b"event: content_block_delta\ndata: {}\n\n",
+        Drive::ToEnd,
+        FinishWiring {
+            span_status: "ok",
+            event: None,
+        },
+    );
+}
+
+#[test]
+fn finish_does_not_touch_the_span_or_emit_an_event_for_an_incomplete_responses_completion() {
+    // A raw Responses-protocol relay (the inbound Codex endpoint) that ends
+    // with `response.incomplete` concluded cleanly, just with truncated
+    // content — it must not read as an `UpstreamCut` and must not emit the
+    // "cut before a terminal event" Sentry warning.
+    assert_finish_wiring(
+        Protocol::Responses,
+        StatusCode::OK,
+        b"event: response.incomplete\ndata: {}\n\n",
         Drive::ToEnd,
         FinishWiring {
             span_status: "ok",

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -180,13 +180,16 @@ fn upstream_truncated_marker_forces_upstream_cut_even_with_a_terminal_event() {
     assert_eq!(observer.outcome(false), Outcome::UpstreamCut);
 }
 
-#[test]
-fn parses_responses_completion_usage_and_done() {
+/// Pushes a `response.*` SSE frame named `event` carrying `usage` through a
+/// fresh `Protocol::Responses` observer and asserts token extraction plus a
+/// `Completed` outcome — the shared shape of every clean Responses terminal
+/// (`response.completed`, `response.done`, `response.incomplete`).
+fn assert_terminal_with_usage(event: &str) {
     let mut observer = state(Protocol::Responses);
     observer.push_bytes(
         format!(
-            "event: response.completed\ndata: {}\n\n",
-            json!({"type": "response.completed", "response": {"usage": {
+            "event: {event}\ndata: {}\n\n",
+            json!({"type": event, "response": {"usage": {
                 "input_tokens": 30,
                 "output_tokens": 12,
                 "input_tokens_details": {"cached_tokens": 7}
@@ -200,6 +203,11 @@ fn parses_responses_completion_usage_and_done() {
     assert_eq!(observer.tokens.cache_read, Some(7));
     assert_eq!(observer.tokens.cache_creation, None);
     assert_eq!(observer.outcome(true), Outcome::Completed);
+}
+
+#[test]
+fn parses_responses_completion_usage_and_done() {
+    assert_terminal_with_usage("response.completed");
 
     let mut done = state(Protocol::Responses);
     done.push_bytes(b"data: [DONE]\n\n");
@@ -229,22 +237,7 @@ fn responses_done_event_is_terminal_and_carries_usage() {
     // `"response.done"` identically (see also
     // docs/m1-responses-translation.md) — both carry the full `response` +
     // `usage` and end the stream normally.
-    let mut observer = state(Protocol::Responses);
-    observer.push_bytes(
-        format!(
-            "event: response.done\ndata: {}\n\n",
-            json!({"type": "response.done", "response": {"usage": {
-                "input_tokens": 30,
-                "output_tokens": 12,
-                "input_tokens_details": {"cached_tokens": 7}
-            }}})
-        )
-        .as_bytes(),
-    );
-    assert_eq!(observer.tokens.input, Some(30));
-    assert_eq!(observer.tokens.output, Some(12));
-    assert_eq!(observer.tokens.cache_read, Some(7));
-    assert_eq!(observer.outcome(true), Outcome::Completed);
+    assert_terminal_with_usage("response.done");
 }
 
 #[test]
@@ -254,25 +247,7 @@ fn responses_incomplete_event_is_terminal_and_carries_usage() {
     // docs/m7-codex-websocket.md) treats `"response.incomplete"` as a clean
     // (if truncated) end of the stream, not a transport cut — the observer
     // must classify it as `Completed`, not `UpstreamCut`.
-    let mut observer = state(Protocol::Responses);
-    observer.push_bytes(
-        format!(
-            "event: response.incomplete
-data: {}
-
-",
-            json!({"type": "response.incomplete", "response": {"usage": {
-                "input_tokens": 30,
-                "output_tokens": 12,
-                "input_tokens_details": {"cached_tokens": 7}
-            }}})
-        )
-        .as_bytes(),
-    );
-    assert_eq!(observer.tokens.input, Some(30));
-    assert_eq!(observer.tokens.output, Some(12));
-    assert_eq!(observer.tokens.cache_read, Some(7));
-    assert_eq!(observer.outcome(true), Outcome::Completed);
+    assert_terminal_with_usage("response.incomplete");
 }
 
 #[test]

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -297,8 +297,34 @@ async fn dropping_body_mid_stream_exercises_client_disconnect_path() {
 // for the whole synchronous call — both are thread-local / dynamic-scoped,
 // so nesting an `.await` inside would require a second, real executor.
 
-#[test]
-fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_event() {
+/// How the wrapped body is driven — the only axis, besides the SSE bytes and
+/// the expectation, on which the `finish` wiring cases differ.
+#[derive(Clone, Copy)]
+enum Drive {
+    /// Forward the mock stream to its end, so `finish` sees a natural end.
+    ToEnd,
+    /// Read the first chunk, then drop the body while the upstream is still
+    /// open (`stream::pending()` never resolves) — the client-disconnect path,
+    /// exercised via `ObservedStream`'s `Drop` impl calling `finish(false)`.
+    DropAfterFirstChunk,
+}
+
+/// What `ObserverState::finish` must have wired up once the stream is over.
+struct FinishWiring {
+    /// The `otel.status_code` the request span carries afterwards. Every case
+    /// starts from `"ok"`, mirroring what `record_span_outcome` recorded at
+    /// response-header time for the `200` that opened the stream: a mid-stream
+    /// failure has to overwrite it, anything else has to leave it untouched.
+    span_status: &'static str,
+    /// The single Sentry event `record_stream_failure` emits, or `None` when
+    /// the outcome is not a failure and nothing at all may be captured.
+    event: Option<(sentry::Level, &'static str)>,
+}
+
+/// Runs one wiring case: wrap an SSE response carrying `sse`, drive its body
+/// per `drive`, and assert the span field and the Sentry capture match
+/// `expected`.
+fn assert_finish_wiring(sse: &'static [u8], drive: Drive, expected: FinishWiring) {
     let captured = CapturingLayer::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
 
@@ -312,15 +338,16 @@ fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_eve
             // Mirrors what `record_span_outcome` already recorded at
             // response-header time for the 200 that opened this stream.
             span.record("otel.status_code", "ok");
-            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
-                b"event: error
-data: {}
-
-",
-            ))];
+            let chunk = Ok::<_, Infallible>(Bytes::from_static(sse));
+            let body = match drive {
+                Drive::ToEnd => Body::from_stream(stream::iter(vec![chunk])),
+                Drive::DropAfterFirstChunk => {
+                    Body::from_stream(stream::once(async { chunk }).chain(stream::pending()))
+                }
+            };
             let response = Response::builder()
                 .header(CONTENT_TYPE, "text/event-stream")
-                .body(Body::from_stream(stream::iter(chunks)))
+                .body(body)
                 .unwrap();
             let wrapped = observe_response(
                 response,
@@ -331,191 +358,102 @@ data: {}
             );
             drop(entered);
 
-            to_bytes(wrapped.into_body(), usize::MAX)
-                .now_or_never()
-                .expect("mock stream resolves without a real pending state")
-                .unwrap();
+            match drive {
+                Drive::ToEnd => {
+                    to_bytes(wrapped.into_body(), usize::MAX)
+                        .now_or_never()
+                        .expect("mock stream resolves without a real pending state")
+                        .unwrap();
+                }
+                Drive::DropAfterFirstChunk => {
+                    let mut body_stream = wrapped.into_body().into_data_stream();
+                    body_stream
+                        .next()
+                        .now_or_never()
+                        .expect("first chunk is ready without a real pending state")
+                        .unwrap()
+                        .unwrap();
+                    drop(body_stream);
+                }
+            }
         })
     });
 
     let fields = captured.0.lock().unwrap();
     assert_eq!(
         fields.get("otel.status_code").map(String::as_str),
-        Some("error"),
-        "a mid-stream error event must overwrite the header-time \"ok\""
+        Some(expected.span_status),
+        "finish must leave otel.status_code as {:?}, which header time recorded as \"ok\"",
+        expected.span_status
     );
     drop(fields);
 
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].level, sentry::Level::Error);
-    assert_eq!(
-        events[0].message.as_deref(),
-        Some("upstream SSE stream sent an error event mid-stream")
+    match expected.event {
+        Some((level, message)) => {
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].level, level);
+            assert_eq!(events[0].message.as_deref(), Some(message));
+        }
+        None => assert!(events.is_empty()),
+    }
+}
+
+#[test]
+fn finish_records_otel_error_and_emits_a_sentry_event_for_a_mid_stream_error_event() {
+    assert_finish_wiring(
+        b"event: error\ndata: {}\n\n",
+        Drive::ToEnd,
+        FinishWiring {
+            span_status: "error",
+            event: Some((
+                sentry::Level::Error,
+                "upstream SSE stream sent an error event mid-stream",
+            )),
+        },
     );
 }
 
 #[test]
 fn finish_records_otel_error_and_emits_a_sentry_event_for_an_upstream_cut() {
-    let captured = CapturingLayer::default();
-    let subscriber = tracing_subscriber::registry().with(captured.clone());
-
-    let events = tracing::subscriber::with_default(subscriber, || {
-        sentry::test::with_captured_events(|| {
-            let span = tracing::info_span!(
-                "test_stream_request",
-                otel.status_code = tracing::field::Empty
-            );
-            let entered = span.enter();
-            span.record("otel.status_code", "ok");
-            // A content delta with no terminal/error event, then the upstream
-            // simply ends the stream (`natural_end = true`) — `UpstreamCut`.
-            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
-                b"event: content_block_delta
-data: {}
-
-",
-            ))];
-            let response = Response::builder()
-                .header(CONTENT_TYPE, "text/event-stream")
-                .body(Body::from_stream(stream::iter(chunks)))
-                .unwrap();
-            let wrapped = observe_response(
-                response,
-                Protocol::Anthropic,
-                "provider".to_string(),
-                "model".to_string(),
-                Instant::now(),
-            );
-            drop(entered);
-
-            to_bytes(wrapped.into_body(), usize::MAX)
-                .now_or_never()
-                .expect("mock stream resolves without a real pending state")
-                .unwrap();
-        })
-    });
-
-    let fields = captured.0.lock().unwrap();
-    assert_eq!(
-        fields.get("otel.status_code").map(String::as_str),
-        Some("error")
-    );
-    drop(fields);
-
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].level, sentry::Level::Warning);
-    assert_eq!(
-        events[0].message.as_deref(),
-        Some("upstream SSE stream was cut before a terminal event")
+    // A content delta with no terminal/error event, then the upstream simply
+    // ends the stream (`natural_end = true`) — `UpstreamCut`.
+    assert_finish_wiring(
+        b"event: content_block_delta\ndata: {}\n\n",
+        Drive::ToEnd,
+        FinishWiring {
+            span_status: "error",
+            event: Some((
+                sentry::Level::Warning,
+                "upstream SSE stream was cut before a terminal event",
+            )),
+        },
     );
 }
 
 #[test]
 fn finish_does_not_touch_the_span_or_emit_an_event_for_a_normal_completion() {
-    let captured = CapturingLayer::default();
-    let subscriber = tracing_subscriber::registry().with(captured.clone());
-
-    let events = tracing::subscriber::with_default(subscriber, || {
-        sentry::test::with_captured_events(|| {
-            let span = tracing::info_span!(
-                "test_stream_request",
-                otel.status_code = tracing::field::Empty
-            );
-            let entered = span.enter();
-            span.record("otel.status_code", "ok");
-            let chunks = vec![Ok::<_, Infallible>(Bytes::from_static(
-                b"event: message_stop
-data: {}
-
-",
-            ))];
-            let response = Response::builder()
-                .header(CONTENT_TYPE, "text/event-stream")
-                .body(Body::from_stream(stream::iter(chunks)))
-                .unwrap();
-            let wrapped = observe_response(
-                response,
-                Protocol::Anthropic,
-                "provider".to_string(),
-                "model".to_string(),
-                Instant::now(),
-            );
-            drop(entered);
-
-            to_bytes(wrapped.into_body(), usize::MAX)
-                .now_or_never()
-                .expect("mock stream resolves without a real pending state")
-                .unwrap();
-        })
-    });
-
-    let fields = captured.0.lock().unwrap();
-    // Untouched since header time: `record_stream_failure` never ran, so the
+    // Untouched since header time: `record_stream_failure` never runs, so the
     // field still holds whatever the (simulated) header-time call recorded.
-    assert_eq!(
-        fields.get("otel.status_code").map(String::as_str),
-        Some("ok")
+    assert_finish_wiring(
+        b"event: message_stop\ndata: {}\n\n",
+        Drive::ToEnd,
+        FinishWiring {
+            span_status: "ok",
+            event: None,
+        },
     );
-    drop(fields);
-
-    assert!(events.is_empty());
 }
 
 #[test]
 fn finish_does_not_touch_the_span_or_emit_an_event_for_a_client_disconnect() {
-    let captured = CapturingLayer::default();
-    let subscriber = tracing_subscriber::registry().with(captured.clone());
-
-    let events = tracing::subscriber::with_default(subscriber, || {
-        sentry::test::with_captured_events(|| {
-            let span = tracing::info_span!(
-                "test_stream_request",
-                otel.status_code = tracing::field::Empty
-            );
-            let entered = span.enter();
-            span.record("otel.status_code", "ok");
-            let first = Ok::<_, Infallible>(Bytes::from_static(
-                b"event: content_block_delta
-data: {}
-
-",
-            ));
-            let upstream = stream::once(async { first }).chain(stream::pending());
-            let response = Response::builder()
-                .header(CONTENT_TYPE, "text/event-stream")
-                .body(Body::from_stream(upstream))
-                .unwrap();
-            let wrapped = observe_response(
-                response,
-                Protocol::Anthropic,
-                "provider".to_string(),
-                "model".to_string(),
-                Instant::now(),
-            );
-            drop(entered);
-
-            let mut body_stream = wrapped.into_body().into_data_stream();
-            body_stream
-                .next()
-                .now_or_never()
-                .expect("first chunk is ready without a real pending state")
-                .unwrap()
-                .unwrap();
-            // Dropped before the upstream ever ends (`stream::pending()` never
-            // resolves) — this is the client-disconnect path, exercised via
-            // `ObservedStream`'s `Drop` impl calling `finish(false)`.
-            drop(body_stream);
-        })
-    });
-
-    let fields = captured.0.lock().unwrap();
-    assert_eq!(
-        fields.get("otel.status_code").map(String::as_str),
-        Some("ok")
+    assert_finish_wiring(
+        b"event: content_block_delta\ndata: {}\n\n",
+        Drive::DropAfterFirstChunk,
+        FinishWiring {
+            span_status: "ok",
+            event: None,
+        },
     );
-    drop(fields);
-
-    assert!(events.is_empty());
 }
 
 #[tokio::test]

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -538,3 +538,20 @@ async fn non_sse_body_is_left_untouched() {
         "{}"
     );
 }
+
+#[test]
+fn stream_failure_labels_match_outcome_labels() {
+    // The Sentry `outcome` tag and the metrics `stream_outcome` label are
+    // produced by two independent `as_str` functions; they must agree or the
+    // two surfaces stop joining.
+    for outcome in [
+        Outcome::Completed,
+        Outcome::ErrorEvent,
+        Outcome::UpstreamCut,
+        Outcome::ClientDisconnect,
+    ] {
+        if let Some(kind) = outcome.as_stream_failure() {
+            assert_eq!(outcome.as_str(), kind.as_str());
+        }
+    }
+}

--- a/src/stream_metrics/tests.rs
+++ b/src/stream_metrics/tests.rs
@@ -164,6 +164,23 @@ fn distinguishes_upstream_cut_and_client_disconnect() {
 }
 
 #[test]
+fn upstream_truncated_marker_forces_upstream_cut_even_with_a_terminal_event() {
+    // `adapters::responses::http::stream_response` emits this marker frame
+    // right before a synthesized completion whenever `machine.finish()` only
+    // produced output because the upstream connection was cut before a real
+    // terminal event. Even though the synthesized `message_stop` that
+    // follows sets `terminal_seen`, the marker must still win the
+    // classification.
+    let mut observer = state(Protocol::Anthropic);
+    observer.push_bytes(super::UPSTREAM_TRUNCATED_MARKER);
+    observer.push_bytes(b"\n\n");
+    observer.push_bytes(b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+
+    assert_eq!(observer.outcome(true), Outcome::UpstreamCut);
+    assert_eq!(observer.outcome(false), Outcome::UpstreamCut);
+}
+
+#[test]
 fn parses_responses_completion_usage_and_done() {
     let mut observer = state(Protocol::Responses);
     observer.push_bytes(
@@ -359,12 +376,7 @@ struct FinishWiring {
 /// Runs one wiring case: wrap an SSE response with the given `status`
 /// carrying `sse`, drive its body per `drive`, and assert the span field and
 /// the Sentry capture match `expected`.
-fn assert_finish_wiring(
-    status: StatusCode,
-    sse: &'static [u8],
-    drive: Drive,
-    expected: FinishWiring,
-) {
+fn assert_finish_wiring(status: StatusCode, sse: &[u8], drive: Drive, expected: FinishWiring) {
     let captured = CapturingLayer::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
 
@@ -381,7 +393,7 @@ fn assert_finish_wiring(
             // behavior for any non-5xx status (including the non-2xx case
             // exercised below, e.g. 400).
             span.record("otel.status_code", "ok");
-            let chunk = Ok::<_, Infallible>(Bytes::from_static(sse));
+            let chunk = Ok::<_, Infallible>(Bytes::copy_from_slice(sse));
             let body = match drive {
                 Drive::ToEnd => Body::from_stream(stream::iter(vec![chunk])),
                 Drive::DropAfterFirstChunk => {
@@ -465,6 +477,33 @@ fn finish_records_otel_error_and_emits_a_sentry_event_for_an_upstream_cut() {
     assert_finish_wiring(
         StatusCode::OK,
         b"event: content_block_delta\ndata: {}\n\n",
+        Drive::ToEnd,
+        FinishWiring {
+            span_status: "error",
+            event: Some((
+                sentry::Level::Warning,
+                "upstream SSE stream was cut before a terminal event",
+            )),
+        },
+    );
+}
+
+#[test]
+fn finish_reports_an_upstream_cut_for_a_marked_synthetic_completion() {
+    // Reproduces exactly what `adapters::responses::http::stream_response`
+    // puts on the wire for a Responses-backend stream that was cut before a
+    // real terminal event: the marker frame, then the synthesized
+    // `message_delta` + `message_stop` completion `AnthropicSseMachine::finish`
+    // builds. Despite that well-formed terminal, the marker must still route
+    // this into the same UpstreamCut Sentry/span path as an unmarked cut.
+    let sse = [
+        super::UPSTREAM_TRUNCATED_MARKER,
+        b"\n\nevent: message_delta\ndata: {}\n\nevent: message_stop\ndata: {}\n\n",
+    ]
+    .concat();
+    assert_finish_wiring(
+        StatusCode::OK,
+        &sse,
         Drive::ToEnd,
         FinishWiring {
             span_status: "error",

--- a/tests/responses_translate.rs
+++ b/tests/responses_translate.rs
@@ -980,6 +980,73 @@ fn streaming_state_machine_emits_incremental_anthropic_events() {
     assert!(emitted.contains("\"output_tokens\":9"));
 }
 
+#[test]
+fn response_incomplete_ends_the_turn_like_a_normal_completion() {
+    // `response.incomplete` is a clean (if truncated) terminal, not a
+    // transport cut — issue #300 / PR #295 discussion_r3685776686. Unlike
+    // `truncated_stream_falls_back_to_input_token_estimate` (no terminal
+    // event at all), this stream DOES end on a terminal event, so it must
+    // behave like `response.completed`: emit its own message_delta +
+    // message_stop, mark the machine `stopped`, and leave `finish()` with
+    // nothing left to flush (which in turn keeps `http.rs`'s EOF branch from
+    // injecting `UPSTREAM_TRUNCATED_MARKER` for this stream).
+    let fixture = concat!(
+        "event: response.created
+",
+        "data: {\"response\":{\"id\":\"resp_1\"}}
+
+",
+        "event: response.output_item.added
+",
+        "data: {\"item\":{\"type\":\"message\"}}
+
+",
+        "event: response.output_text.delta
+",
+        "data: {\"delta\":\"hi\"}
+
+",
+        "event: response.output_text.done
+",
+        "data: {}
+
+",
+        "event: response.incomplete
+",
+        "data: {\"response\":{\"usage\":{\"input_tokens\":30,\"output_tokens\":12}}}
+
+",
+    );
+    let mut machine = AnthropicSseMachine::new("gpt-5.2-codex", false, false);
+    let emitted = parse_sse_events(fixture)
+        .into_iter()
+        .flat_map(|event| machine.apply(event))
+        .collect::<String>();
+
+    assert_eq!(
+        event_names(&emitted),
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop"
+        ]
+    );
+    assert!(emitted.contains("\"stop_reason\":\"end_turn\""));
+    let delta_usage = event_usage(&emitted, "message_delta");
+    assert_eq!(delta_usage["input_tokens"], json!(30));
+    assert_eq!(delta_usage["output_tokens"], json!(12));
+
+    // The stream ending right here (no further bytes) must not produce a
+    // second, synthetic completion — `finish()` sees `stopped` already set
+    // and flushes nothing, so `http.rs`'s cut-before-terminal fallback never
+    // triggers.
+    assert_eq!(machine.finish(), Vec::<String>::new());
+}
+
 /// Extract the `usage` object of the first SSE event of `event_type` in an
 /// emitted Anthropic stream. Order-independent, unlike a substring match:
 /// `message_start` nests usage under `message`, `message_delta` at the top.


### PR DESCRIPTION
## Summary

All observability call sites previously recorded the terminal request outcome at response-header time only. A request that returned `200` and then failed mid-stream (an upstream `event: error` SSE frame, or the connection cut before a terminal SSE event) was permanently recorded as `otel.status_code=ok` with zero Sentry events, even though `stream_metrics::ObserverState::finish` already detected this incrementally (`Outcome::ErrorEvent` / `Outcome::UpstreamCut`) — it just only fed the `shunt.stream_outcome` Prometheus metric, never `observability`.

`ObserverState::finish` now calls a new `observability::record_stream_failure` hook for exactly those two outcomes (never `Completed`, never `ClientDisconnect`). It:
1. Re-records `otel.status_code = "error"` on the request span. `ObserverState` holds a ref-counted clone of the span from the moment the stream is wrapped (`observe_response`), which defers the span's `on_close` — and the OTel/Sentry export it triggers — until the stream itself finishes, so a header-time `"ok"` is reliably overwritten later.
2. Emits a Sentry event via `sentry::capture_message` — `error` level for `ErrorEvent`, `warning` for `UpstreamCut`.
3. Tags the event with exactly `{model, provider, outcome}` — no message content, no bodies/headers/credentials. Reuses `sanitize_model_tag` for the model id.

Closes #287. Extends the header-time-only span tagging / event capture from #281 (#284).

**Documented limitation:** Sentry's own span/transaction *status* enum (as opposed to `data`/tags) cannot be set from the stream-poll path. `sentry-tracing`'s `on_exit` pops the `HubSwitchGuard` once the instrumented handler future returns — before any streamed-body polling happens — so `sentry::configure_scope(..).get_span()` no longer resolves to the request's Sentry span during stream polling. This is a structural limitation of `sentry-tracing` 0.48, documented in `src/observability.rs`'s module doc rather than worked around.

## Milestone / spec

No frozen milestone spec covers this; behavior is scoped by issue #287 and documented inline in `src/observability.rs`'s module doc.

## Test plan

- New tests: `src/observability.rs` +5 (`record_stream_failure` — overwrite of a stale `"ok"`, error vs. warning event level by outcome, exact 3-tag allow-list, oversized-model-tag sanitization).
- New tests: `src/stream_metrics/tests.rs` +4 (wiring `ObserverState::finish` → the hook: fires for `ErrorEvent`/`UpstreamCut`, does **not** fire for `Completed`/`ClientDisconnect`).
- `cargo test --all-features --lib observability`: 23/23 passed.
- `cargo test --all-features --lib stream_metrics`: 19/19 passed.
- `cargo test --all-features --workspace`: every binary `0 failed` (largest, the lib unit suite including all new tests: `1072 passed; 0 failed; 1 ignored`).
- `cargo fmt --all --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean, zero warnings.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] No frozen spec in `docs/` covers this area to update
- [x] User-facing docs updated — `docs/running.md`, `site/src/content/docs/reference/configuration.md`, `site/src/content/docs/guides/opentelemetry.mdx`; `README.md` checked, needed no change (no Sentry/otel mention there); `wiki/` untouched (generated)
- [x] No new GitHub Actions added

## Notes for reviewers

- No PII/body/header/credential leakage: the new event only ever carries `model` (sanitized), `provider`, and `outcome` — verified by an exact `tags.len() == 3` assertion in the new tests.
- `observe_response`'s public signature is unchanged; the 3 external call sites (`proxy/failover.rs`, `codex_endpoint.rs` ×2) needed no changes because `tracing::Span::current()` is captured internally, synchronously, inside `observe_response` itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces mid‑stream SSE failures in spans and Sentry so 200 streams that fail later are recorded as errors and emit events. Implements #287 and fixes Responses‑protocol terminals, including `response.incomplete`.

- **New Features**
  - Added `observability::record_stream_failure`, called by `stream_metrics::ObserverState::finish` for `ErrorEvent`/`UpstreamCut` on 2xx streams; re‑records `otel.status_code=error` and captures a Sentry event tagged with `model`, `provider`, `outcome`.
  - `stream_metrics::observe_response` now captures the request `tracing::Span` so mid‑stream updates reach the span; Sentry span status still can’t be set mid‑stream due to `sentry-tracing` scope limits.
  - `adapters::responses::http::stream_response` prefixes synthesized completions from truncated upstreams with `stream_metrics::UPSTREAM_TRUNCATED_MARKER` so observers classify them as `UpstreamCut` without affecting clients.

- **Bug Fixes**
  - Responses protocol: treat `event: error` as a failure; treat `response.done` as terminal success.
  - Treat `response.incomplete` as a terminal success in both the observer and the Anthropic translation machine; updated docs to reflect this.
  - Gate mid‑stream failure reporting to 2xx SSE responses to avoid double‑reporting non‑2xx errors captured at header time.

<sup>Written for commit 00a3fc2fe295607ce046ea77813b7195f1239477. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

