### PR TITLE
fix(antigravity): resolve --effort per model and surface agy's diagnosis

### DIFF
--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -58,6 +58,33 @@ upstream_model = "gemini-3.6-flash"
 
 The Antigravity path runs one CLI subprocess per request. Its current streaming response is emitted only after `agy` finishes, and token usage is estimated rather than reported by Google. The configured upstream slug proves which model shunt asks `agy` to run; it does not independently attest Google's internal serving identity.
 
+#### Reasoning effort
+
+`agy` takes a `--effort` flag, and the accepted values differ per model. shunt sends a default when a route configures none:
+
+| `upstream_model` | Accepted efforts | shunt's default |
+| --- | --- | --- |
+| `gemini-3.1-pro` | `low`, `high` | `high` |
+| `gemini-3.6-flash` | `low`, `medium`, `high` | `medium` |
+| `gemini-3.5-flash` | `low`, `medium`, `high` | `medium` |
+| `gemini-3-flash` | `low`, `medium`, `high` | `medium` |
+
+`gemini-3.1-pro` is the exception: it exposes a two-position slider and **rejects `medium`**, failing the whole invocation. Note that `agy`'s own flag parser accepts `low|medium|high` for every model and defers the real check to the model, so a parser-level probe will not reveal this.
+
+Set an effort explicitly per route:
+
+```toml
+[[routes]]
+model = "claude-gemini-3.1-pro-via-antigravity"
+provider = "antigravity"
+upstream_model = "gemini-3.1-pro"
+effort = "low"
+```
+
+Configuring an effort the model does not accept returns `400 invalid_request_error` naming the valid values, rather than forwarding a request `agy` will reject. A model absent from the table above sends no `--effort` flag unless a route sets one, deferring to `agy`'s own default.
+
+Values verified against Antigravity CLI 1.1.8.
+
 ### The codex provider (ChatGPT subscription)
 
 Log in once with the Codex CLI; shunt reads and auto-refreshes `~/.codex/auth.json`:

--- a/src/adapters/antigravity/mod.rs
+++ b/src/adapters/antigravity/mod.rs
@@ -13,10 +13,115 @@ use std::path::PathBuf;
 
 use crate::{
     adapters::{Adapter, AdapterError, AdapterFuture},
+    error::ShuntError,
     request::RequestBody,
     routing::Route,
     server::AppState,
 };
+
+/// `--effort` values the Antigravity CLI accepts per model, with the default to
+/// send when the route configures none: `(model, supported, default)`.
+///
+/// `agy` validates `--effort` in two stages. Its flag parser accepts
+/// `low|medium|high` for every model, and only then does the model reject a
+/// value it does not offer — `gemini-3.1-pro` exposes a two-position slider
+/// (`low`/`high`) and fails the whole invocation on `medium`, which the CLI
+/// reports as `gemini-3.1-pro has no "medium" effort`. Probing the flag parser
+/// therefore does not reveal the real per-model set; each row below was
+/// verified by invoking the model itself against Antigravity CLI 1.1.8.
+///
+/// Table-driven so a new model is one row rather than another branch
+/// (AGENTS.md: prefer table-driven config additions over hardcoded provider
+/// logic). A model absent from this table is left to `agy`'s own default.
+const ANTIGRAVITY_EFFORTS: &[(&str, &[&str], &str)] = &[
+    ("gemini-3.1-pro", &["low", "high"], "high"),
+    ("gemini-3.6-flash", &["low", "medium", "high"], "medium"),
+    ("gemini-3.5-flash", &["low", "medium", "high"], "medium"),
+    ("gemini-3-flash", &["low", "medium", "high"], "medium"),
+];
+
+/// Resolve the `--effort` argument for a route.
+///
+/// `Ok(None)` means send no `--effort` flag at all. An unknown model with no
+/// configured effort lands there deliberately: guessing a value the model may
+/// not accept is what made every `gemini-3.1-pro` request fail, so an
+/// unrecognised model defers to `agy` instead of to us.
+///
+/// `Err` carries an operator-facing message for a configured effort the model
+/// does not offer. Catching it here turns what `agy` would report as an opaque
+/// upstream failure into a 400 that names the valid values.
+fn resolve_effort(model: &str, configured: Option<&str>) -> Result<Option<String>, String> {
+    let known = ANTIGRAVITY_EFFORTS
+        .iter()
+        .find(|(candidate, _, _)| *candidate == model);
+    match (known, configured) {
+        (Some((_, supported, _)), Some(effort)) if !supported.contains(&effort) => Err(format!(
+            "model {model} does not support effort \"{effort}\" (supported: {})",
+            supported.join(", ")
+        )),
+        (_, Some(effort)) => Ok(Some(effort.to_string())),
+        (Some((_, _, default)), None) => Ok(Some((*default).to_string())),
+        (None, None) => Ok(None),
+    }
+}
+
+/// Shape a missing `agy` binary as an Anthropic-form error.
+///
+/// Worth naming the search path explicitly: a service manager commonly runs
+/// shunt under a restricted `PATH`. Homebrew's `brew services` unit sets
+/// `PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin`,
+/// which excludes `~/.local/bin` — the default install location for `agy` — so
+/// a provider that works in a shell returns 503 under the service with no
+/// indication why. `AGY_BIN` is the fix, and the message has to say so.
+fn agy_not_found() -> AdapterError {
+    let message = "Antigravity CLI (agy) not found on PATH, in ~/.gemini/antigravity-cli/bin, or at $AGY_BIN. \
+         Install agy, or set AGY_BIN to its absolute path — a service manager \
+         (for example `brew services`) may run shunt with a PATH that excludes it."
+        .to_string();
+    AdapterError {
+        response: Box::new(
+            ShuntError::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "api_error",
+                message.clone(),
+            )
+            .into_response(),
+        ),
+        message,
+        failure: None,
+    }
+}
+
+/// Cap on the upstream detail echoed back to the client, in bytes.
+const AGY_STDERR_LIMIT: usize = 2000;
+
+/// Shape a failed `agy` invocation as an Anthropic-form error carrying the
+/// CLI's own diagnosis.
+///
+/// The previous code built this message and then paired it with a bare
+/// `StatusCode::BAD_GATEWAY`, so the client received a 502 with an empty body
+/// while the actual cause — often a precise, actionable line like
+/// `gemini-3.1-pro has no "medium" effort` — was discarded at the wire.
+/// AGENTS.md requires gateway-owned errors in the Anthropic error shape.
+fn agy_failure(detail: &str) -> AdapterError {
+    let detail = detail.trim();
+    let mut detail = detail
+        .char_indices()
+        .take_while(|(index, _)| *index < AGY_STDERR_LIMIT)
+        .map(|(_, character)| character)
+        .collect::<String>();
+    if detail.is_empty() {
+        detail.push_str("no output");
+    }
+    let message = format!("Antigravity CLI (agy) failed: {detail}");
+    AdapterError {
+        response: Box::new(
+            ShuntError::new(StatusCode::BAD_GATEWAY, "api_error", message.clone()).into_response(),
+        ),
+        message,
+        failure: None,
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AntigravityAdapter;
@@ -38,35 +143,42 @@ impl Adapter for AntigravityAdapter {
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
 
-            let agy_bin = find_agy_binary().ok_or_else(|| AdapterError {
-                message: "Antigravity CLI (agy) binary not found. Please install agy or set AGY_BIN environment variable.".to_string(),
-                response: Box::new(StatusCode::SERVICE_UNAVAILABLE.into_response()),
-                failure: None,
-            })?;
+            let agy_bin = find_agy_binary().ok_or_else(agy_not_found)?;
 
             let mut cmd = tokio::process::Command::new(&agy_bin);
             cmd.arg("-p").arg(&prompt);
             cmd.arg("--model").arg(&route.upstream_model);
 
-            // Add effort for 3.x models or explicitly set effort
-            if route.upstream_model.contains("3.") || route.effort.is_some() {
-                let effort = route.effort.as_deref().unwrap_or("medium");
-                cmd.arg("--effort").arg(effort);
+            // Effort is resolved from a per-model table rather than guessed:
+            // the models disagree on which values they accept, and sending an
+            // unsupported one fails the whole invocation.
+            match resolve_effort(&route.upstream_model, route.effort.as_deref()) {
+                Ok(Some(effort)) => {
+                    cmd.arg("--effort").arg(effort);
+                }
+                Ok(None) => {}
+                Err(message) => {
+                    return Err(AdapterError {
+                        response: Box::new(
+                            ShuntError::new(
+                                StatusCode::BAD_REQUEST,
+                                "invalid_request_error",
+                                message.clone(),
+                            )
+                            .into_response(),
+                        ),
+                        message,
+                        failure: None,
+                    });
+                }
             }
 
-            let output = cmd.output().await.map_err(|err| AdapterError {
-                message: format!("failed to execute agy CLI: {err}"),
-                response: Box::new(StatusCode::BAD_GATEWAY.into_response()),
-                failure: None,
+            let output = cmd.output().await.map_err(|err| {
+                agy_failure(&format!("could not execute {}: {err}", agy_bin.display()))
             })?;
 
             if !output.status.success() {
-                let err_msg = String::from_utf8_lossy(&output.stderr);
-                return Err(AdapterError {
-                    message: format!("agy CLI execution failed: {err_msg}"),
-                    response: Box::new(StatusCode::BAD_GATEWAY.into_response()),
-                    failure: None,
-                });
+                return Err(agy_failure(&String::from_utf8_lossy(&output.stderr)));
             }
 
             let stdout_text = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -274,3 +386,6 @@ pub fn format_antigravity_sse(model: &str, text: &str) -> String {
 
     out
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/adapters/antigravity/tests.rs
+++ b/src/adapters/antigravity/tests.rs
@@ -1,0 +1,112 @@
+use super::*;
+
+#[test]
+fn pro_defaults_to_high_because_it_has_no_medium_effort() {
+    // The regression this table exists for: `gemini-3.1-pro` offers only
+    // `low`/`high`, so the previous unconditional `medium` default made
+    // every effort-less request to that model fail with an `agy` error.
+    assert_eq!(
+        resolve_effort("gemini-3.1-pro", None),
+        Ok(Some("high".to_string()))
+    );
+}
+
+#[test]
+fn flash_models_keep_a_medium_default() {
+    for model in ["gemini-3.6-flash", "gemini-3.5-flash"] {
+        assert_eq!(
+            resolve_effort(model, None),
+            Ok(Some("medium".to_string())),
+            "{model} should default to medium"
+        );
+    }
+}
+
+#[test]
+fn dotless_flash_model_still_receives_an_effort() {
+    // The previous gate was `upstream_model.contains("3.")`, which matches
+    // `gemini-3.1-pro` and `gemini-3.6-flash` but NOT `gemini-3-flash` —
+    // that model silently never received an `--effort` flag at all.
+    assert_eq!(
+        resolve_effort("gemini-3-flash", None),
+        Ok(Some("medium".to_string()))
+    );
+}
+
+#[test]
+fn a_configured_effort_the_model_offers_is_passed_through() {
+    assert_eq!(
+        resolve_effort("gemini-3.1-pro", Some("low")),
+        Ok(Some("low".to_string()))
+    );
+}
+
+#[test]
+fn a_configured_effort_the_model_rejects_is_refused_locally() {
+    // Caught here rather than at `agy`, so the operator gets a 400 naming
+    // the valid values instead of an opaque upstream failure.
+    let error = resolve_effort("gemini-3.1-pro", Some("medium"))
+        .expect_err("medium is not offered by gemini-3.1-pro");
+    assert!(
+        error.contains("does not support effort \"medium\""),
+        "{error}"
+    );
+    assert!(error.contains("low, high"), "{error}");
+}
+
+#[test]
+fn an_unknown_model_defers_to_the_cli_instead_of_guessing() {
+    // Guessing a default for a model we have not verified is exactly what
+    // broke `gemini-3.1-pro`; an unrecognised model sends no flag, and a
+    // configured value passes through for `agy` itself to validate.
+    assert_eq!(resolve_effort("gemini-9-experimental", None), Ok(None));
+    assert_eq!(
+        resolve_effort("gemini-9-experimental", Some("medium")),
+        Ok(Some("medium".to_string()))
+    );
+}
+
+#[test]
+fn every_table_default_is_one_of_that_models_supported_values() {
+    for (model, supported, default) in ANTIGRAVITY_EFFORTS {
+        assert!(
+            supported.contains(default),
+            "{model} defaults to {default}, which is not in {supported:?}"
+        );
+    }
+}
+
+#[test]
+fn a_failed_invocation_carries_the_cli_diagnosis_in_anthropic_shape() {
+    let error = agy_failure("  gemini-3.1-pro has no \"medium\" effort  ");
+    assert!(
+        error.message.contains("has no \"medium\" effort"),
+        "the CLI's own diagnosis must survive to the client: {}",
+        error.message
+    );
+}
+
+#[test]
+fn an_empty_stderr_still_produces_a_usable_message() {
+    assert!(agy_failure("   ").message.contains("no output"));
+}
+
+#[test]
+fn an_oversized_stderr_is_truncated() {
+    let message = agy_failure(&"x".repeat(AGY_STDERR_LIMIT * 2)).message;
+    assert!(
+        message.len() < AGY_STDERR_LIMIT * 2,
+        "len {}",
+        message.len()
+    );
+}
+
+#[test]
+fn a_missing_binary_names_agy_bin_and_the_restricted_path_trap() {
+    // Encountered live: under `brew services` the unit's PATH excludes
+    // ~/.local/bin, so a provider that works in a shell returns 503 with
+    // no indication why. The message must point at the actual remedy.
+    let message = agy_not_found().message;
+    assert!(message.contains("AGY_BIN"), "{message}");
+    assert!(message.contains("PATH"), "{message}");
+}


### PR DESCRIPTION
## Summary

Closes #305.

`gemini-3.1-pro` accepts only `low`/`high` and fails the whole `agy` invocation on `medium`, so every effort-less request to that model failed. The adapter gated `--effort` on `upstream_model.contains("3.")` and defaulted to `"medium"` — wrong in both halves, since that pattern also misses `gemini-3-flash` (`3-`, no dot), which therefore never received an effort flag at all.

Replaced with an `ANTIGRAVITY_EFFORTS` table of `(model, supported, default)`. A model absent from the table sends no flag rather than a guessed one, and a route-configured effort the model does not accept is refused locally as a `400 invalid_request_error` naming the valid values instead of being forwarded for `agy` to reject.

Separately, all three failure paths returned a bare `StatusCode::*.into_response()` — a status with **no body** — while the code had already built a useful message. The client saw an empty 502/503 and `agy`'s precise diagnosis was dropped at the wire. They now return the Anthropic error shape carrying that diagnosis (trimmed, capped at 2000 chars).

### Effort matrix

Verified by invoking each model against Antigravity CLI 1.1.8:

| `upstream_model` | accepted | default sent |
| --- | --- | --- |
| `gemini-3.1-pro` | `low`, `high` | `high` |
| `gemini-3.6-flash` | `low`, `medium`, `high` | `medium` |
| `gemini-3.5-flash` | `low`, `medium`, `high` | `medium` |
| `gemini-3-flash` | `low`, `medium`, `high` | `medium` |

`agy` validates in two stages — its flag parser accepts `low|medium|high` for every model and only the model itself rejects an unsupported value — so a parser-level probe does not reveal the real per-model set. Each row was confirmed against the model.

## Milestone / spec

No milestone doc covers the Antigravity adapter. `site/src/content/docs/guides/providers.mdx` is updated with the effort matrix and the two-stage-validation caveat, per AGENTS.md's provider/model documentation rule.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (11 new unit tests; all offline, no network or loopback)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines (tests moved to `antigravity/tests.rs`, mirroring `discovery/upstream/tests.rs`; `mod.rs` is 391)
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — n/a
- [x] User-facing docs updated — `site/src/content/docs/guides/providers.mdx`
- [x] Any new GitHub Action is pinned to a full commit SHA — n/a

## Test plan with observed results

Unit: `cargo test --all-features --lib antigravity` → **11 passed, 0 failed**.
Workspace: `cargo test --all-features --workspace` → **1132 + 283 passed, 0 failed**.

End-to-end against a live gateway and a real Google AI Ultra subscription:

| case | before | after |
| --- | --- | --- |
| `gemini-3.1-pro`, no `effort` configured | `HTTP 502`, empty body | `HTTP 200`, `{"content":[{"text":"ok",...}]}` |
| `agy` absent from `PATH` | `HTTP 503`, empty body | `HTTP 503` with `{"type":"error","error":{"type":"api_error","message":"Antigravity CLI (agy) not found on PATH, in ~/.gemini/antigravity-cli/bin, or at $AGY_BIN. ..."}}` |

The "before" column was reproduced against the released 0.32.0 Homebrew build, not against a reverted local patch.

## Notes for reviewers

- **Unknown models deliberately send no `--effort`.** Guessing a default for an unverified model is exactly what broke `gemini-3.1-pro`; `resolve_effort` returns `Ok(None)` there and defers to `agy`. A route-configured value still passes through for `agy` itself to validate.
- **`every_table_default_is_one_of_that_models_supported_values`** guards the table against a future row whose default is not in its own supported set.
- **The truncation cap** bounds what upstream text reaches the client. `agy` stderr is CLI diagnostics rather than user content, but it is echoed to the caller, so it is trimmed and capped.
- **Adjacent, not fixed here:** since #288, the `brew services` unit sets a `PATH` that excludes `~/.local/bin`, so the Antigravity provider returns 503 under the service for a common `agy` install. This PR makes that failure *legible* (the message names `AGY_BIN` and the restricted-PATH trap) but does not change the formula. Happy to follow up if you want `AGY_BIN` or a wider `PATH` in `environment_variables`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Antigravity effort handling per model and surface `agy` errors to clients. Requests to `gemini-3.1-pro` now succeed without a configured effort, and failures return clear Anthropic-form errors.

- **Bug Fixes**
  - Per-model effort via `ANTIGRAVITY_EFFORTS`; known models get a safe default, unknown models send no `--effort`.
  - Validate configured `effort` locally; reject unsupported values with `400 invalid_request_error` naming accepted options.
  - Return Anthropic error shape for `agy` failures, including trimmed stderr (max 2000 chars); missing binary now returns `503` with `AGY_BIN`/PATH guidance. Docs updated with the effort matrix; 11 unit tests added.

<sup>Written for commit 787aac76ee7fadaa79528ba83b66f9dac86de385. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

