### PR TITLE
chore: record gateway-claims comment-rot review learnings

### DIFF
--- a/.claude/agent-memory/review-review-comment-analyzer/MEMORY.md
+++ b/.claude/agent-memory/review-review-comment-analyzer/MEMORY.md
@@ -6,4 +6,5 @@
 - [shunt account scan-cache comment rot](shunt-account-scan-cache-comment-rot.md) — Recheck lexical path collisions, discovery-only I/O claims, concurrent misses, and mtime invalidation language.
 - [Codex WS continuation quantifier rot](codex-ws-continuation-quantifier-rot.md) — Reused continuation-enabled turns retrieve stored state; fresh, overflow, and full-retry turns bypass it, so avoid universal “every turn” claims.
 - [shunt perf benchmark baseline scope](shunt-perf-benchmark-baseline-scope.md) — `perf_issues.rs` mixes frozen pre-#261 baselines with later issue-specific pairs; scope each baseline to its refactor.
+- [gateway_claims scope rot in failover.rs](shunt-gateway-claims-scope-rot.md) — `gateway_claims` is set before the auth-gate early return (so "gated chain" wording over-narrows), and `injects_credential` is chain-level in `check_inbound_auth` but per-route in `headers_for_route`.
 - [shunt PR #331 auto-mode classifier clean](shunt-pr331-auto-mode-classifier-clean.md) — 3-round rewordings verified against `resolve_claude_account`/`forward_claude_oauth`; 7-surface cross-check method for gating-invariant claims.

--- a/.claude/agent-memory/review-review-comment-analyzer/shunt-gateway-claims-scope-rot.md
+++ b/.claude/agent-memory/review-review-comment-analyzer/shunt-gateway-claims-scope-rot.md
@@ -1,0 +1,16 @@
+---
+name: shunt-gateway-claims-scope-rot
+description: In src/proxy/failover.rs, `InboundContext.gateway_claims` is populated before the auth gate's early return, so comments scoping a gateway-JWT behavior to "a gated chain" over-narrow what the code does; also `injects_credential` means different things in check_inbound_auth (chain-level) vs headers_for_route (per-route).
+metadata:
+  type: project
+---
+
+Two recurring comment-rot traps in `src/proxy/failover.rs` (seen in PR #355, `fix/gateway-jwt-credential-slots`):
+
+1. `check_inbound_auth` computes `gateway_claims` *before* the `if !injects_credential || (no auth configured)` early return. So `inbound.gateway_claims.is_some()` is true for any caller holding a valid gateway JWT — including an all-passthrough chain where nothing was gated. Any comment or doc sentence phrased as "whenever a gateway JWT **authenticated** the request" or "on the passthrough attempt of a **gated** chain" is narrower than the code.
+
+2. `injects_credential` is a local name used twice with different meanings: chain-level (`routes.iter().any(...)`) in `check_inbound_auth`, per-route (`!is_passthrough_route(state, route)`) in `headers_for_route`. Comments inside `headers_for_route` that assert "`injects_credential` is chain-level" contradict the binding 20 lines above them.
+
+**Why:** both produce comments that read correct in isolation but assert the wrong scope for the reader standing in that function.
+
+**How to apply:** when reviewing comments about gateway-JWT credential stripping, re-read `check_inbound_auth` top-to-bottom for the early return, and check which `injects_credential` binding is in scope. Related: [[unfalsifiable-doc-claims]] style over-scoped claims.


### PR DESCRIPTION
## Summary

Adds one project-scope agent-memory note (plus its index entry) capturing two comment-rot traps observed in `src/proxy/failover.rs` while reviewing PR #355. No source, tests, or configuration are touched — documentation only, no runtime effect.

## Milestone / spec

N/A — internal review-learnings memory, not tied to a milestone spec.

## Changes

- `.claude/agent-memory/review-review-comment-analyzer/shunt-gateway-claims-scope-rot.md` (new)
- `.claude/agent-memory/review-review-comment-analyzer/MEMORY.md` (one added index entry)

The note records:

1. `check_inbound_auth` computes `gateway_claims` *before* its `!injects_credential` early return, so `gateway_claims.is_some()` means "the caller presented a valid gateway JWT", not "a gateway JWT authenticated this request". Any comment/doc phrased as "whenever a gateway JWT **authenticated** the request" or "on the passthrough attempt of a **gated** chain" is narrower than what the code actually does. This is still structurally true on `main` — PR #355's fix made the gap harmless by checking each credential slot by value rather than keying off the request-level flag, but the flag itself is still computed before the early return, so the trap remains relevant for future reviewers.
2. `injects_credential` is bound twice with different meanings — chain-level (`routes.iter().any(...)`) in `check_inbound_auth`, per-route (`!is_passthrough_route(state, route)`) in `headers_for_route`. A comment inside `headers_for_route` asserting it is chain-level directly contradicts the binding above it. This trap was fixed by PR #355's comment rewrite.

## Checklist

- [ ] `cargo build` passes — N/A, no Rust source touched
- [ ] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — N/A, no tests touched
- [ ] `cargo clippy --all-targets -- -D warnings` clean — N/A, no Rust source touched
- [ ] `cargo fmt --all --check` clean — N/A, no Rust source touched
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it — N/A, no spec deviation
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — N/A, no user-facing behavior changed
- [x] Any new GitHub Action is pinned to a full commit SHA — N/A, no workflow changes

## Notes for reviewers

Pure documentation of review learnings for future PRs touching `src/proxy/failover.rs`'s inbound-auth path; no code review action needed beyond confirming the note accurately reflects current `main` behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents two comment-rot traps in `src/proxy/failover.rs` to guide future reviews; no runtime, test, or config changes.

- Adds `./.claude/agent-memory/review-review-comment-analyzer/shunt-gateway-claims-scope-rot.md` and indexes it in `MEMORY.md`.
- Clarifies that `check_inbound_auth` sets `gateway_claims` before the auth-gate early return, so `gateway_claims.is_some()` means “valid gateway JWT was presented,” not “request was gated.”
- Notes `injects_credential` is chain-level in `check_inbound_auth` but per-route in `headers_for_route`, which can invalidate comments that assume a single meaning.

<sup>Written for commit 8955b70cb2bcbdafab0cad1546e61c003742c82c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

