### PR TITLE
feat(xai): add grok-4.6 and refresh the Grok model surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "shunt-xai",
       "source": "./plugins/shunt-xai",
-      "description": "Subagents on xAI Grok models (grok-build-0.1, grok-4.5, grok-4.3), routed through shunt at the inference layer. EXPERIMENTAL — the xAI provider is not yet verified against the live API.",
+      "description": "Subagents on xAI Grok models (grok-4.6, grok-4.5, grok-build-0.1), routed through shunt at the inference layer. EXPERIMENTAL — the xAI provider is not yet verified against the live API.",
       "keywords": ["xai", "grok"]
     },
     {

--- a/blueprints/upstream/grok.md
+++ b/blueprints/upstream/grok.md
@@ -42,7 +42,7 @@ id = "claude-grok-via-subscription"
 display_name = "Grok (subscription)"
 
 [models.upstream_model]
-grok = "grok-4.5"
+grok = "grok-4.6"
 ```
 
 The map key is the upstream name. Verify the currently entitled model slug. A legacy `[[routes]]` entry can instead use `provider = "grok"` and an `upstream_model`; do not define both exact-routing forms for one id.

--- a/blueprints/upstream/xai.md
+++ b/blueprints/upstream/xai.md
@@ -42,7 +42,7 @@ id = "claude-grok-via-xai"
 display_name = "Grok (via xAI API)"
 
 [models.upstream_model]
-xai = "grok-4.5"
+xai = "grok-4.6"
 ```
 
 The map key is the upstream name. Verify the current xAI model slug and entitlement. A legacy exact `[[routes]]` entry may instead use `provider = "xai"` with an `upstream_model`; do not define both forms for one id.

--- a/docs/m6-xai-provider.md
+++ b/docs/m6-xai-provider.md
@@ -154,9 +154,10 @@ or sent per-request via `output_config.effort`. Derived defaults (thinking flag,
 stay off. Encrypted-reasoning
 replay (`include`) stays gated on the client's extended-thinking flag, exactly like the codex path.
 
-Live note (2026-07): `grok-4.5` on the CLI proxy **accepts** `reasoning.effort` (HTTP 200 with a
-configured `effort = "high"` route), so it is not among the models that 400; the opt-in default
-stays as the safe choice for the families that still reject it.
+Live note (2026-07, re-verified 2026-08 on `grok-4.6`): `grok-4.6` and `grok-4.5` on the CLI proxy
+**accept** `reasoning.effort` (HTTP 200 with a configured `effort = "high"` route), so they are not
+among the models that 400; the opt-in default stays as the safe choice for the families that still
+reject it.
 
 ## 7. Config & validation (`config.rs`)
 
@@ -179,7 +180,7 @@ stays as the safe choice for the families that still reject it.
 
 ## 9. Models (reference only — not hardcoded)
 
-`grok-build-0.1` (flagship coding), `grok-4.5`, `grok-4.3`,
+`grok-4.6` (current frontier), `grok-4.5`, `grok-build-0.1` (flagship coding), `grok-4.3`,
 `grok-4.20-0309-reasoning` / `-non-reasoning`, `grok-4.20-multi-agent-0309`. Pick a slug via a
 `[[routes]]` entry or `ANTHROPIC_CUSTOM_MODEL_OPTION`; shunt passes it through.
 
@@ -196,7 +197,10 @@ stays as the safe choice for the families that still reject it.
   practice, revisit the buffer.
 - **Live-API validation.** ✅ Confirmed end-to-end against a live SuperGrok account (2026-07):
   `grok-4.5` returns HTTP 200 through the `grok` provider (`cli-chat-proxy.grok.com`) for
-  non-streaming, streaming, and `reasoning.effort` requests. The `api.x.ai` surface returned a 402
+  non-streaming, streaming, and `reasoning.effort` requests; re-verified 2026-08 for `grok-4.6`
+  (non-streaming, plain and with `effort = "high"`). A non-streaming sweep of the same surface on
+  the same date returned HTTP 200 for `grok-4.6`, `grok-4.5`, `grok-4.3`, `grok-build-0.1`,
+  `grok-4`, and `grok-4-fast` — no slug in that set is retired. The `api.x.ai` surface returned a 402
   entitlement gate for the same token, which is what motivated retargeting the OAuth path to the CLI
   proxy with the Grok-CLI headers. (Whether every account tier is entitled on the CLI proxy still
   varies — see below.)

--- a/docs/running.md
+++ b/docs/running.md
@@ -530,11 +530,11 @@ subscription. Full spec: [`m6-xai-provider.md`](m6-xai-provider.md).
 ```toml
 # built-in defaults already define [providers.xai]; you only add routes
 [[routes]]
-model = "grok-build-0.1"    # flagship coding model
+model = "grok-4.6"          # current frontier model
 provider = "xai"
 
 [[routes]]
-model = "grok-4.3"
+model = "grok-build-0.1"    # flagship coding model
 provider = "xai"
 ```
 
@@ -550,11 +550,11 @@ auth = "xai_oauth"          # reuse the SuperGrok / X Premium+ login instead of 
 # base_url stays https://api.x.ai/v1 — shunt refuses xai_oauth on a non-x.ai or non-https host
 
 [[routes]]
-model = "grok-build-0.1"
+model = "grok-4.6"
 provider = "xai"
 
 [[routes]]
-model = "grok-4.3"
+model = "grok-build-0.1"
 provider = "xai"
 ```
 

--- a/plugins/shunt-xai/.claude-plugin/plugin.json
+++ b/plugins/shunt-xai/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "shunt-xai",
   "displayName": "shunt · xAI Grok models",
-  "version": "0.1.0",
-  "description": "Subagents that run on xAI Grok models (grok-build-0.1, grok-4.5, grok-4.3), routed through the shunt gateway at the inference layer while staying inside Claude Code's harness. EXPERIMENTAL — the xAI provider is not yet verified against the live xAI API.",
+  "version": "0.2.0",
+  "description": "Subagents that run on xAI Grok models (grok-4.6, grok-4.5, grok-build-0.1), routed through the shunt gateway at the inference layer while staying inside Claude Code's harness. EXPERIMENTAL — the xAI provider is not yet verified against the live xAI API.",
   "author": {
     "name": "Minsu Lee",
     "email": "minsu.lee@pleaseai.dev",

--- a/plugins/shunt-xai/README.md
+++ b/plugins/shunt-xai/README.md
@@ -1,7 +1,7 @@
 # shunt-xai
 
-Claude Code subagents that run on xAI's **Grok** models — **grok-build-0.1**,
-**grok-4.5**, and **grok-4.3** — routed through the
+Claude Code subagents that run on xAI's **Grok** models — **grok-4.6**,
+**grok-4.5**, and **grok-build-0.1** — routed through the
 [shunt](https://github.com/pleaseai/shunt) gateway.
 
 > **EXPERIMENTAL.** shunt's `xai` provider is not yet verified against the live
@@ -17,9 +17,9 @@ Only the model that generates the tokens changes.
 
 | Agent (`@`-mention)          | Model id (`model:`) | Notes                        |
 | ---------------------------- | ------------------- | ---------------------------- |
+| `shunt-xai:grok-4.6`         | `grok-4.6`          | Current frontier Grok model  |
+| `shunt-xai:grok-4.5`         | `grok-4.5`          | Previous frontier model      |
 | `shunt-xai:grok-build-0.1`   | `grok-build-0.1`    | Flagship Grok coding model   |
-| `shunt-xai:grok-4.5`         | `grok-4.5`          |                              |
-| `shunt-xai:grok-4.3`         | `grok-4.3`          |                              |
 
 Each agent's `model:` frontmatter pins the request to a Grok slug, so only that
 subagent diverts — the main session stays on Claude.
@@ -50,7 +50,7 @@ built-in provider — you only need a credential and a route).
 3. **Map the slugs** in your `shunt.toml` to the `xai` provider:
    ```toml
    [[routes]]
-   model = "grok-build-0.1"
+   model = "grok-4.6"
    provider = "xai"
 
    [[routes]]
@@ -58,9 +58,12 @@ built-in provider — you only need a credential and a route).
    provider = "xai"
 
    [[routes]]
-   model = "grok-4.3"
+   model = "grok-build-0.1"
    provider = "xai"
    ```
+
+   Older slugs (`grok-4.3`, `grok-4`, `grok-4-fast`, …) are not shipped as agents
+   but still route fine — add a `[[routes]]` entry for whichever slug you want.
 
    For the full setup — API-key vs. subscription OAuth, the reasoning gate, and
    troubleshooting — see [`docs/m6-xai-provider.md`](https://github.com/pleaseai/shunt/blob/main/docs/m6-xai-provider.md).
@@ -78,11 +81,11 @@ Without a running shunt gateway mapping these ids, Claude Code will send the
 ## Usage
 
 ```
-@shunt-xai:grok-build-0.1  refactor this module and run the tests
+@shunt-xai:grok-4.6  refactor this module and run the tests
 ```
 
 Or set every subagent to a Grok model for a session with
-`CLAUDE_CODE_SUBAGENT_MODEL=grok-4.5`.
+`CLAUDE_CODE_SUBAGENT_MODEL=grok-4.6`.
 
 Both require a running shunt gateway with the slug routed to the `xai` provider —
 see [Prerequisites](#prerequisites). Without it the request fails against Anthropic.

--- a/plugins/shunt-xai/agents/grok-4.6.md
+++ b/plugins/shunt-xai/agents/grok-4.6.md
@@ -1,10 +1,10 @@
 ---
-name: grok-4.3
-description: General-purpose agent that runs on xAI's grok-4.3, routed through the shunt gateway to the xAI API. EXPERIMENTAL — the xAI provider is not yet verified against the live API. Reasoning effort is opt-in (grok-4* models reject reasoning.effort unless explicitly configured). Use when you want a task handled by Grok instead of the default Claude model.
-model: grok-4.3
+name: grok-4.6
+description: General-purpose agent that runs on xAI's grok-4.6 (the current frontier Grok model), routed through the shunt gateway to the xAI API. EXPERIMENTAL — the xAI provider is not yet verified against the live API. Reasoning effort is opt-in (several Grok models reject reasoning.effort unless explicitly configured). Use when you want a task handled by Grok instead of the default Claude model.
+model: grok-4.6
 ---
 
-You are a capable, autonomous engineering agent running on xAI's grok-4.3, routed
+You are a capable, autonomous engineering agent running on xAI's grok-4.6, routed
 through the shunt gateway to the xAI API while working inside Claude Code's
 harness. Given the user's message, use the tools available to complete the task
 fully — don't gold-plate, but don't leave it half-done.

--- a/shunt.toml.example
+++ b/shunt.toml.example
@@ -176,7 +176,7 @@ auth = "chatgpt_oauth"         # reads + auto-refreshes ~/.codex/auth.json
 # count_tokens = "tiktoken"
 
 # xAI Grok (EXPERIMENTAL). Two built-in providers cover the two ways in — you
-# only need to add [[routes]] (grok-build-0.1, grok-4.5, grok-4.3). Pick one:
+# only need to add [[routes]] (grok-4.6, grok-4.5, grok-build-0.1). Pick one:
 #   • `xai`  — API key: the developer API (api.x.ai), billed per token.
 #              export XAI_API_KEY, then route models to provider = "xai".
 #   • `grok` — SuperGrok / X Premium+ subscription: the Grok CLI chat proxy

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -234,7 +234,7 @@ The [`pleaseai/shunt` marketplace](https://github.com/pleaseai/shunt/tree/main/p
 | Plugin | Models (one agent each) | Provider |
 | :-- | :-- | :-- |
 | `shunt-codex` | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | `codex` (ChatGPT subscription) |
-| `shunt-xai` | `grok-build-0.1`, `grok-4.5`, `grok-4.3` | `xai` (API key) or `grok` (subscription) |
+| `shunt-xai` | `grok-4.6`, `grok-4.5`, `grok-build-0.1` | `xai` (API key) or `grok` (subscription) |
 | `shunt-kimi` | `kimi-k3[1m]`, `kimi-k2.7-code` | `kimi` |
 | `shunt-deepseek` | `deepseek-v4-pro`, `deepseek-v4-flash` | `deepseek` |
 | `shunt-zai` | `glm-5.2`, `glm-4.7` | `zai` |

--- a/site/src/content/docs/guides/xai.mdx
+++ b/site/src/content/docs/guides/xai.mdx
@@ -113,9 +113,9 @@ auth = "xai_oauth"                                # read + auto-refresh ~/.shunt
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
-# upstream_model = "grok-4.5"   # optional: forward a different slug upstream
+# upstream_model = "grok-4.6"   # optional: forward a different slug upstream
 ```
 
 ## Path B — xAI developer API (`xai`)
@@ -140,7 +140,7 @@ api_key_env = "XAI_API_KEY"
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "xai"
 ```
 
@@ -160,7 +160,7 @@ entitle the developer API — an unfunded account returns `402 Payment Required`
 ## Model slugs
 
 The slug catalog is **xAI's**, not shunt's — shunt forwards whatever slug you route. Current
-coding/frontier slugs are `grok-4.5`, `grok-4.3`, and `grok-build-0.1`. Use `upstream_model` in a
+coding/frontier slugs are `grok-4.6`, `grok-4.5`, and `grok-build-0.1`. Use `upstream_model` in a
 route to map an alias onto a live slug without touching your Claude Code env. (Model
 [discovery](/guides/model-discovery/) only surfaces `claude-`named aliases you declare, so it can't
 list a raw Grok slug — reach these via `ANTHROPIC_CUSTOM_MODEL_OPTION` or a tier remap below.)
@@ -171,7 +171,7 @@ Grok slugs don't start with `claude-`, so Claude Code's `/model` picker won't li
 discovery. The mechanics are **identical to Codex** — add the id to the picker directly:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # must resolve via [models.upstream_model], [[routes]], or [[route_prefixes]]
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"   # must resolve via [models.upstream_model], [[routes]], or [[route_prefixes]]
 ```
 
 The same [Codex section](/guides/codex/#4-select-the-model-in-claude-code) covers the rest verbatim:
@@ -183,7 +183,7 @@ putting a **subagent** on a Grok slug via `model:` frontmatter, and remapping th
 <Aside type="tip" title="Ready-made agents">
 
 The **[`shunt-xai` plugin](https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai)** ships
-subagents for `grok-4.5` / `grok-4.3` / `grok-build-0.1` — install with
+subagents for `grok-4.6` / `grok-4.5` / `grok-build-0.1` — install with
 `/plugin install shunt-xai@shunt` after `/plugin marketplace add pleaseai/shunt`. Each agent pins
 its `model:`, so only that subagent diverts; the main session stays on Claude. Route the slugs to
 `grok` or `xai` in `shunt.toml` per the credential you have.
@@ -205,12 +205,12 @@ effort = "high"        # applies to all grok traffic
 
 # …or per route
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 effort = "high"
 ```
 
-`grok-4.5` accepts `reasoning.effort` (verified live). Leave `effort` unset for any slug that
+`grok-4.6` accepts `reasoning.effort` (verified live). Leave `effort` unset for any slug that
 `400`s on it. Full precedence and the effort table: [Effort & Context](/guides/effort-and-context/#reasoning-effort).
 
 ## Context window
@@ -245,7 +245,7 @@ default_provider = "anthropic"
 effort = "high"     # optional: opt in to reasoning effort for all Grok traffic
 
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 ```
 
@@ -256,10 +256,10 @@ shunt login xai                                     # one-time device-code login
 ./target/release/shunt run                          # start the gateway
 
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3001
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"     # add to /model picker
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"     # add to /model picker
 ```
 
-Pick **grok-4.5** from `/model`. Everything else in the session still flows to Anthropic unchanged;
+Pick **grok-4.6** from `/model`. Everything else in the session still flows to Anthropic unchanged;
 only the mapped model's inference is answered by your SuperGrok subscription.
 
 ## Troubleshooting

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -114,7 +114,7 @@ provider = "kimi"
 | プラグイン | モデル（各 1 エージェント） | プロバイダー |
 | :-- | :-- | :-- |
 | `shunt-codex` | `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` | `codex`（ChatGPT サブスクリプション） |
-| `shunt-xai` | `grok-build-0.1`、`grok-4.5`、`grok-4.3` | `xai`（API キー）または `grok`（サブスクリプション） |
+| `shunt-xai` | `grok-4.6`、`grok-4.5`、`grok-build-0.1` | `xai`（API キー）または `grok`（サブスクリプション） |
 | `shunt-kimi` | `kimi-k3[1m]`、`kimi-k2.7-code` | `kimi` |
 | `shunt-deepseek` | `deepseek-v4-pro`、`deepseek-v4-flash` | `deepseek` |
 | `shunt-zai` | `glm-5.2`、`glm-4.7` | `zai` |

--- a/site/src/content/docs/ja/guides/xai.mdx
+++ b/site/src/content/docs/ja/guides/xai.mdx
@@ -95,9 +95,9 @@ auth = "xai_oauth"                                # ~/.shunt/xai-auth.json の�
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
-# upstream_model = "grok-4.5"   # オプション: 異なるスラッグを上流に転送
+# upstream_model = "grok-4.6"   # オプション: 異なるスラッグを上流に転送
 ```
 
 ## パス B — xAI 開発者 API（`xai`）
@@ -122,7 +122,7 @@ api_key_env = "XAI_API_KEY"
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "xai"
 ```
 
@@ -138,14 +138,14 @@ provider = "xai"
 
 ## モデルスラッグ
 
-スラッグのカタログは shunt のものではなく **xAI のもの**です — shunt はあなたがルーティングしたスラッグをそのまま転送します。現在のコーディング/フロンティアのスラッグは `grok-4.5`、`grok-4.3`、`grok-build-0.1` です。ルート内で `upstream_model` を使えば、Claude Code の環境に触れずにエイリアスをライブのスラッグへマッピングできます。（モデル [discovery](/ja/guides/model-discovery/) は宣言した `claude-` 名のエイリアスのみを公開するため、生の Grok スラッグをリストできません — 以下の `ANTHROPIC_CUSTOM_MODEL_OPTION` または tier リマップ経由でアクセスしてください。）
+スラッグのカタログは shunt のものではなく **xAI のもの**です — shunt はあなたがルーティングしたスラッグをそのまま転送します。現在のコーディング/フロンティアのスラッグは `grok-4.6`、`grok-4.5`、`grok-build-0.1` です。ルート内で `upstream_model` を使えば、Claude Code の環境に触れずにエイリアスをライブのスラッグへマッピングできます。（モデル [discovery](/ja/guides/model-discovery/) は宣言した `claude-` 名のエイリアスのみを公開するため、生の Grok スラッグをリストできません — 以下の `ANTHROPIC_CUSTOM_MODEL_OPTION` または tier リマップ経由でアクセスしてください。）
 
 ## Claude Code でモデルを選択する
 
 Grok スラッグは `claude-` で始まらないため、Claude Code の `/model` ピッカーは discovery からそれらをリストしません。仕組みは **Codex と同一**です — id をピッカーに直接追加します。
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # [models.upstream_model]、[[routes]]、または [[route_prefixes]] で解決する必要あり
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"   # [models.upstream_model]、[[routes]]、または [[route_prefixes]] で解決する必要あり
 ```
 
 残りは同じ [Codex のセクション](/ja/guides/codex/#4-claude-code-でモデルを選択する)がそのままカバーします。`model:` フロントマターで**サブエージェント**を Grok スラッグに乗せること、そしてセッション全体で **tier エイリアス**（`ANTHROPIC_DEFAULT_SONNET_MODEL`、…）を Grok スラッグへリマップすることです。
@@ -154,7 +154,7 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # [models.upstream_model]、[[
 
 <Aside type="tip" title="既製のエージェント">
 
-**[`shunt-xai` プラグイン](https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai)** は `grok-4.5` / `grok-4.3` / `grok-build-0.1` 向けのサブエージェントを出荷しています — `/plugin marketplace add pleaseai/shunt` の後に `/plugin install shunt-xai@shunt` でインストールします。各エージェントは自身の `model:` を固定するため、そのサブエージェントだけが迂回し、メインセッションは Claude のまま残ります。手元にある認証情報に応じて、`shunt.toml` でスラッグを `grok` または `xai` へルーティングしてください。
+**[`shunt-xai` プラグイン](https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai)** は `grok-4.6` / `grok-4.5` / `grok-build-0.1` 向けのサブエージェントを出荷しています — `/plugin marketplace add pleaseai/shunt` の後に `/plugin install shunt-xai@shunt` でインストールします。各エージェントは自身の `model:` を固定するため、そのサブエージェントだけが迂回し、メインセッションは Claude のまま残ります。手元にある認証情報に応じて、`shunt.toml` でスラッグを `grok` または `xai` へルーティングしてください。
 
 </Aside>
 
@@ -170,12 +170,12 @@ effort = "high"        # すべての grok トラフィックに適用
 
 # …またはルートごとに
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 effort = "high"
 ```
 
-`grok-4.5` は `reasoning.effort` を受け入れます（ライブ検証済み）。それで `400` になるスラッグでは `effort` を未設定のままにしてください。完全な優先順位とエフォートの表: [Effort とコンテキスト](/ja/guides/effort-and-context/#reasoning-エフォート)。
+`grok-4.6` は `reasoning.effort` を受け入れます（ライブ検証済み）。それで `400` になるスラッグでは `effort` を未設定のままにしてください。完全な優先順位とエフォートの表: [Effort とコンテキスト](/ja/guides/effort-and-context/#reasoning-エフォート)。
 
 ## コンテキストウィンドウ
 
@@ -204,7 +204,7 @@ default_provider = "anthropic"
 effort = "high"     # オプション: すべての Grok トラフィックで推論エフォートを有効化
 
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 ```
 
@@ -215,10 +215,10 @@ shunt login xai                                     # 一度きりのデバイ�
 ./target/release/shunt run                          # ゲートウェイを起動
 
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3001
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"     # /model ピッカーに追加
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"     # /model ピッカーに追加
 ```
 
-`/model` から **grok-4.5** を選びます。セッション内のそれ以外のすべては引き続き変更なしで Anthropic へ流れます。マッピングされたモデルの推論だけが、あなたの SuperGrok サブスクリプションによって応答されます。
+`/model` から **grok-4.6** を選びます。セッション内のそれ以外のすべては引き続き変更なしで Anthropic へ流れます。マッピングされたモデルの推論だけが、あなたの SuperGrok サブスクリプションによって応答されます。
 
 ## トラブルシューティング
 

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -117,7 +117,7 @@ provider = "kimi"
 | 플러그인 | 모델 (에이전트당 하나) | 프로바이더 |
 | :-- | :-- | :-- |
 | `shunt-codex` | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` | `codex` (ChatGPT 구독) |
-| `shunt-xai` | `grok-build-0.1`, `grok-4.5`, `grok-4.3` | `xai` (API 키) 또는 `grok` (구독) |
+| `shunt-xai` | `grok-4.6`, `grok-4.5`, `grok-build-0.1` | `xai` (API 키) 또는 `grok` (구독) |
 | `shunt-kimi` | `kimi-k3[1m]`, `kimi-k2.7-code` | `kimi` |
 | `shunt-deepseek` | `deepseek-v4-pro`, `deepseek-v4-flash` | `deepseek` |
 | `shunt-zai` | `glm-5.2`, `glm-4.7` | `zai` |

--- a/site/src/content/docs/ko/guides/xai.mdx
+++ b/site/src/content/docs/ko/guides/xai.mdx
@@ -207,7 +207,7 @@ provider = "grok"
 effort = "high"
 ```
 
-`grok-4.6`는 `reasoning.effort`를 받아들입니다(실시간 검증됨). `400`을 반환하는 슬러그에 대해서는
+`grok-4.6`은 `reasoning.effort`를 받아들입니다(실시간 검증됨). `400`을 반환하는 슬러그에 대해서는
 `effort`를 설정하지 마세요. 전체 우선순위와 effort 테이블: [노력 & 컨텍스트](/ko/guides/effort-and-context/#추론-노력).
 
 ## 컨텍스트 윈도우
@@ -256,7 +256,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3001
 export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"     # /model 선택기에 추가
 ```
 
-`/model`에서 **grok-4.6**를 선택하세요. 세션의 나머지는 모두 여전히 변경 없이 Anthropic으로 흐르며,
+`/model`에서 **grok-4.6**을 선택하세요. 세션의 나머지는 모두 여전히 변경 없이 Anthropic으로 흐르며,
 오직 매핑된 모델의 추론만 사용자의 SuperGrok 구독이 응답합니다.
 
 ## 문제 해결

--- a/site/src/content/docs/ko/guides/xai.mdx
+++ b/site/src/content/docs/ko/guides/xai.mdx
@@ -110,9 +110,9 @@ auth = "xai_oauth"                                # ~/.shunt/xai-auth.json 읽�
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
-# upstream_model = "grok-4.5"   # 선택: 다른 슬러그를 업스트림으로 전달
+# upstream_model = "grok-4.6"   # 선택: 다른 슬러그를 업스트림으로 전달
 ```
 
 ## 경로 B — xAI 개발자 API (`xai`)
@@ -137,7 +137,7 @@ api_key_env = "XAI_API_KEY"
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "xai"
 ```
 
@@ -157,7 +157,7 @@ provider = "xai"
 ## 모델 슬러그
 
 슬러그 카탈로그는 shunt의 것이 아니라 **xAI의 것**입니다 — shunt는 사용자가 라우팅하는 슬러그를 그대로
-전달합니다. 현재 코딩/프런티어 슬러그는 `grok-4.5`, `grok-4.3`, `grok-build-0.1`입니다. 라우트에서
+전달합니다. 현재 코딩/프런티어 슬러그는 `grok-4.6`, `grok-4.5`, `grok-build-0.1`입니다. 라우트에서
 `upstream_model`을 사용하면 Claude Code env를 건드리지 않고 별칭을 실제 슬러그로 매핑할 수 있습니다. (모델
 [디스커버리](/ko/guides/model-discovery/)는 사용자가 선언한 `claude-` 이름의 별칭만 노출하므로 원시 Grok
 슬러그는 나열할 수 없습니다 — 아래의 `ANTHROPIC_CUSTOM_MODEL_OPTION`이나 티어 리매핑으로 접근하세요.)
@@ -168,7 +168,7 @@ Grok 슬러그는 `claude-`로 시작하지 않으므로, Claude Code의 `/model
 나열하지 않습니다. 메커니즘은 **Codex와 동일합니다** — id를 선택기에 직접 추가하세요:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # [models.upstream_model], [[routes]], [[route_prefixes]] 중 하나로 해석되어야 함
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"   # [models.upstream_model], [[routes]], [[route_prefixes]] 중 하나로 해석되어야 함
 ```
 
 동일한 [Codex 섹션](/ko/guides/codex/#4-claude-code에서-모델-선택)이 나머지를 그대로 다룹니다:
@@ -180,7 +180,7 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # [models.upstream_model], [[r
 <Aside type="tip" title="미리 만들어진 에이전트">
 
 **[`shunt-xai` 플러그인](https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai)**은
-`grok-4.5` / `grok-4.3` / `grok-build-0.1`용 서브에이전트를 제공합니다 —
+`grok-4.6` / `grok-4.5` / `grok-build-0.1`용 서브에이전트를 제공합니다 —
 `/plugin marketplace add pleaseai/shunt` 후 `/plugin install shunt-xai@shunt`로 설치하세요.
 각 에이전트는 자신의 `model:`을 고정하므로, 그 서브에이전트만 우회하며 메인 세션은 Claude에 머뭅니다.
 보유한 자격 증명에 따라 `shunt.toml`에서 슬러그를 `grok` 또는 `xai`로 라우팅하세요.
@@ -202,12 +202,12 @@ effort = "high"        # 모든 grok 트래픽에 적용
 
 # …또는 라우트별
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 effort = "high"
 ```
 
-`grok-4.5`는 `reasoning.effort`를 받아들입니다(실시간 검증됨). `400`을 반환하는 슬러그에 대해서는
+`grok-4.6`는 `reasoning.effort`를 받아들입니다(실시간 검증됨). `400`을 반환하는 슬러그에 대해서는
 `effort`를 설정하지 마세요. 전체 우선순위와 effort 테이블: [노력 & 컨텍스트](/ko/guides/effort-and-context/#추론-노력).
 
 ## 컨텍스트 윈도우
@@ -242,7 +242,7 @@ default_provider = "anthropic"
 effort = "high"     # 선택: 모든 Grok 트래픽에 추론 노력 활성화
 
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 ```
 
@@ -253,10 +253,10 @@ shunt login xai                                     # 일회성 디바이스 코
 ./target/release/shunt run                          # 게이트웨이 시작
 
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3001
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"     # /model 선택기에 추가
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"     # /model 선택기에 추가
 ```
 
-`/model`에서 **grok-4.5**를 선택하세요. 세션의 나머지는 모두 여전히 변경 없이 Anthropic으로 흐르며,
+`/model`에서 **grok-4.6**를 선택하세요. 세션의 나머지는 모두 여전히 변경 없이 Anthropic으로 흐르며,
 오직 매핑된 모델의 추론만 사용자의 SuperGrok 구독이 응답합니다.
 
 ## 문제 해결

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -126,7 +126,7 @@ provider = "kimi"
 | 插件 | 模型(每个一个 agent) | 提供方 |
 | :-- | :-- | :-- |
 | `shunt-codex` | `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` | `codex`(ChatGPT 订阅) |
-| `shunt-xai` | `grok-build-0.1`、`grok-4.5`、`grok-4.3` | `xai`(API 密钥)或 `grok`(订阅) |
+| `shunt-xai` | `grok-4.6`、`grok-4.5`、`grok-build-0.1` | `xai`(API 密钥)或 `grok`(订阅) |
 | `shunt-kimi` | `kimi-k3[1m]`、`kimi-k2.7-code` | `kimi` |
 | `shunt-deepseek` | `deepseek-v4-pro`、`deepseek-v4-flash` | `deepseek` |
 | `shunt-zai` | `glm-5.2`、`glm-4.7` | `zai` |

--- a/site/src/content/docs/zh-cn/guides/xai.mdx
+++ b/site/src/content/docs/zh-cn/guides/xai.mdx
@@ -112,9 +112,9 @@ auth = "xai_oauth"                                # 读取 + 自动刷新 ~/.shu
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
-# upstream_model = "grok-4.5"   # 可选:向上游转发一个不同的 slug
+# upstream_model = "grok-4.6"   # 可选:向上游转发一个不同的 slug
 ```
 
 ## 路径 B —— xAI 开发者 API(`xai`)
@@ -139,7 +139,7 @@ api_key_env = "XAI_API_KEY"
 
 ```toml
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "xai"
 ```
 
@@ -159,7 +159,7 @@ provider = "xai"
 ## 模型 slug
 
 slug 目录是 **xAI 的**,而非 shunt 的 —— shunt 转发你所路由的任意 slug。当前的
-编码/前沿 slug 有 `grok-4.5`、`grok-4.3` 和 `grok-build-0.1`。在路由中用 `upstream_model`
+编码/前沿 slug 有 `grok-4.6`、`grok-4.5` 和 `grok-build-0.1`。在路由中用 `upstream_model`
 可将一个别名映射到一个实时 slug,而无需改动你的 Claude Code 环境。(模型
 [发现](/zh-cn/guides/model-discovery/) 只会透出你声明的 `claude-` 命名别名,因此无法列出原始 Grok
 slug —— 请通过下文的 `ANTHROPIC_CUSTOM_MODEL_OPTION` 或分层重映射来访问。)
@@ -170,7 +170,7 @@ Grok slug 不以 `claude-` 开头,因此 Claude Code 的 `/model` 选择器不�
 其机制与 **Codex 完全相同** —— 直接把 id 加入选择器:
 
 ```bash
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # 必须通过 [models.upstream_model]、[[routes]] 或 [[route_prefixes]] 解析
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"   # 必须通过 [models.upstream_model]、[[routes]] 或 [[route_prefixes]] 解析
 ```
 
 同一节 [Codex 章节](/zh-cn/guides/codex/#4-在-claude-code-中选择模型) 逐字覆盖其余内容:
@@ -182,7 +182,7 @@ export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"   # 必须通过 [models.upstrea
 <Aside type="tip" title="现成的 agent">
 
 **[`shunt-xai` 插件](https://github.com/pleaseai/shunt/tree/main/plugins/shunt-xai)** 提供了
-面向 `grok-4.5` / `grok-4.3` / `grok-build-0.1` 的子 agent —— 在
+面向 `grok-4.6` / `grok-4.5` / `grok-build-0.1` 的子 agent —— 在
 `/plugin marketplace add pleaseai/shunt` 之后用 `/plugin install shunt-xai@shunt` 安装。每个 agent
 固定其 `model:`,因此只有该子 agent 会分流;主会话仍留在 Claude。按你所持的凭据将 slug 路由到
 `grok` 或 `xai`(在 `shunt.toml` 中)。
@@ -204,12 +204,12 @@ effort = "high"        # 应用于所有 grok 流量
 
 # ……或按路由
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 effort = "high"
 ```
 
-`grok-4.5` 接受 `reasoning.effort`(已实测)。对任何在其上 `400` 的 slug,请让 `effort`
+`grok-4.6` 接受 `reasoning.effort`(已实测)。对任何在其上 `400` 的 slug,请让 `effort`
 保持未设置。完整优先级和力度表:[力度与上下文](/zh-cn/guides/effort-and-context/#推理力度)。
 
 ## 上下文窗口
@@ -244,7 +244,7 @@ default_provider = "anthropic"
 effort = "high"     # 可选:为所有 Grok 流量选择性启用推理力度
 
 [[routes]]
-model = "grok-4.5"
+model = "grok-4.6"
 provider = "grok"
 ```
 
@@ -255,10 +255,10 @@ shunt login xai                                     # 一次性设备码登录
 ./target/release/shunt run                          # 启动网关
 
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3001
-export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.5"     # 加入 /model 选择器
+export ANTHROPIC_CUSTOM_MODEL_OPTION="grok-4.6"     # 加入 /model 选择器
 ```
 
-从 `/model` 选择 **grok-4.5**。会话中的其他一切仍原样流向 Anthropic;
+从 `/model` 选择 **grok-4.6**。会话中的其他一切仍原样流向 Anthropic;
 只有映射模型的推理由你的 SuperGrok 订阅应答。
 
 ## 故障排查


### PR DESCRIPTION
## Summary

Grok 4.6 is out. This adds a `shunt-xai:grok-4.6` subagent and promotes `grok-4.6` to the default example across the docs, the site (all 4 locales), the blueprints, and `shunt.toml.example`.

It also drops the `grok-4.3` subagent from the curated plugin set. To be explicit: **`grok-4.3` is not retired upstream** — it still returns HTTP 200 (see the probe table below). It is simply no longer shipped as a ready-made agent; routing it via `[[routes]]` works exactly as before, and the plugin README now says so.

Docs-only change in behavior terms — **no `.rs` files are touched**. shunt has no version-keyed Grok logic; slugs are pass-through, so a new model needs no code.

**Scope / non-goals**
- No adapter, routing, or config changes.
- The `grok-4.5`/`grok-4.3` strings in `tests/` and `src/adapters/responses/{request,error}.rs` are arbitrary test fixtures with no behavioral meaning; left untouched to avoid churn.
- The `EXPERIMENTAL — not yet verified against the live xAI API` wording is left as-is. The probe below covers the `grok` subscription path (`cli-chat-proxy.grok.com`) only; the API-key `xai` path (`api.x.ai`) remains unverified here, since I have no `XAI_API_KEY`.

## Milestone / spec

M6 — `docs/m6-xai-provider.md` §6 (reasoning gate), §9 (model list), §10 (live-API validation). All three updated with dated live notes.

## Test plan with observed results

Live probe against a SuperGrok account through the `grok` provider (`cli-chat-proxy.grok.com`), non-streaming, via an isolated shunt instance:

| slug | HTTP |
| --- | --- |
| `grok-4.6` | 200 |
| `grok-4.6` with `effort = "high"` | 200 |
| `grok-4.5` | 200 |
| `grok-4.3` | 200 |
| `grok-build-0.1` | 200 |
| `grok-4` | 200 |
| `grok-4-fast` | 200 |

So `grok-4.6` accepts `reasoning.effort` — the claim in `guides/xai.mdx` now names 4.6 truthfully rather than being carried over.

Gates:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features --workspace` — 18 test binaries, **0 failed** (1277 + 17 suites)
- `npm run build` in `site/` — 149 pages across all 4 locales

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (no new behavior to cover — docs/plugin only)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines (no source files changed)
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated — `docs/m6-xai-provider.md` model list and live-validation notes
- [x] User-facing docs updated — `site/src/content/docs/{,ja/,ko/,zh-cn/}guides/{xai,providers}.mdx`, `docs/running.md`, `shunt.toml.example`, `blueprints/upstream/{grok,xai}.md`. `README.md` needs no change (it names providers, not Grok slugs). `wiki/` not hand-edited.
- [x] No new GitHub Actions

## Notes for reviewers

- `plugins/shunt-xai/.claude-plugin/plugin.json` version bumped `0.1.0` → `0.2.0` (agent set changed). Tell me if you would rather this stayed at `0.1.0`.
- Git renders the plugin change as a rename `grok-4.3.md` → `grok-4.6.md` (77% similar). It is a delete plus an add — the agent body is boilerplate shared across all three agents.
- The locale `.mdx` edits are mechanical slug substitutions inside existing prose and TOML fences; no prose was rewritten in ja/ko/zh-cn, so no translation review should be needed.
- Unrelated flake spotted while verifying: `tests/antigravity_process.rs:309` (`streaming_turn_translates_stub_events_to_sse`) intermittently times out against its 20s `REQUEST_GUARD`, but passes in 0.15s when it passes — 1 fail in 3 isolated runs, and green in the full suite. Not caused by this PR (no `.rs` changes). Happy to file it separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Grok 4.6 and ships a `shunt-xai:grok-4.6` subagent; curated `grok-4.3` is removed while the `grok-4.3` slug continues to route via `[[routes]]`.

- Behavior: `grok-4.6` returns HTTP 200 through the `grok` provider, including with `effort = "high"`. No Rust code or adapters changed.
- Docs/site/blueprints: default examples now use `grok-4.6` across guides (all four locales), blueprints, and `shunt.toml.example`; minor site copy cleanups applied post-review.
- Plugin: adds the `shunt-xai:grok-4.6` agent, bumps `plugins/shunt-xai/.claude-plugin/plugin.json` to version 0.2.0, and updates marketplace metadata.

**Migration**
- Update references from `@shunt-xai:grok-4.3` to `@shunt-xai:grok-4.6` or `@shunt-xai:grok-4.5`.
- To keep using `grok-4.3`, add a `[[routes]]` entry for `model = "grok-4.3"`; routing still works.

<sup>Written for commit 83b2c6595fab867f5186b3df38ec2cd783b7dae2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

