### PR TITLE
fix(codex): accept lowercase auth_mode in import_auth

### DIFF
--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -123,8 +123,8 @@ shunt reads (and, on refresh, rewrites) this JSON, written by `codex login`:
 
 ```jsonc
 {
-  "auth_mode": "ChatGPT",          // "ApiKey" routes to the openai provider instead
-  "OPENAI_API_KEY": null,          // a string only in ApiKey mode
+  "auth_mode": "chatgpt",          // "apikey" routes to the openai provider instead
+  "OPENAI_API_KEY": null,          // a string only in apikey mode
   "tokens": {
     "id_token":      "<JWT>",
     "access_token":  "<JWT>",      // bearer sent upstream; carries exp + account claim
@@ -135,6 +135,11 @@ shunt reads (and, on refresh, rewrites) this JSON, written by `codex login`:
 }
 ```
 
+- **`auth_mode` spelling** — the Codex CLI serializes its `AuthMode` enum with
+  `rename_all = "lowercase"`, so a current `codex login` writes `"chatgpt"` and `codex login
+  --api-key` writes `"apikey"`. Older Codex versions wrote `"ChatGPT"` / `"ApiKey"`. shunt
+  compares this field **case-insensitively** everywhere it reads it (`import_auth`,
+  `read_openai_api_key`, credential observation), so either spelling is accepted.
 - **Account id** — shunt prefers `tokens.account_id`; if absent it decodes the `access_token`
   JWT payload and reads `["https://api.openai.com/auth"].chatgpt_account_id`. If neither exists
   the request fails with `ChatGPT account id missing; run codex login`.
@@ -671,7 +676,7 @@ cooldown/failover rules, and how this differs from the Anthropic (`claude_oauth`
 | Symptom | Likely cause / fix |
 | :-- | :-- |
 | `authentication_error: ChatGPT auth not found; run codex login` | No `~/.codex/auth.json` (or wrong `$CODEX_AUTH_FILE`). Run `codex login`. |
-| `ChatGPT auth tokens missing` / `refresh token missing` | Auth file is in `ApiKey` mode or truncated — that path is the `openai` provider, not `codex`. Re-`codex login` with a ChatGPT account. |
+| `ChatGPT auth tokens missing` / `refresh token missing` | Auth file is in API-key mode (`"auth_mode": "apikey"`) or truncated — that path is the `openai` provider, not `codex`. Re-`codex login` with a ChatGPT account. |
 | `400 … not supported when using Codex with a ChatGPT account` | You used a `gpt-*-codex` slug. Use an entitled non-`-codex` slug (§5). |
 | `Model not found <slug>` | Client-version gating or an unentitled slug — not a code error. Confirm the slug via `models.json`; shunt already sends the pinned CLI headers (§4.4). |
 | Effort slider seems ignored on a `gpt-*` id | A `route`/`provider` `effort` override is winning, or no effort level is set. `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` is not the fix — these ids already send effort (§8). |

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -136,8 +136,9 @@ shunt reads (and, on refresh, rewrites) this JSON, written by `codex login`:
 ```
 
 - **`auth_mode` spelling** — the Codex CLI serializes its `AuthMode` enum with
-  `rename_all = "lowercase"`, so a current `codex login` writes `"chatgpt"` and `codex login
-  --api-key` writes `"apikey"`. Older Codex versions wrote `"ChatGPT"` / `"ApiKey"`. shunt
+  `rename_all = "lowercase"`, so a current `codex login` writes `"chatgpt"` and an API-key
+  login (`printenv OPENAI_API_KEY | codex login --with-api-key`) writes `"apikey"`. Older Codex
+  versions wrote `"ChatGPT"` / `"ApiKey"`. shunt
   compares this field **case-insensitively** everywhere it reads it (`import_auth`,
   `read_openai_api_key`, credential observation), so either spelling is accepted.
 - **Account id** — shunt prefers `tokens.account_id`; if absent it decodes the `access_token`

--- a/docs/m10-codex-multi-account.md
+++ b/docs/m10-codex-multi-account.md
@@ -66,7 +66,10 @@ Each account has these fields:
 
 `credentials` and `token_env` are mutually exclusive. A name-only account reads `~/.shunt/accounts/codex/<name>.json` (override the directory with `SHUNT_CODEX_ACCOUNTS_DIR`). With an entirely empty `accounts` list, shunt scans that directory and uses every valid `*.json` account in filename order. Store files are written atomically at `0600`, and the store directory is `0700` on Unix — the account is stored **verbatim** in the Codex CLI's own `auth.json` shape (no `claudeAiOauth`-style wrapper, unlike the Claude store).
 
-`shunt login codex --name <name>` imports the current login from `$CODEX_AUTH_FILE` (or `~/.codex/auth.json`) into the store without modifying the source file, and validates it is in `ChatGPT` auth mode with non-empty access and refresh tokens. Reusing a name replaces that store file. There is no `--long-lived` equivalent — Codex has no setup-token concept; every store-managed account is a refreshable OAuth login.
+`shunt login codex --name <name>` imports the current login from `$CODEX_AUTH_FILE` (or `~/.codex/auth.json`) into the store without modifying the source file, and validates it is a ChatGPT login with non-empty access and refresh tokens. The Codex CLI
+serializes `auth_mode` in lowercase (`"chatgpt"`); shunt matches it case-insensitively, so files
+from older Codex versions (`"ChatGPT"`) import unchanged. An API-key login (`"apikey"`) is
+rejected with `is not a ChatGPT login (auth_mode is not "chatgpt")`. Reusing a name replaces that store file. There is no `--long-lived` equivalent — Codex has no setup-token concept; every store-managed account is a refreshable OAuth login.
 
 The built-in `codex` provider remains `auth = "chatgpt_oauth"` by default even without a pool — a single-account `chatgpt_oauth` provider with no `accounts` configured behaves exactly as before M10 (see the "existing single-account path" note below). Multi-account pooling is opt-in via `[[providers.codex.accounts]]`.
 

--- a/docs/m2-chatgpt-oauth.md
+++ b/docs/m2-chatgpt-oauth.md
@@ -44,7 +44,8 @@ Out of scope: any change to request/response translation (that is M1).
 
 **`openai` provider (API key):**
 1. `OPENAI_API_KEY` env, else
-2. `~/.codex/auth.json` `.OPENAI_API_KEY` when `auth_mode == "ApiKey"` and non-null, else
+2. `~/.codex/auth.json` `.OPENAI_API_KEY` when `auth_mode` is `"apikey"` (compared
+   case-insensitively — older Codex wrote `"ApiKey"`) and non-null, else
 3. `[providers.openai] api_key_env` indirection in config.
 → header `Authorization: Bearer <key>`.
 
@@ -58,8 +59,8 @@ Out of scope: any change to request/response translation (that is M1).
 
 ```jsonc
 {
-  "auth_mode": "ChatGPT",          // or "ApiKey"
-  "OPENAI_API_KEY": null,          // string when auth_mode == "ApiKey"
+  "auth_mode": "chatgpt",          // or "apikey"; matched case-insensitively
+  "OPENAI_API_KEY": null,          // string in apikey mode
   "tokens": {
     "id_token":      "<JWT>",
     "access_token":  "<JWT>",      // bearer sent upstream; carries exp + account claim

--- a/site/src/content/docs/guides/codex-multi-account.mdx
+++ b/site/src/content/docs/guides/codex-multi-account.mdx
@@ -68,6 +68,8 @@ Store files live at `~/.shunt/accounts/codex/<name>.json`; set `SHUNT_CODEX_ACCO
 
 There is no `--long-lived` flag for `shunt login codex` — Codex has no setup-token concept, so every store-managed account is a refreshable OAuth login imported from an existing `codex login`.
 
+The import only accepts a **ChatGPT** login. A current `codex login` writes `"auth_mode": "chatgpt"` into `$CODEX_AUTH_FILE` (or `~/.codex/auth.json`); shunt matches that field case-insensitively, so a file from an older Codex version (`"ChatGPT"`) imports unchanged. An API-key login (`"auth_mode": "apikey"`) is rejected with `is not a ChatGPT login (auth_mode is not "chatgpt")` — re-run `codex login` and pick a ChatGPT account.
+
 ## Account fields
 
 | Field | Required | Meaning |

--- a/site/src/content/docs/ja/guides/codex-multi-account.mdx
+++ b/site/src/content/docs/ja/guides/codex-multi-account.mdx
@@ -68,6 +68,8 @@ name = "backup"
 
 `shunt login codex` に `--long-lived` フラグはありません — Codex に setup-token の概念はないため、ストア管理のアカウントはすべて、既存の `codex login` からインポートされたリフレッシュ可能な OAuth ログインです。
 
+インポートが受け付けるのは **ChatGPT** ログインだけです。現行の `codex login` は `$CODEX_AUTH_FILE`（または `~/.codex/auth.json`）に `"auth_mode": "chatgpt"` を書き込みます。shunt はこのフィールドを大文字小文字を区別せずに比較するため、古い Codex が残したファイル（`"ChatGPT"`）もそのままインポートできます。API キーのログイン（`"auth_mode": "apikey"`）は `is not a ChatGPT login (auth_mode is not "chatgpt")` として拒否されます — `codex login` をやり直して ChatGPT アカウントを選んでください。
+
 ## アカウントのフィールド
 
 | フィールド | 必須 | 意味 |

--- a/site/src/content/docs/ko/guides/codex-multi-account.mdx
+++ b/site/src/content/docs/ko/guides/codex-multi-account.mdx
@@ -68,6 +68,8 @@ name = "backup"
 
 `shunt login codex`에는 `--long-lived` 플래그가 없습니다 — Codex에는 setup token 개념이 없으므로, 스토어가 관리하는 모든 계정은 기존 `codex login`에서 가져온 갱신 가능한 OAuth 로그인입니다.
 
+가져오기는 **ChatGPT** 로그인만 받아들입니다. 현재 버전의 `codex login`은 `$CODEX_AUTH_FILE`(또는 `~/.codex/auth.json`)에 `"auth_mode": "chatgpt"`를 씁니다. shunt는 이 필드를 대소문자 구분 없이 비교하므로, 예전 Codex 버전이 남긴 파일(`"ChatGPT"`)도 그대로 가져옵니다. API 키 로그인(`"auth_mode": "apikey"`)은 `is not a ChatGPT login (auth_mode is not "chatgpt")` 오류로 거부됩니다 — `codex login`을 다시 실행해 ChatGPT 계정을 선택하세요.
+
 ## 계정 필드
 
 | 필드 | 필수 | 의미 |

--- a/site/src/content/docs/zh-cn/guides/codex-multi-account.mdx
+++ b/site/src/content/docs/zh-cn/guides/codex-multi-account.mdx
@@ -68,6 +68,8 @@ name = "backup"
 
 `shunt login codex` 没有 `--long-lived` 标志 —— Codex 没有 setup-token 这一概念,因此每个由存储管理的账户,都是从已有的 `codex login` 导入的可刷新 OAuth 登录。
 
+导入只接受 **ChatGPT** 登录。当前版本的 `codex login` 会向 `$CODEX_AUTH_FILE`(或 `~/.codex/auth.json`)写入 `"auth_mode": "chatgpt"`;shunt 比较该字段时忽略大小写,因此旧版 Codex 留下的文件(`"ChatGPT"`)也能原样导入。API 密钥登录(`"auth_mode": "apikey"`)会被拒绝,并报 `is not a ChatGPT login (auth_mode is not "chatgpt")` —— 请重新运行 `codex login` 并选择 ChatGPT 账户。
+
 ## 账户字段
 
 | 字段 | 必填 | 含义 |

--- a/src/auth/codex/auth.rs
+++ b/src/auth/codex/auth.rs
@@ -272,7 +272,15 @@ struct OAuthTokenResponse {
 
 pub fn read_openai_api_key(path: &Path) -> Option<String> {
     let auth = read_auth_file(path).ok()?;
-    if auth.value.get("auth_mode").and_then(Value::as_str) != Some("ApiKey") {
+    // The Codex CLI serializes `AuthMode` with `rename_all = "lowercase"`, so a
+    // current `codex login --api-key` writes `"apikey"`; older files wrote
+    // `"ApiKey"`. Accept either spelling.
+    if !auth
+        .value
+        .get("auth_mode")
+        .and_then(Value::as_str)
+        .is_some_and(|mode| mode.eq_ignore_ascii_case("apikey"))
+    {
         return None;
     }
     auth.value
@@ -541,6 +549,40 @@ mod tests {
         .unwrap();
 
         assert_eq!(read_openai_api_key(&path).as_deref(), Some("key-from-file"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The Codex CLI serializes `AuthMode` with `rename_all = "lowercase"`, so a
+    /// real API-key login writes `"apikey"`, not `"ApiKey"`.
+    #[test]
+    fn parses_auth_json_for_lowercase_api_key_mode() {
+        let dir = std::env::temp_dir().join("shunt-auth-json-lowercase-api-key");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"auth_mode":"apikey","OPENAI_API_KEY":"key-from-file","tokens":null}"#,
+        )
+        .unwrap();
+
+        assert_eq!(read_openai_api_key(&path).as_deref(), Some("key-from-file"));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// The relaxed comparison must stay a *spelling* relaxation: a ChatGPT-mode
+    /// file is still not an API-key login, even when it carries a stray key.
+    #[test]
+    fn read_openai_api_key_rejects_chatgpt_mode() {
+        let dir = std::env::temp_dir().join("shunt-auth-json-chatgpt-not-api-key");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"auth_mode":"chatgpt","OPENAI_API_KEY":"stray","tokens":null}"#,
+        )
+        .unwrap();
+
+        assert_eq!(read_openai_api_key(&path), None);
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/auth/codex/auth.rs
+++ b/src/auth/codex/auth.rs
@@ -273,7 +273,7 @@ struct OAuthTokenResponse {
 pub fn read_openai_api_key(path: &Path) -> Option<String> {
     let auth = read_auth_file(path).ok()?;
     // The Codex CLI serializes `AuthMode` with `rename_all = "lowercase"`, so a
-    // current `codex login --api-key` writes `"apikey"`; older files wrote
+    // current `codex login --with-api-key` writes `"apikey"`; older files wrote
     // `"ApiKey"`. Accept either spelling.
     if !auth
         .value

--- a/src/auth/codex/store.rs
+++ b/src/auth/codex/store.rs
@@ -184,7 +184,11 @@ pub fn import_auth(name: &str, source: &Path) -> anyhow::Result<PathBuf> {
             format!("invalid Codex credentials JSON: {error}"),
         )
     })?;
-    if value.get("auth_mode").and_then(Value::as_str) != Some("ChatGPT") {
+    if !value
+        .get("auth_mode")
+        .and_then(Value::as_str)
+        .is_some_and(|mode| mode.eq_ignore_ascii_case("chatgpt"))
+    {
         anyhow::bail!(
             "{} is not a ChatGPT login (auth_mode != \"ChatGPT\"); run `codex login` first",
             source.display()
@@ -322,6 +326,30 @@ mod tests {
 
         let error = import_auth("ci", &source).unwrap_err();
         assert!(error.to_string().contains("auth_mode"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// The codex CLI writes `"auth_mode": "chatgpt"` (lowercase enum variant
+    /// `AuthMode::Chatgpt`). Verify that `import_auth` accepts it — the
+    /// comparison must be case-insensitive.
+    #[tokio::test]
+    async fn import_accepts_lowercase_chatgpt_auth_mode() {
+        let _guard = TEST_ENV_LOCK.lock().await;
+        let dir = temp_dir("lowercase-chatgpt");
+        fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("source.json");
+        fs::write(
+            &source,
+            r#"{"auth_mode":"chatgpt","tokens":{"access_token":"access","refresh_token":"refresh"}}"#,
+        )
+        .unwrap();
+        let accounts_dir = dir.join("accounts");
+        let _env = shared::EnvVarGuard::set("SHUNT_CODEX_ACCOUNTS_DIR", &accounts_dir);
+
+        let path = import_auth("ci", &source).unwrap();
+        let saved: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(saved["auth_mode"], "chatgpt");
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/src/auth/codex/store.rs
+++ b/src/auth/codex/store.rs
@@ -190,7 +190,7 @@ pub fn import_auth(name: &str, source: &Path) -> anyhow::Result<PathBuf> {
         .is_some_and(|mode| mode.eq_ignore_ascii_case("chatgpt"))
     {
         anyhow::bail!(
-            "{} is not a ChatGPT login (auth_mode != \"ChatGPT\"); run `codex login` first",
+            "{} is not a ChatGPT login (auth_mode is not \"chatgpt\"); run `codex login` first",
             source.display()
         );
     }

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -27,17 +27,17 @@ pub(super) async fn forward(
     headers: &HeaderMap,
     body: Body,
     started_at: Instant,
-) -> Result<(StatusCode, axum::response::Response), ForwardError> {
+) -> Result<(StatusCode, axum::response::Response), Box<ForwardError>> {
     let max_request_bytes = state.config.server.limits.max_request_bytes;
     if crate::http_tuning::content_length_exceeds(headers, max_request_bytes) {
-        return Err(ForwardError {
+        return Err(Box::new(ForwardError {
             message: "request body exceeds the configured limit".to_string(),
-            response: crate::http_tuning::request_too_large(false).await,
-        });
+            response: Box::new(crate::http_tuning::request_too_large(false).await),
+        }));
     }
     let body = crate::http_tuning::read_body(body, max_request_bytes, false)
         .await
-        .map_err(|response| ForwardError {
+        .map_err(|response| Box::new(ForwardError {
             message: if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
                 "request body exceeds the configured limit"
             } else {
@@ -45,20 +45,20 @@ pub(super) async fn forward(
             }
             .to_string(),
             response,
-        })?;
+        }))?;
     let mut body = crate::request::RequestBody::parse(body.to_vec())
         .map_err(routing::invalid_routing_request)
-        .map_err(|error| ForwardError {
+        .map_err(|error| Box::new(ForwardError {
             message: "failed to route request".to_string(),
-            response: error.into_response(),
-        })?;
+            response: Box::new(error.into_response()),
+        }))?;
     normalize_request_body(&mut body);
     let (mut routes, requested_model) =
         routing::resolve_request_chain_value(&state.config, body.json()).map_err(|error| {
-            ForwardError {
+            Box::new(ForwardError {
                 message: "failed to route request".to_string(),
-                response: error.into_response(),
-            }
+                response: Box::new(error.into_response()),
+            })
         })?;
     crate::observability::record_requested_model(&requested_model);
     // Records the request's final outcome exactly once, at whichever terminal
@@ -78,9 +78,9 @@ pub(super) async fn forward(
         routes.truncate(1);
     }
     let (base_headers, inbound) =
-        check_inbound_auth(&state, &routes, headers).map_err(|error| *error)?;
+        check_inbound_auth(&state, &routes, headers).await?;
     enforce_managed_model_policy(&state, inbound.gateway_claims.as_ref(), &requested_model)
-        .map_err(|error| *error)?;
+        .await?;
 
     let first_route = routes
         .first()
@@ -216,10 +216,7 @@ pub(super) async fn forward(
                     }
                     _ => {
                         finish(&provider, response.status());
-                        return Err(ForwardError {
-                            message,
-                            response: *response,
-                        });
+                        return Err(Box::new(ForwardError { message, response }));
                     }
                 }
             }
@@ -246,10 +243,7 @@ pub(super) async fn forward(
             }
             FinalResponse::MappedError { message, response } => {
                 finish(&failure.provider, response.status());
-                Err(ForwardError {
-                    message,
-                    response: *response,
-                })
+                Err(Box::new(ForwardError { message, response }))
             }
         };
     }
@@ -264,7 +258,10 @@ pub(super) async fn forward(
         &last_route.upstream_model,
     );
     finish(&last_route.provider, StatusCode::BAD_GATEWAY);
-    Err(ForwardError { message, response })
+    Err(Box::new(ForwardError {
+        message,
+        response: Box::new(response),
+    }))
 }
 
 async fn count_tokens_response(
@@ -275,7 +272,7 @@ async fn count_tokens_response(
     inbound: &InboundContext,
     body: crate::request::RequestBody,
     requested_model: &str,
-) -> Result<(StatusCode, axum::response::Response), ForwardError> {
+) -> Result<(StatusCode, axum::response::Response), Box<ForwardError>> {
     let provider = route.provider.clone();
     let upstream_model = route.upstream_model.clone();
     let result = if matches!(
@@ -326,15 +323,15 @@ async fn count_tokens_response(
             Ok((status, response))
         }
         Err(error) => {
-            let mut response = *error.response;
+            let mut response = error.response;
             stamp_gateway_headers(&mut response, &provider, requested_model, &upstream_model);
             let status = response.status();
             crate::observability::record_span_outcome(&provider, status);
             crate::observability::capture_upstream_outcome(&provider, requested_model, status);
-            Err(ForwardError {
+            Err(Box::new(ForwardError {
                 message: error.message,
                 response,
-            })
+            }))
         }
     }
 }
@@ -448,7 +445,7 @@ fn remember_failure(
     });
 }
 
-fn enforce_managed_model_policy(
+async fn enforce_managed_model_policy(
     state: &AppState,
     claims: Option<&crate::gateway::jwt::Claims>,
     requested_model: &str,
@@ -473,8 +470,10 @@ fn enforce_managed_model_policy(
         format!("model \"{requested_model}\" is not permitted by this gateway's managed policy");
     Err(Box::new(ForwardError {
         message: message.clone(),
-        response: ShuntError::new(StatusCode::BAD_REQUEST, "invalid_request_error", message)
-            .into_response(),
+        response: Box::new(
+            ShuntError::new(StatusCode::BAD_REQUEST, "invalid_request_error", message)
+                .into_response(),
+        ),
     }))
 }
 
@@ -490,7 +489,7 @@ pub(crate) struct InboundContext {
 /// it. On failover, a passthrough attempt keeps the credential only while its
 /// origin matches the primary upstream's, so a host-specific token is never
 /// replayed to a different origin (a same-origin fallback still carries it).
-pub(crate) fn check_inbound_auth(
+pub(crate) async fn check_inbound_auth(
     state: &AppState,
     routes: &[routing::Route],
     headers: &HeaderMap,
@@ -559,8 +558,10 @@ pub(crate) fn check_inbound_auth(
     };
     Err(Box::new(ForwardError {
         message: "inbound authentication failed".to_string(),
-        response: ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
-            .into_response(),
+        response: Box::new(
+            ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
+                .into_response(),
+        ),
     }))
 }
 


### PR DESCRIPTION
## Problem

`shunt login codex --name <account>` fails when importing from `~/.codex/auth.json` with:

```
~/.codex/auth.json is not a ChatGPT login (auth_mode != "ChatGPT"); run `codex login` first
```

## Root Cause

`import_auth` in `src/auth/codex/store.rs:187` performs a **case-sensitive** comparison:

```rust
if value.get("auth_mode").and_then(Value::as_str) != Some("ChatGPT") {
```

But the codex CLI writes `"auth_mode": "chatgpt"` (lowercase) — its enum variant is `AuthMode::Chatgpt`. The comparison always rejects codex CLI output.

## Fix

Change the check to case-insensitive:

```rust
if !value
    .get("auth_mode")
    .and_then(Value::as_str)
    .is_some_and(|mode| mode.eq_ignore_ascii_case("chatgpt"))
```

Also adds a test (`import_accepts_lowercase_chatgpt_auth_mode`) that verifies lowercase `"chatgpt"` (what codex CLI actually writes) is accepted. The existing test `import_rejects_non_chatgpt_auth_mode` only checked against `"ApiKey"`, so this bug was not caught.

## Notes

- Runtime auth (`read_auth_file`) does **not** check `auth_mode`, so once tokens are manually placed, they work fine. The bug is isolated to the `import_auth` path used by `shunt login codex`.
- The existing test fixture `chatgpt_source_json` uses `"ChatGPT"` (capitalized), which masks the bug since it matches shunt's expectation rather than codex CLI's actual output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts lowercase Codex `auth_mode` in imports and API-key detection so current `codex` CLI `auth.json` works with shunt. Previously we required "ChatGPT"/"ApiKey"; now we match "chatgpt"/"apikey" case-insensitively while still rejecting non-ChatGPT imports and ChatGPT-mode keys.

**Bug Fixes**
- `import_auth` compares `auth_mode` to "chatgpt" case-insensitively, updates the error to quote "chatgpt", and adds a test.
- `read_openai_api_key` compares `auth_mode` to "apikey" case-insensitively and rejects ChatGPT mode even if `OPENAI_API_KEY` is present; adds tests.
- No migration required; runtime auth loading behavior is unchanged.

**Docs**
- Document lowercase `auth_mode` spelling and shunt’s case-insensitive matching in config and guides (all locales).
- Correct the API-key login flag to `codex login --with-api-key` and update the corresponding code comment.

<sup>Written for commit ff05e1de47ef0e96a67a407ffc61eacf96d1b45b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

