### PR TITLE
fix(antigravity): keep an undelivered agy handoff from failing a completed turn

### DIFF
--- a/docs/notes/agy-print-mode-tool-surface.md
+++ b/docs/notes/agy-print-mode-tool-surface.md
@@ -47,7 +47,7 @@ curl -sN -X POST http://localhost:3001/v1/messages \
 
 `Translator::on_line` (`src/adapters/antigravity/stream.rs`) treats a non-`SUCCESS`
 terminal result as `AgyEnd::Success` when the error has the
-`recipient "<name>" not found` shape **and** assistant text was already
+`recipient "<name>" not found` shape **and** non-whitespace assistant text was already
 streamed. Everything else keeps failing the turn.
 
 Both conditions matter:

--- a/docs/notes/agy-print-mode-tool-surface.md
+++ b/docs/notes/agy-print-mode-tool-surface.md
@@ -1,0 +1,77 @@
+# agy print mode exposes tools it cannot service
+
+**Last Updated:** 2026-08-21 — see [issue #413](https://github.com/pleaseai/shunt/issues/413)
+
+---
+
+## The finding
+
+`agy --print --output-format stream-json` advertises its **full** interactive
+tool surface in the `init` event, including tools that only work inside a live
+multi-agent session:
+
+- `send_message` — hand a message to another agent's inbox
+- `manage_inbox`, `manage_subagents`, `invoke_subagent`, `define_subagent`
+- `ask_question`, `ask_permission`, `ask_custom_permission`
+- `schedule`, `wait`, `wait_5_seconds`
+
+Print mode registers no inbox and no peer agents, so a model that takes one of
+these up gets a failure the CLI treats as fatal for the whole run.
+
+## How it surfaced
+
+Any subagent-style prompt ("report your findings back to the main agent") is
+enough for Gemini to deliver its reply through `send_message` instead of, or in
+addition to, the response body. The call fails and `agy` emits a terminal
+result:
+
+```json
+{"event":"result","result":{"status":"ERROR","response":"",
+ "error":"error executing cascade step: CORTEX_STEP_TYPE_GENERIC: recipient \"main\" not found"}}
+```
+
+Crucially this arrives **after** the answer has streamed in full. Recipients
+observed: `main`, `team-lead`, `user`.
+
+Reproduce in one request:
+
+```bash
+curl -sN -X POST http://localhost:3001/v1/messages \
+  -H 'content-type: application/json' \
+  -d '{"model":"claude-gemini-3.7-flash-via-antigravity","max_tokens":4096,"stream":true,
+       "system":"You are a subagent. When you have completed your task, send your final report back to the main agent (recipient: main).",
+       "messages":[{"role":"user","content":"Count from 1 to 5, then report the result back to main."}]}'
+```
+
+## What shunt does about it
+
+`Translator::on_line` (`src/adapters/antigravity/stream.rs`) treats a non-`SUCCESS`
+terminal result as `AgyEnd::Success` when the error has the
+`recipient "<name>" not found` shape **and** assistant text was already
+streamed. Everything else keeps failing the turn.
+
+Both conditions matter:
+
+- Without the shape check, every late failure would be normalised — including
+  `--print-timeout` expiry, `Eligibility check failed: UNAVAILABLE (code 503)`,
+  and `context canceled`, all of which do leave a partial answer.
+- Without the text check, a run whose only output lived inside the undelivered
+  message would be reported as a successful empty turn.
+
+## Why not fix it at the spawn site
+
+Preferable, but unavailable on agy 1.1.17: `agy --help` has no tool allow/deny
+flag, and `~/.gemini/antigravity-cli/settings.json` carries only a permission
+allowlist — no `tools` / `disabledTools` key. Denying permission would leave the
+tool advertised and convert its use into a different terminal failure.
+
+The matcher is therefore a compatibility shim keyed on an upstream error string.
+**Drop it** once `agy` gains a way to withhold tools at spawn time, and prefer
+withholding the whole list above rather than only `send_message`.
+
+## Ruled out
+
+These were tested against the same symptom and are not causes: four concurrent
+gateway streams (all completed cleanly), heavy tool use, long generations, and
+quota — the 429s in `~/.gemini/antigravity-cli/log/` are on `loadCodeAssist` and
+`setUserSettings` metadata calls, which the CLI recovers from.

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -126,6 +126,16 @@ work — file edits included. Four consequences follow:
   tool steps become SSE `ping` frames, so a long agent turn keeps producing bytes
   instead of going silent until it finishes. Token usage is Google's reported count,
   not an estimate.
+- **An undelivered `send_message` handoff does not fail a finished turn.** Print mode
+  advertises `agy`'s full interactive tool surface, including `send_message`, but registers
+  no inbox. A subagent-style prompt ("report your findings back to the main agent") is
+  enough for the model to hand its reply to `main`, `team-lead` or `user`; the call fails
+  and `agy` marks the run `ERROR` with `recipient "<name>" not found` — after the answer
+  has already streamed. shunt ends that turn normally (`end_turn`, HTTP `200`) when
+  assistant text was streamed, and keeps failing it when nothing was, since the reply
+  then only existed inside the undelivered message. Every other late failure still ends
+  the turn with an SSE `error`. This is a compatibility shim keyed on an upstream error
+  string; see [`docs/notes/agy-print-mode-tool-surface.md`](https://github.com/pleaseai/shunt/blob/main/docs/notes/agy-print-mode-tool-surface.md) in the repository.
 - **Gateway shutdown ends the turn on Unix.** Each run has an isolated process group,
   so shunt terminates the agent and its tool subprocesses when shutdown starts instead
   of letting an unattended turn hold the graceful drain open.

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -101,6 +101,15 @@ Google の [Antigravity 利用規約](https://antigravity.google/terms)は、こ
 ため例外です。空の `tools: []` も同様にツール要求ではありません。ツールループを自分で回す必要があるクライアントは、
 ツールを転送する `antigravity` または `gemini` プロバイダーを使用してください。
 
+配信されなかった `send_message` のハンドオフは、完了したターンを失敗にしません。print モードは `send_message` を含む
+`agy` の対話用ツール一式を公開しますが、inbox は登録しません。サブエージェント風のプロンプト（「結果をメインエージェントに
+報告せよ」）だけで、モデルは返答を `main`、`team-lead`、`user` に渡そうとし、その呼び出しは失敗して、`agy` は — 返答が
+すでにストリーミングされた後で — `recipient "<name>" not found` エラーとともに実行を `ERROR` にします。shunt は
+アシスタントのテキストがストリーミングされていればそのターンを通常どおり終了（`end_turn`、HTTP `200`）し、何も
+ストリーミングされていなければ返答は配信されなかったメッセージの中にしか存在しなかったため、引き続き失敗として扱います。
+それ以外の遅い失敗は今までどおり SSE `error` でターンを終えます。これは upstream のエラー文字列に依存する互換性の
+ための処理です。リポジトリの [`docs/notes/agy-print-mode-tool-surface.md`](https://github.com/pleaseai/shunt/blob/main/docs/notes/agy-print-mode-tool-surface.md) を参照してください。
+
 非対話実行では権限プロンプトに応答できないため、`agy` は `--dangerously-skip-permissions` 付きで、さらにデフォルトでは
 `--sandbox` 付きで実行されます。したがって **このプロバイダーは shunt を実行しているユーザー権限での任意コード実行として
 扱ってください。**

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -101,6 +101,14 @@ shunt는 Antigravity OAuth를 사용하는 서드파티 소프트웨어이므로
 `tools: []`도 도구 요청이 아닙니다. 도구 루프를 직접 구동해야 하는 클라이언트는 도구를 전달하는 `antigravity` 또는
 `gemini` 프로바이더를 사용하세요.
 
+전달되지 못한 `send_message` 핸드오프는 완료된 턴을 실패시키지 않습니다. print 모드는 `send_message`를 포함한 `agy`의
+전체 대화형 도구 목록을 노출하지만 인박스를 등록하지 않습니다. 서브에이전트 형태의 프롬프트("결과를 메인 에이전트에게
+보고하라")만으로도 모델은 답변을 `main`, `team-lead`, `user`에게 넘기려 하고, 호출은 실패하며 `agy`는 — 답변이 이미
+스트리밍된 뒤에 — `recipient "<name>" not found` 오류로 실행을 `ERROR`로 표시합니다. shunt는 어시스턴트 텍스트가
+스트리밍된 경우 그 턴을 정상 종료(`end_turn`, HTTP `200`)하고, 아무것도 스트리밍되지 않았으면 답변이 전달되지 못한
+메시지 안에만 존재했던 것이므로 계속 실패로 처리합니다. 그 밖의 뒤늦은 실패는 여전히 SSE `error`로 턴을 끝냅니다.
+이는 업스트림 오류 문자열에 기댄 호환성 처리이며, 저장소의 [`docs/notes/agy-print-mode-tool-surface.md`](https://github.com/pleaseai/shunt/blob/main/docs/notes/agy-print-mode-tool-surface.md)를 참고하세요.
+
 비대화형 실행에서는 권한 프롬프트에 응답할 수 없으므로, `agy`는 `--dangerously-skip-permissions`로, 그리고 기본적으로
 `--sandbox`와 함께 실행됩니다. 그러므로 **이 프로바이더는 shunt를 실행하는 사용자 권한의 임의 코드 실행으로 취급하세요.**
 

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -94,6 +94,13 @@ OpenClaw 与 Antigravity OAuth 配合使用)即违反本协议",且此类违约"
 `tool_choice: {"type": "auto"}` 同样不受限制,它是许多客户端在每个请求中都会序列化的 Anthropic SDK 默认值。空的
 `tools: []` 同样不算工具请求。需要自行驱动工具循环的客户端应改用会转发工具的 `antigravity` 或 `gemini` 提供方。
 
+未能送达的 `send_message` 交接不会让已完成的轮次失败。print 模式会暴露 `agy` 的全部交互式工具面(包括 `send_message`),
+却不会注册任何收件箱。一条子 agent 式的提示("把结果汇报给主 agent")就足以让模型把回复交给 `main`、`team-lead` 或
+`user`;该调用失败,`agy` 会在回答已经流式输出之后,以 `recipient "<name>" not found` 错误把本次运行标记为 `ERROR`。
+只要已经流式输出了助手文本,shunt 就把这一轮正常结束(`end_turn`、HTTP `200`);若什么都没有输出,则回复只存在于那条
+未送达的消息里,shunt 仍按失败处理。其他所有晚到的失败依旧以 SSE `error` 结束轮次。这是一个依赖上游错误字符串的兼容性
+处理,详见仓库中的 [`docs/notes/agy-print-mode-tool-surface.md`](https://github.com/pleaseai/shunt/blob/main/docs/notes/agy-print-mode-tool-surface.md)。
+
 由于非交互式运行无法回答权限提示,`agy` 会带 `--dangerously-skip-permissions` 运行,并且默认带 `--sandbox`,所以**请把该
 提供方视为以运行 shunt 的用户身份执行任意代码**。
 

--- a/src/adapters/antigravity/stream.rs
+++ b/src/adapters/antigravity/stream.rs
@@ -247,10 +247,10 @@ impl Translator {
                     // An undelivered handoff is bookkeeping that failed after
                     // the reply itself was streamed, so failing the turn would
                     // report a complete answer as a server error. Text is
-                    // required: with nothing streamed the reply only ever
-                    // existed inside the message that could not be delivered,
-                    // and the run genuinely produced nothing.
-                    if self.text.is_empty() || !is_undelivered_handoff(&message) {
+                    // required: with nothing but whitespace streamed the reply
+                    // only ever existed inside the message that could not be
+                    // delivered, and the run genuinely produced nothing.
+                    if self.text.trim().is_empty() || !is_undelivered_handoff(&message) {
                         self.end = Some(AgyEnd::Failed(message));
                         return String::new();
                     }

--- a/src/adapters/antigravity/stream.rs
+++ b/src/adapters/antigravity/stream.rs
@@ -61,6 +61,29 @@ fn sse(event: &str, data: &Value) -> String {
     format!("event: {event}\ndata: {data}\n\n")
 }
 
+/// Does this `agy` error report a handoff to a recipient print mode never had?
+///
+/// The CLI's tool surface includes `send_message`, and a subagent-style prompt
+/// ("report your findings back to the main agent") is enough for the model to
+/// use it to deliver its reply. Print mode registers no inbox, so the call
+/// fails and `agy` marks the whole run `ERROR` — after the answer has already
+/// been streamed in full. Shunt's caller then sees a complete response closed
+/// by an SSE `error`, which reads as a truncated turn.
+///
+/// Matched by shape rather than by name: `main`, `team-lead` and `user` have
+/// all been observed, sometimes behind a `CORTEX_STEP_TYPE_GENERIC:` wrapper.
+/// Deliberately narrow — a run that failed for any other reason after emitting
+/// some text really is partial, and must keep failing. Keyed on an upstream
+/// error string, so it should be dropped once `agy` offers a way to withhold
+/// the tool at spawn time.
+fn is_undelivered_handoff(message: &str) -> bool {
+    let Some((_, rest)) = message.split_once("recipient \"") else {
+        return false;
+    };
+    rest.split_once('"')
+        .is_some_and(|(_, tail)| tail.starts_with(" not found"))
+}
+
 /// Incremental `agy` stream-json → Anthropic SSE translator.
 ///
 /// Feed it one JSON line at a time with [`Translator::on_line`] and flush with
@@ -221,8 +244,16 @@ impl Translator {
                         .and_then(Value::as_str)
                         .unwrap_or("agy reported a failed run")
                         .to_string();
-                    self.end = Some(AgyEnd::Failed(message));
-                    return String::new();
+                    // An undelivered handoff is bookkeeping that failed after
+                    // the reply itself was streamed, so failing the turn would
+                    // report a complete answer as a server error. Text is
+                    // required: with nothing streamed the reply only ever
+                    // existed inside the message that could not be delivered,
+                    // and the run genuinely produced nothing.
+                    if self.text.is_empty() || !is_undelivered_handoff(&message) {
+                        self.end = Some(AgyEnd::Failed(message));
+                        return String::new();
+                    }
                 }
                 self.end = Some(AgyEnd::Success);
                 // `result.response` repeats text already delivered through

--- a/src/adapters/antigravity/stream.rs
+++ b/src/adapters/antigravity/stream.rs
@@ -81,7 +81,7 @@ fn is_undelivered_handoff(message: &str) -> bool {
         return false;
     };
     rest.split_once('"')
-        .is_some_and(|(_, tail)| tail.starts_with(" not found"))
+        .is_some_and(|(_, tail)| tail.trim_start().starts_with("not found"))
 }
 
 /// Incremental `agy` stream-json → Anthropic SSE translator.

--- a/tests/antigravity_translate.rs
+++ b/tests/antigravity_translate.rs
@@ -253,20 +253,26 @@ fn test_translator_reports_failed_runs() {
 /// must end as a normal turn rather than an SSE error.
 #[test]
 fn test_undelivered_handoff_after_a_full_reply_ends_the_turn() {
-    let mut t = Translator::new("gemini", "msg_test");
-    t.on_line(
-        r#"{"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"the whole answer"}}"#,
-    );
-    t.on_line(
-        r#"{"event":"result","result":{"status":"ERROR","response":"","error":"error executing cascade step: CORTEX_STEP_TYPE_GENERIC: recipient \"main\" not found"}}"#,
-    );
+    for error in [
+        r#"recipient \"main\" not found"#,
+        r#"recipient \"main\"not found"#,
+        r#"recipient \"main\"   not found"#,
+    ] {
+        let mut t = Translator::new("gemini", "msg_test");
+        t.on_line(
+            r#"{"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"the whole answer"}}"#,
+        );
+        t.on_line(&format!(
+            r#"{{"event":"result","result":{{"status":"ERROR","response":"","error":"error executing cascade step: CORTEX_STEP_TYPE_GENERIC: {error}"}}}}"#,
+        ));
 
-    assert_eq!(t.end(), Some(&AgyEnd::Success));
-    assert_eq!(t.text(), "the whole answer", "no error text is appended");
+        assert_eq!(t.end(), Some(&AgyEnd::Success), "error: {error}");
+        assert_eq!(t.text(), "the whole answer", "error: {error}");
 
-    let out = t.finish();
-    assert!(out.contains("end_turn"));
-    assert!(!out.contains("event: error"));
+        let out = t.finish();
+        assert!(out.contains("end_turn"), "error: {error}");
+        assert!(!out.contains("event: error"), "error: {error}");
+    }
 }
 
 /// Only the handoff itself is forgiven. Any other late failure leaves a

--- a/tests/antigravity_translate.rs
+++ b/tests/antigravity_translate.rs
@@ -246,6 +246,67 @@ fn test_translator_reports_failed_runs() {
     );
 }
 
+/// `agy` exposes `send_message` in print mode, where no inbox recipient
+/// exists. A subagent-style prompt makes the model use it to hand its reply
+/// back to "main", the call fails, and the run is marked ERROR — after the
+/// answer was streamed in full. The caller has the whole response, so this
+/// must end as a normal turn rather than an SSE error.
+#[test]
+fn test_undelivered_handoff_after_a_full_reply_ends_the_turn() {
+    let mut t = Translator::new("gemini", "msg_test");
+    t.on_line(
+        r#"{"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"the whole answer"}}"#,
+    );
+    t.on_line(
+        r#"{"event":"result","result":{"status":"ERROR","response":"","error":"error executing cascade step: CORTEX_STEP_TYPE_GENERIC: recipient \"main\" not found"}}"#,
+    );
+
+    assert_eq!(t.end(), Some(&AgyEnd::Success));
+    assert_eq!(t.text(), "the whole answer", "no error text is appended");
+
+    let out = t.finish();
+    assert!(out.contains("end_turn"));
+    assert!(!out.contains("event: error"));
+}
+
+/// Only the handoff itself is forgiven. Any other late failure leaves a
+/// genuinely partial answer and has to keep failing the turn.
+#[test]
+fn test_other_failures_after_text_still_fail_the_turn() {
+    let mut t = Translator::new("gemini", "msg_test");
+    t.on_line(
+        r#"{"event":"step_update","step_update":{"step_type":"agent_response","text_delta":"half an answer"}}"#,
+    );
+    t.on_line(
+        r#"{"event":"result","result":{"status":"ERROR","response":"","error":"Eligibility check failed: UNAVAILABLE (code 503)"}}"#,
+    );
+
+    assert_eq!(
+        t.end(),
+        Some(&AgyEnd::Failed(
+            "Eligibility check failed: UNAVAILABLE (code 503)".to_string()
+        ))
+    );
+}
+
+/// With no text streamed, the reply only ever existed inside the message that
+/// could not be delivered: the run produced nothing, and saying otherwise
+/// would report an empty turn as a success.
+#[test]
+fn test_undelivered_handoff_without_text_still_fails() {
+    let mut t = Translator::new("gemini", "msg_test");
+    t.on_line(
+        r#"{"event":"result","result":{"status":"ERROR","response":"","error":"recipient \"team-lead\" not found"}}"#,
+    );
+
+    assert_eq!(
+        t.end(),
+        Some(&AgyEnd::Failed(
+            "recipient \"team-lead\" not found".to_string()
+        ))
+    );
+}
+
 #[test]
 fn test_translator_tolerates_garbage_lines() {
     let mut t = Translator::new("gemini", "msg_test");

--- a/tests/antigravity_translate.rs
+++ b/tests/antigravity_translate.rs
@@ -300,17 +300,26 @@ fn test_other_failures_after_text_still_fail_the_turn() {
 /// would report an empty turn as a success.
 #[test]
 fn test_undelivered_handoff_without_text_still_fails() {
-    let mut t = Translator::new("gemini", "msg_test");
-    t.on_line(
-        r#"{"event":"result","result":{"status":"ERROR","response":"","error":"recipient \"team-lead\" not found"}}"#,
-    );
+    for streamed in [None, Some("\n  \n")] {
+        let mut t = Translator::new("gemini", "msg_test");
+        if let Some(whitespace) = streamed {
+            t.on_line(&format!(
+                r#"{{"event":"step_update","step_update":{{"step_type":"agent_response","text_delta":{}}}}}"#,
+                serde_json::to_string(whitespace).unwrap()
+            ));
+        }
+        t.on_line(
+            r#"{"event":"result","result":{"status":"ERROR","response":"","error":"recipient \"team-lead\" not found"}}"#,
+        );
 
-    assert_eq!(
-        t.end(),
-        Some(&AgyEnd::Failed(
-            "recipient \"team-lead\" not found".to_string()
-        ))
-    );
+        assert_eq!(
+            t.end(),
+            Some(&AgyEnd::Failed(
+                "recipient \"team-lead\" not found".to_string()
+            )),
+            "streamed: {streamed:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #413

## Summary

`agy --print --output-format stream-json` advertises its full interactive tool surface, including `send_message` — which needs an inbox that print mode never registers. A subagent-style prompt ("report your findings back to the main agent") is enough for the model to deliver its reply that way. The call fails, and the CLI marks the whole run `ERROR`:

```
error executing cascade step: CORTEX_STEP_TYPE_GENERIC: recipient "main" not found
```

That arrives **after** the answer has streamed in full. The translator recorded it as a failed run, so callers received a complete response closed by an SSE `error` — which Claude Code renders as *"Server error mid-response. The response above may be incomplete."* Nothing was missing; only the framing was wrong.

`Translator::on_line` now treats a non-`SUCCESS` terminal result as `AgyEnd::Success` when the error has the `recipient "<name>" not found` shape **and** assistant text was already streamed. Recipients observed in the wild: `main`, `team-lead`, `user`, so the match is on shape rather than on a fixed name.

Both conditions are load-bearing:

- Without the shape check, every late failure would be normalised — including `--print-timeout` expiry, `Eligibility check failed: UNAVAILABLE (code 503)`, and `context canceled`, all of which do leave a genuinely partial answer.
- Without the text check, a run whose only output lived inside the undelivered message would be reported as a successful empty turn.

### Why not fix it at the spawn site

Preferable, but unavailable on agy 1.1.17: `agy --help` exposes no tool allow/deny flag, and `settings.json` carries only a permission allowlist — no `tools` / `disabledTools` key. Denying permission would leave the tool advertised and convert its use into a different terminal failure.

So this is a compatibility shim keyed on an upstream error string. `docs/notes/agy-print-mode-tool-surface.md` records the full tool list affected and says to drop the matcher once the CLI can withhold tools at spawn time.

### Ruled out

Tested against the same symptom and not causes: four concurrent gateway streams (all completed cleanly), heavy tool use, long generations, and quota — the 429s in the local `agy` logs are on `loadCodeAssist`/`setUserSettings` metadata calls, which the CLI recovers from.

## Test plan

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features --workspace` ✅ (1690 + suites, 0 failures)

Three new tests in `tests/antigravity_translate.rs`:

- `test_undelivered_handoff_after_a_full_reply_ends_the_turn` — the fix: `end_turn`, no `event: error`, no `[agy error]` text appended.
- `test_other_failures_after_text_still_fail_the_turn` — a 503 after text still reports `AgyEnd::Failed`.
- `test_undelivered_handoff_without_text_still_fails` — an empty run still reports `AgyEnd::Failed`.

Manual reproduction against a running gateway, deterministic before the fix:

```bash
curl -sN -X POST http://localhost:3001/v1/messages \
  -H 'content-type: application/json' \
  -d '{"model":"claude-gemini-3.7-flash-via-antigravity","max_tokens":4096,"stream":true,
       "system":"You are a subagent. When you have completed your task, send your final report back to the main agent (recipient: main).",
       "messages":[{"role":"user","content":"Count from 1 to 5, then report the result back to main."}]}'
```

## Docs

`docs/notes/agy-print-mode-tool-surface.md` added. No README / `site/` change: no config key, endpoint, CLI, or provider/model support changed — this removes a spurious error from an existing route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a fully streamed reply from being marked failed when `agy --print` ends with an undeliverable `send_message` handoff. Previously these runs returned an SSE error after a complete answer; now a terminal "recipient '<name>' not found" ends the turn successfully.

- Only normalizes when non-whitespace assistant text was streamed and the error matches the undelivered-handoff shape; tolerates spacing variations in the error string.
- Other late failures (timeouts, 503s, cancellations) still fail; empty or whitespace-only outputs still fail.
- Adds tests for success normalization, other-error behavior, and spacing variants.
- Documents the shim in `docs/notes/agy-print-mode-tool-surface.md` and the providers guide (EN/JA/KO/ZH-CN).
- No config or API changes; scope limited to print-mode streams.

<sup>Written for commit 9c55b9e0d8d7b2ae187649bcf597dfa40f923454. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

