### PR TITLE
docs: add Greptile OSS badge and backfill CodSpeed badge in localized READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,9 +1,11 @@
 # shunt
 
 [![CI](https://github.com/pleaseai/shunt/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/shunt/actions/workflows/ci.yml)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://app.codspeed.io/pleaseai/shunt?utm_source=badge)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_shunt&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_shunt)
 [![codecov](https://codecov.io/gh/pleaseai/shunt/graph/badge.svg)](https://codecov.io/gh/pleaseai/shunt)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 [English](README.md) · [한국어](README.ko.md) · **日本語** · [简体中文](README.zh-CN.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -234,7 +234,7 @@ Issue と PR を歓迎します。ビルド／テストコマンドと規約に�
 
 `shunt` へのプルリクエストは 2 つの AI コードレビュアーによってレビューされ、いずれもオープンソースでは無料です。
 
-- [Greptile](https://www.greptile.com/) — OSS プログラムのもと、非商用の MIT/Apache プロジェクトで無料。
+- [Greptile](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source) — OSS プログラムのもと、非商用の MIT/Apache プロジェクトで無料。
 - [cubic](https://cubic.dev/) — 公開リポジトリで無料。
 
 ## ライセンス

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,9 +1,11 @@
 # shunt
 
 [![CI](https://github.com/pleaseai/shunt/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/shunt/actions/workflows/ci.yml)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://app.codspeed.io/pleaseai/shunt?utm_source=badge)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_shunt&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_shunt)
 [![codecov](https://codecov.io/gh/pleaseai/shunt/graph/badge.svg)](https://codecov.io/gh/pleaseai/shunt)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 [English](README.md) · **한국어** · [日本語](README.ja.md) · [简体中文](README.zh-CN.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -234,7 +234,7 @@ Claude Code는 `ANTHROPIC_BASE_URL` 뒤에 **1급 게이트웨이 계약**을 �
 
 `shunt`의 풀 리퀘스트는 두 개의 AI 코드 리뷰어 도구가 검토하며, 둘 다 오픈소스 프로젝트에 무료로 제공됩니다.
 
-- [Greptile](https://www.greptile.com/) — OSS 프로그램에 따라 비상업적 MIT/Apache 프로젝트에 무료.
+- [Greptile](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source) — OSS 프로그램에 따라 비상업적 MIT/Apache 프로젝트에 무료.
 - [cubic](https://cubic.dev/) — 공개 저장소에 무료.
 
 ## 라이선스

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_shunt&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_shunt)
 [![codecov](https://codecov.io/gh/pleaseai/shunt/graph/badge.svg)](https://codecov.io/gh/pleaseai/shunt)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 **English** · [한국어](README.ko.md) · [日本語](README.ja.md) · [简体中文](README.zh-CN.md)
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Issues and PRs are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`AGENT
 
 Pull requests to `shunt` are reviewed by two AI code reviewers, both free for open source:
 
-- [Greptile](https://www.greptile.com/) — free for non-commercial MIT/Apache projects under its OSS program.
+- [Greptile](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source) — free for non-commercial MIT/Apache projects under its OSS program.
 - [cubic](https://cubic.dev/) — free for public repositories.
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -234,7 +234,7 @@ Claude Code 在 `ANTHROPIC_BASE_URL` 后暴露了一个**一等公民的网关�
 
 `shunt` 的拉取请求由两个 AI 代码评审工具审查，两者对开源项目均免费：
 
-- [Greptile](https://www.greptile.com/) — 依据其 OSS 计划，对非商业 MIT/Apache 项目免费。
+- [Greptile](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source) — 依据其 OSS 计划，对非商业 MIT/Apache 项目免费。
 - [cubic](https://cubic.dev/) — 对公开仓库免费。
 
 ## 许可证

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,9 +1,11 @@
 # shunt
 
 [![CI](https://github.com/pleaseai/shunt/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/shunt/actions/workflows/ci.yml)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://app.codspeed.io/pleaseai/shunt?utm_source=badge)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_shunt&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_shunt)
 [![codecov](https://codecov.io/gh/pleaseai/shunt/graph/badge.svg)](https://codecov.io/gh/pleaseai/shunt)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 [English](README.md) · [한국어](README.ko.md) · [日本語](README.ja.md) · **简体中文**
 


### PR DESCRIPTION
## Summary

Two documentation-only changes to the README badge blocks:

- **Greptile OSS badge** — Greptile supports the project through its OSS program for non-commercial MIT/Apache repositories (already credited in prose in the acknowledgements section of each README). Its support badge is now appended to the badge block of all four READMEs, linking to `https://www.greptile.com/` with the OSS-badge UTM parameters.
- **CodSpeed badge backfill** — `README.md` carried a CodSpeed badge that the Korean, Japanese, and Simplified Chinese READMEs were missing. It is backfilled into all three in the same position (right after the CI badge), so every badge block now lists the same six badges in the same order: CI, CodSpeed, Quality Gate Status, codecov, License, Greptile.

Badge alt text is intentionally left untranslated, matching the existing badges, so the four blocks are byte-identical.

## Milestone / spec

N/A — documentation only, no implementation behavior change.

## Checklist

- [x] `cargo build` passes (no source files touched)
- [x] `cargo test` passes (no source files touched)
- [x] `cargo clippy --all-targets -- -D warnings` clean (no source files touched)
- [x] `cargo fmt --all --check` clean (no source files touched)
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — N/A; this change *is* the doc change, and it adds no capability, config key, endpoint, or CLI surface, so `site/` needs no update
- [x] Any new GitHub Action is pinned to a full commit SHA — N/A

## Notes for reviewers

Verified before commit: each inserted line parses as `[![alt](img)](href)` with balanced brackets, is ASCII-only (no zero-width characters from copy-paste), and the badge image URL returns HTTP 200 `image/svg+xml`. The four badge blocks were diffed against each other and are byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the Greptile OSS badge to all four READMEs and backfill the CodSpeed badge in the Korean, Japanese, and Simplified Chinese READMEs to unify the badge blocks (order: CI, CodSpeed, Quality Gate Status, codecov, License, Greptile). Also tag the existing Greptile links in the review-tooling lists with the same OSS-badge UTM URL for consistent attribution.

<sup>Written for commit dacde79b1a7b15dd74862aaa1747f456d5222c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

