### PR TITLE
fix(antigravity): make the project-id writeback a compare-and-swap

### DIFF
--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -230,10 +230,15 @@ Antigravity requests two scopes a Gemini CLI login never carries (`cclog`,
 `experimentsandconfigs`), so this credential and the `gemini` provider's `~/.gemini/oauth_creds.json`
 are **not** interchangeable in either direction.
 
-A login run while a shunt process is serving Antigravity requests is serialized against that
-process's credential writeback through an empty sibling `antigravity-auth.json.lock` file, so a
-refresh token rotated by either side is never lost to the other. The lock file holds no state, and
-is deliberately left in place — that inode is what the two serialize on.
+On Unix, a login run while a shunt process is serving Antigravity requests serializes its credential
+write against that process's writeback through an advisory lock on an empty sibling
+`antigravity-auth.json.lock` file, so the login cannot land inside the running process's
+read-modify-write of the project id and be discarded by it. That is narrower than making the two
+processes atomic: a login that completes while a token refresh is already in flight upstream can
+still be superseded by that refresh's writeback. Off Unix there is no advisory file lock at all —
+nothing is serialized, a rotated refresh token can be lost either way, and shunt warns once on
+stderr when it reaches that path. The lock file holds no state and is deliberately left in place:
+that inode is what the two serialize on.
 
 The login also resolves the Code Assist project, provisioning one for a first-time account, and
 stores it alongside the tokens so no discovery runs in front of a request. If that step fails the

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -230,6 +230,11 @@ Antigravity requests two scopes a Gemini CLI login never carries (`cclog`,
 `experimentsandconfigs`), so this credential and the `gemini` provider's `~/.gemini/oauth_creds.json`
 are **not** interchangeable in either direction.
 
+A login run while a shunt process is serving Antigravity requests is serialized against that
+process's credential writeback through an empty sibling `antigravity-auth.json.lock` file, so a
+refresh token rotated by either side is never lost to the other. The lock file holds no state, and
+is deliberately left in place — that inode is what the two serialize on.
+
 The login also resolves the Code Assist project, provisioning one for a first-time account, and
 stores it alongside the tokens so no discovery runs in front of a request. If that step fails the
 credential is still saved and discovery is retried on the first request. Discovery addresses the

--- a/src/auth/antigravity/auth.rs
+++ b/src/auth/antigravity/auth.rs
@@ -447,34 +447,50 @@ impl AntigravityAuthStore {
 
     /// Replace the credential file, taking [`CREDENTIAL_FILE_LOCK`] first.
     ///
-    /// Every writer of this file must go through a locked path; see
-    /// [`write_unlocked`](Self::write_unlocked) for the one that assumes the
-    /// caller already holds it.
+    /// Every writer of this file goes through a locked path; a caller that is
+    /// already inside a critical section hands its own guard to
+    /// [`write_holding_lock`](Self::write_holding_lock) instead. It must never
+    /// call this one — `flock` on a second descriptor to the same file blocks
+    /// even within one process, so that would deadlock against itself.
     async fn write(&self, stored: &StoredAuth) -> Result<(), AdapterError> {
-        let _guard = self.lock_credential_file().await?;
-        self.write_unlocked(stored).await
+        let guard = self.lock_credential_file().await?;
+        self.write_holding_lock(guard, stored).await
     }
 
-    /// The raw atomic write, with no locking of its own.
+    /// The atomic write, **consuming** the caller's credential-file guard.
     ///
-    /// **The caller must already hold [`CREDENTIAL_FILE_LOCK`].** Calling the
-    /// locking [`write`](Self::write) from inside a critical section would
-    /// deadlock against this very process: `flock` on a second descriptor to
-    /// the same file blocks even within one process.
-    async fn write_unlocked(&self, stored: &StoredAuth) -> Result<(), AdapterError> {
+    /// The guard is moved *into* the blocking task rather than left as a local
+    /// of the awaiting future, so the lock is released only once the write has
+    /// actually landed. That ordering is load-bearing under cancellation: a
+    /// dropped future releases its locals immediately, while `spawn_blocking`
+    /// runs its closure to completion regardless — so a guard held out here
+    /// would let another writer acquire the lock and race a rename that is
+    /// still in flight, which is exactly the compare-and-swap this lock
+    /// exists to provide.
+    async fn write_holding_lock(
+        &self,
+        guard: crate::auth::shared::file_lock::FileLock,
+        stored: &StoredAuth,
+    ) -> Result<(), AdapterError> {
         let path = self.path.clone();
         let value = serde_json::to_value(stored).map_err(|error| {
             auth_error(format!("failed to encode Antigravity credentials: {error}"))
         })?;
-        tokio::task::spawn_blocking(move || write_auth_file_atomic(&path, &value))
-            .await
-            .map_err(|_| auth_error("Antigravity credential write task failed"))?
-            .map_err(|error| {
-                auth_error(format!(
-                    "failed to write Antigravity credential file {}: {error}",
-                    self.path.display()
-                ))
-            })
+        tokio::task::spawn_blocking(move || {
+            let result = write_auth_file_atomic(&path, &value);
+            // Explicit, and after the write: the release must be ordered by
+            // the write completing, not by the closure's scope ending.
+            drop(guard);
+            result
+        })
+        .await
+        .map_err(|_| auth_error("Antigravity credential write task failed"))?
+        .map_err(|error| {
+            auth_error(format!(
+                "failed to write Antigravity credential file {}: {error}",
+                self.path.display()
+            ))
+        })
     }
 
     async fn refresh_call(&self, refresh_token: &str) -> Result<TokenResponse, AdapterError> {
@@ -589,7 +605,7 @@ impl AntigravityAuthStore {
         // detected.
         //
         // This re-read/write pair does not touch `REFRESH_LOCK` — `read` and
-        // `write_unlocked` are plain file I/O, and the file lock is a
+        // `write_holding_lock` are plain file I/O, and the file lock is a
         // different, finer-grained lock — so it is still safe to call
         // `project_id` regardless of whether the caller already holds
         // `REFRESH_LOCK` (it does on two of its three call sites in
@@ -656,15 +672,19 @@ impl AntigravityAuthStore {
                     if let Some(hook) = self.between_merge_read_and_write.clone() {
                         hook.run();
                     }
-                    // `write_unlocked`, never `write`: the guard above is
+                    // `write_holding_lock`, never `write`: the guard above is
                     // already held, and `flock` on a second descriptor to the
-                    // same file blocks even within one process.
-                    if let Err(error) = self.write_unlocked(&fresh).await {
+                    // same file blocks even within one process. Handing the
+                    // guard over rather than keeping it here is what keeps the
+                    // lock held until the write has actually landed, even if
+                    // this future is cancelled mid-write.
+                    if let Err(error) = self.write_holding_lock(guard, &fresh).await {
                         tracing::warn!(
                             "failed to persist discovered Antigravity project id: {}",
                             error.message
                         );
                     }
+                    return Ok(project);
                 }
             }
             Err(error) => {
@@ -681,8 +701,10 @@ impl AntigravityAuthStore {
                 );
             }
         }
-        // Explicit rather than left to the end of the function, so the release
-        // is visibly ordered after the write rather than after the `Ok`.
+        // Only the paths that did *not* write reach here; the writing path
+        // handed its guard to `write_holding_lock` and returned. Explicit
+        // rather than left to the end of the function, so the release is
+        // visibly ordered with the section rather than with the `Ok`.
         drop(guard);
 
         Ok(project)
@@ -2037,8 +2059,10 @@ mod tests {
     /// competing writer, and then waits in two stages so the test is
     /// deterministic in both directions — it returns the instant the writer is
     /// observed parked on the lock (the fixed behavior), or the instant the
-    /// writer's record appears on disk (the unfixed behavior). The bounded
-    /// grace is a cost the passing case never pays.
+    /// writer's record appears on disk (the unfixed behavior). Reaching the
+    /// outer deadline means neither was observed, which proves nothing, so it
+    /// fails loudly rather than falling through — a silent fallthrough would
+    /// let the unlocked code pass.
     ///
     /// Unix only: off Unix the lock is a documented no-op, so there is nothing
     /// for a waiter to park on.
@@ -2098,7 +2122,15 @@ mod tests {
         let hook_path = path_buf.clone();
         let store = store_at(path_buf.clone(), &server).with_merge_hook(move || {
             go.store(true, Ordering::SeqCst);
-            let grace = std::time::Instant::now() + Duration::from_millis(500);
+            // A bound on a wedged environment, NOT a window the unlocked code
+            // has to lose: both exits below fire within milliseconds in their
+            // respective worlds, so a run that reaches this deadline observed
+            // neither outcome and has proved nothing. It panics rather than
+            // returning, because silently falling through here would let the
+            // unlocked code pass — the merge would write first and the delayed
+            // writer would land last, leaving exactly the record the
+            // assertions want to see.
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
             loop {
                 // Parked on the very lock this section holds: the writer is
                 // excluded, so the merge write cannot lose it.
@@ -2110,9 +2142,12 @@ mod tests {
                 if fs::read_to_string(&hook_path).unwrap() != baseline {
                     return;
                 }
-                if std::time::Instant::now() >= grace {
-                    return;
-                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "the competing writer neither parked on the credential lock nor wrote \
+                     within 10s, so this run cannot distinguish a working lock from an \
+                     absent one"
+                );
                 std::thread::sleep(Duration::from_millis(2));
             }
         });

--- a/src/auth/antigravity/auth.rs
+++ b/src/auth/antigravity/auth.rs
@@ -119,6 +119,45 @@ const CREDENTIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// In-process single-flight for the refresh path, mirroring the other stores.
 static REFRESH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Cross-process exclusion over the credential file itself (issue #384).
+///
+/// [`REFRESH_LOCK`] cannot cover this: the competing writer is a *different
+/// process*. `shunt login antigravity` (see [`super::login::run`]) rewrites the
+/// same file while the gateway is serving requests, so the project-id merge's
+/// re-read/write pair has to serialize against it on the filesystem.
+///
+/// **Lock ordering.** `REFRESH_LOCK` is only ever taken *before* this lock,
+/// never after, and this lock is never held across a network call — so the two
+/// cannot deadlock, and holding this one costs at most two file operations of
+/// contention.
+static CREDENTIAL_FILE_LOCK: crate::auth::shared::file_lock::FileLockKind =
+    crate::auth::shared::file_lock::FileLockKind {
+        lock_name: "Antigravity credential lock",
+        contention_hint: "Another shunt process is writing the credential file \
+                          (`shunt login antigravity`, or a token refresh). If no such process is \
+                          running, remove that file",
+        task_context: "Antigravity credential lock task failed",
+        unsupported_warning: "Warning: this platform has no advisory file lock, so a `shunt login \
+                              antigravity` running alongside the gateway is not serialized against \
+                              its credential writeback. A rotated refresh token can be lost that \
+                              way; run `shunt login antigravity` again if that happens.",
+        #[cfg(not(unix))]
+        warned: std::sync::Once::new(),
+    };
+
+/// How long a writer waits for [`CREDENTIAL_FILE_LOCK`].
+///
+/// Derived from what the lock actually covers, not from a network budget: the
+/// longest legitimate critical section is one `read` plus one atomic write of a
+/// sub-kilobyte JSON file — two `spawn_blocking` round trips, sub-millisecond
+/// of real I/O. No network call ever happens under this lock (`discover_project`
+/// completes before the merge section opens), so seconds of headroom is already
+/// four orders of magnitude over the worst case. Five seconds absorbs a loaded
+/// blocking pool and a slow filesystem while still failing fast against a
+/// genuinely wedged holder, well inside the 120s `ANTIGRAVITY_CREDENTIAL_TIMEOUT`
+/// that bounds request-path credential resolution (`src/auth/mod.rs`).
+const CREDENTIAL_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AntigravityCred {
     pub access_token: String,
@@ -165,6 +204,33 @@ pub struct AntigravityAuthStore {
     /// that much headroom between polls, but a test against a local mock
     /// server does not, and `ONBOARD_POLL_INTERVAL` is 5s.
     onboard_poll_interval: Duration,
+    /// Fires inside [`AntigravityAuthStore::project_id`]'s merge critical
+    /// section, after the re-read and before the write, while
+    /// [`CREDENTIAL_FILE_LOCK`] is held. See [`MergeHook`].
+    #[cfg(test)]
+    between_merge_read_and_write: Option<MergeHook>,
+}
+
+/// Test-only seam for the project-id compare-and-swap.
+///
+/// A newtype rather than a bare `Option<Arc<dyn Fn()>>` so
+/// [`AntigravityAuthStore`] can keep its derived `Debug`.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct MergeHook(Arc<dyn Fn() + Send + Sync>);
+
+#[cfg(test)]
+impl MergeHook {
+    fn run(&self) {
+        (self.0)();
+    }
+}
+
+#[cfg(test)]
+impl std::fmt::Debug for MergeHook {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("MergeHook")
+    }
 }
 
 impl AntigravityAuthStore {
@@ -204,6 +270,8 @@ impl AntigravityAuthStore {
             project_cache: Arc::new(RwLock::new(None)),
             request_timeout: CREDENTIAL_REQUEST_TIMEOUT,
             onboard_poll_interval: ONBOARD_POLL_INTERVAL,
+            #[cfg(test)]
+            between_merge_read_and_write: None,
         }
     }
 
@@ -224,6 +292,8 @@ impl AntigravityAuthStore {
             project_cache: Arc::new(RwLock::new(None)),
             request_timeout: CREDENTIAL_REQUEST_TIMEOUT,
             onboard_poll_interval: ONBOARD_POLL_INTERVAL,
+            #[cfg(test)]
+            between_merge_read_and_write: None,
         }
     }
 
@@ -240,6 +310,15 @@ impl AntigravityAuthStore {
     #[cfg(test)]
     pub(crate) fn with_onboard_poll_interval(mut self, interval: Duration) -> Self {
         self.onboard_poll_interval = interval;
+        self
+    }
+
+    /// Test-only seam: run `hook` inside [`project_id`](Self::project_id)'s
+    /// merge critical section, after the re-read and before the write, with
+    /// [`CREDENTIAL_FILE_LOCK`] held.
+    #[cfg(test)]
+    pub(crate) fn with_merge_hook(mut self, hook: impl Fn() + Send + Sync + 'static) -> Self {
+        self.between_merge_read_and_write = Some(MergeHook(Arc::new(hook)));
         self
     }
 
@@ -308,6 +387,15 @@ impl AntigravityAuthStore {
         })
     }
 
+    /// Read the credential file.
+    ///
+    /// Deliberately **unlocked**. Every writer replaces the file by atomic
+    /// rename, so a reader always sees one complete record — never a torn one —
+    /// and taking [`CREDENTIAL_FILE_LOCK`] here would add contention and a
+    /// timeout failure mode without adding any exclusion. The one place a read
+    /// *does* need the lock is the read half of the project-id compare-and-swap
+    /// in [`project_id`](Self::project_id), and that site takes the guard
+    /// itself and calls this method inside it.
     async fn read(&self) -> Result<StoredAuth, AdapterError> {
         let path = self.path.clone();
         let content = tokio::task::spawn_blocking(move || fs::read_to_string(&path))
@@ -335,7 +423,45 @@ impl AntigravityAuthStore {
         })
     }
 
+    /// Take [`CREDENTIAL_FILE_LOCK`] for this store's credential file.
+    ///
+    /// Held across `.await` points, which is why this is the async entry point:
+    /// the project-id merge's critical section spans two `spawn_blocking` file
+    /// operations.
+    async fn lock_credential_file(
+        &self,
+    ) -> Result<crate::auth::shared::file_lock::FileLock, AdapterError> {
+        crate::auth::shared::file_lock::lock_file(
+            &self.path,
+            &CREDENTIAL_FILE_LOCK,
+            CREDENTIAL_LOCK_TIMEOUT,
+        )
+        .await
+        .map_err(|error| {
+            auth_error(format!(
+                "failed to lock the Antigravity credential file {}: {error:#}",
+                self.path.display()
+            ))
+        })
+    }
+
+    /// Replace the credential file, taking [`CREDENTIAL_FILE_LOCK`] first.
+    ///
+    /// Every writer of this file must go through a locked path; see
+    /// [`write_unlocked`](Self::write_unlocked) for the one that assumes the
+    /// caller already holds it.
     async fn write(&self, stored: &StoredAuth) -> Result<(), AdapterError> {
+        let _guard = self.lock_credential_file().await?;
+        self.write_unlocked(stored).await
+    }
+
+    /// The raw atomic write, with no locking of its own.
+    ///
+    /// **The caller must already hold [`CREDENTIAL_FILE_LOCK`].** Calling the
+    /// locking [`write`](Self::write) from inside a critical section would
+    /// deadlock against this very process: `flock` on a second descriptor to
+    /// the same file blocks even within one process.
+    async fn write_unlocked(&self, stored: &StoredAuth) -> Result<(), AdapterError> {
         let path = self.path.clone();
         let value = serde_json::to_value(stored).map_err(|error| {
             auth_error(format!("failed to encode Antigravity credentials: {error}"))
@@ -450,11 +576,42 @@ impl AntigravityAuthStore {
         // narrow the write to the case where it still is, and where nobody
         // else has already resolved a project id.
         //
+        // Re-reading is not enough on its own either: a refresh or a
+        // `shunt login antigravity` landing *between* the re-read and the
+        // write is still lost, because atomic rename makes each individual
+        // write all-or-nothing without making this read/merge/write a
+        // transaction (issue #384). So the whole section below runs under
+        // `CREDENTIAL_FILE_LOCK`, making it a genuine compare-and-swap: the
+        // guard is taken before the re-read and released after the write, and
+        // every other writer of this file takes the same guard. The guards
+        // still matter under it — the lock excludes a *concurrent* writer, but
+        // one that already landed before the guard was taken still has to be
+        // detected.
+        //
         // This re-read/write pair does not touch `REFRESH_LOCK` — `read` and
-        // `write` are plain file I/O with no locking of their own — so it is
-        // safe to call `project_id` regardless of whether the caller already
-        // holds that lock (it does on two of its three call sites in
-        // `get_valid`, but not on the fast, already-valid path).
+        // `write_unlocked` are plain file I/O, and the file lock is a
+        // different, finer-grained lock — so it is still safe to call
+        // `project_id` regardless of whether the caller already holds
+        // `REFRESH_LOCK` (it does on two of its three call sites in
+        // `get_valid`, but not on the fast, already-valid path). The two
+        // cannot deadlock: `REFRESH_LOCK` is only ever taken *before* the file
+        // lock, never after, and the file lock is never held across a network
+        // call — `discover_project` has already returned by the time this
+        // section opens.
+        //
+        // Failing to acquire is best-effort, like the write itself: warn and
+        // skip the persist rather than fail a request that already has a
+        // working access token and project id in hand.
+        let guard = match self.lock_credential_file().await {
+            Ok(guard) => guard,
+            Err(error) => {
+                tracing::warn!(
+                    "skipped persisting discovered Antigravity project id: {}",
+                    error.message
+                );
+                return Ok(project);
+            }
+        };
         match self.read().await {
             Ok(mut fresh) => {
                 // A project id belongs to the identity discovery ran against,
@@ -490,7 +647,19 @@ impl AntigravityAuthStore {
                     );
                 } else {
                     fresh.project_id = Some(project.clone());
-                    if let Err(error) = self.write(&fresh).await {
+                    // Test seam: a race between the re-read and the write is
+                    // exactly what this lock exists to close, and a test that
+                    // does not control that interleaving would pass against
+                    // the unlocked code and prove nothing. Fires while the
+                    // guard is held.
+                    #[cfg(test)]
+                    if let Some(hook) = self.between_merge_read_and_write.clone() {
+                        hook.run();
+                    }
+                    // `write_unlocked`, never `write`: the guard above is
+                    // already held, and `flock` on a second descriptor to the
+                    // same file blocks even within one process.
+                    if let Err(error) = self.write_unlocked(&fresh).await {
                         tracing::warn!(
                             "failed to persist discovered Antigravity project id: {}",
                             error.message
@@ -512,6 +681,9 @@ impl AntigravityAuthStore {
                 );
             }
         }
+        // Explicit rather than left to the end of the function, so the release
+        // is visibly ordered after the write rather than after the `Ok`.
+        drop(guard);
 
         Ok(project)
     }
@@ -978,12 +1150,33 @@ fn is_stored_valid(stored: &StoredAuth, now: SystemTime) -> bool {
 
 /// Write a freshly minted credential. Creates the parent directory; the atomic
 /// writer itself deliberately refuses to.
+///
+/// Takes [`CREDENTIAL_FILE_LOCK`] — the *blocking* entry point, because every
+/// caller is already inside a `tokio::task::spawn_blocking` (the login flow at
+/// `super::login::run`, plus the test helpers). This is the separate-process
+/// writer the lock exists for: `shunt login antigravity` runs while the gateway
+/// is serving requests, and without this the project-id compare-and-swap would
+/// have nothing to compare against.
+///
+/// The directory is created *before* the lock is taken, deliberately: the lock
+/// file is a sibling of `path`, so its parent has to exist first.
 pub(crate) fn write_stored(path: &Path, stored: &StoredAuth) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             fs::create_dir_all(parent)?;
         }
     }
+    let _guard = crate::auth::shared::file_lock::lock_file_blocking(
+        path,
+        &CREDENTIAL_FILE_LOCK,
+        CREDENTIAL_LOCK_TIMEOUT,
+    )
+    .map_err(|error| {
+        io::Error::other(format!(
+            "failed to lock the Antigravity credential file {}: {error:#}",
+            path.display()
+        ))
+    })?;
     let value = serde_json::to_value(stored)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     write_auth_file_atomic(path, &value)
@@ -1831,6 +2024,116 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&path_buf).unwrap()).unwrap();
         assert_eq!(written.refresh_token, "b-refresh");
         assert_eq!(written.project_id, None);
+    }
+
+    /// The compare-and-swap itself (issue #384). Re-reading before the write
+    /// narrows the window; it does not close it. A `shunt login antigravity`
+    /// landing *between* the re-read and the write was still lost — and losing
+    /// a rotated refresh token costs the operator a full re-login.
+    ///
+    /// The interleaving is forced rather than hoped for: a test that does not
+    /// control it passes against the unlocked code and proves nothing. The
+    /// merge hook fires while the credential lock is held, releases a
+    /// competing writer, and then waits in two stages so the test is
+    /// deterministic in both directions — it returns the instant the writer is
+    /// observed parked on the lock (the fixed behavior), or the instant the
+    /// writer's record appears on disk (the unfixed behavior). The bounded
+    /// grace is a cost the passing case never pays.
+    ///
+    /// Unix only: off Unix the lock is a documented no-op, so there is nothing
+    /// for a waiter to park on.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn project_id_writeback_serializes_against_a_concurrent_relogin() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1internal:loadCodeAssist"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"cloudaicompanionProject": "proj-discovered"})),
+            )
+            .mount(&server)
+            .await;
+
+        let path_buf = temp_auth_file("writeback_cas");
+        let snapshot = StoredAuth {
+            access_token: "old-access".to_string(),
+            refresh_token: "old-refresh".to_string(),
+            expiry_date: Some(future_millis(3600)),
+            email: Some("a@example.com".to_string()),
+            project_id: None,
+        };
+        write(&path_buf, &snapshot);
+        let baseline = fs::read_to_string(&path_buf).unwrap();
+
+        // Released by the hook, so the replacement is guaranteed to land after
+        // the merge's re-read. Starting it earlier would let it be the record
+        // the merge re-read, which is a different (already-covered) case.
+        let go = Arc::new(AtomicBool::new(false));
+        let writer_go = go.clone();
+        let writer_path = path_buf.clone();
+        let writer = std::thread::spawn(move || {
+            while !writer_go.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            // A completed `shunt login antigravity`, from its own process in
+            // production. Same email as the snapshot, deliberately: a
+            // different one would be held back by `same_identity` and mask
+            // the race this test exists for.
+            write_stored(
+                &writer_path,
+                &StoredAuth {
+                    access_token: "relogin-access".to_string(),
+                    refresh_token: "relogin-refresh".to_string(),
+                    expiry_date: Some(future_millis(7200)),
+                    email: Some("a@example.com".to_string()),
+                    project_id: None,
+                },
+            )
+            .unwrap();
+        });
+
+        let hook_path = path_buf.clone();
+        let store = store_at(path_buf.clone(), &server).with_merge_hook(move || {
+            go.store(true, Ordering::SeqCst);
+            let grace = std::time::Instant::now() + Duration::from_millis(500);
+            loop {
+                // Parked on the very lock this section holds: the writer is
+                // excluded, so the merge write cannot lose it.
+                if crate::auth::shared::file_lock::waiters_blocked_on(&hook_path) > 0 {
+                    return;
+                }
+                // Nothing excluded it, and its record is already on disk — the
+                // merge write below is about to clobber it.
+                if fs::read_to_string(&hook_path).unwrap() != baseline {
+                    return;
+                }
+                if std::time::Instant::now() >= grace {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(2));
+            }
+        });
+
+        assert_eq!(
+            store.project_id(&snapshot).await.unwrap(),
+            "proj-discovered"
+        );
+        writer.join().expect("the competing writer thread");
+
+        let written: StoredAuth =
+            serde_json::from_str(&fs::read_to_string(&path_buf).unwrap()).unwrap();
+        assert_eq!(
+            written.refresh_token, "relogin-refresh",
+            "the re-login's rotated refresh token was lost, so the merge is not a \
+             compare-and-swap"
+        );
+        assert_eq!(
+            written.access_token, "relogin-access",
+            "the re-login's access token was lost, so the merge is not a compare-and-swap"
+        );
     }
 
     #[tokio::test]

--- a/src/auth/antigravity/auth.rs
+++ b/src/auth/antigravity/auth.rs
@@ -134,8 +134,10 @@ static CREDENTIAL_FILE_LOCK: crate::auth::shared::file_lock::FileLockKind =
     crate::auth::shared::file_lock::FileLockKind {
         lock_name: "Antigravity credential lock",
         contention_hint: "Another shunt process is writing the credential file \
-                          (`shunt login antigravity`, or a token refresh). If no such process is \
-                          running, remove that file",
+                          (`shunt login antigravity`, or a token refresh). The lock releases when \
+                          that process exits, so wait for it and retry. Do not delete the lock \
+                          file: removing it while a writer holds it lets the next writer lock a \
+                          new inode and serialize against nothing",
         task_context: "Antigravity credential lock task failed",
         unsupported_warning: "Warning: this platform has no advisory file lock, so a `shunt login \
                               antigravity` running alongside the gateway is not serialized against \

--- a/src/auth/gateway/store.rs
+++ b/src/auth/gateway/store.rs
@@ -157,24 +157,27 @@ pub async fn remove_session(path: &Path) -> anyhow::Result<bool> {
 /// Held for the read -> refresh -> write critical section. Dropping it releases
 /// the advisory lock.
 ///
-/// `Debug` is derived rather than redacted: this holds a descriptor on an empty
-/// lock file, never any token material.
-#[derive(Debug)]
-pub struct SessionLock {
-    #[cfg(unix)]
-    file: fs::File,
-}
+/// An alias for the shared [`shared::file_lock::FileLock`]: the mechanism moved
+/// there when the Antigravity credential store needed the same guard (#384),
+/// and this name stays so the gateway's own call sites still read in terms of
+/// the session.
+pub type SessionLock = shared::file_lock::FileLock;
 
-#[cfg(unix)]
-impl Drop for SessionLock {
-    fn drop(&mut self) {
-        use std::os::unix::io::AsRawFd;
-        // Closing the descriptor would release the lock anyway; unlocking
-        // explicitly keeps the release ordered with respect to the writeback
-        // that just happened rather than with an implicit close.
-        unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
-    }
-}
+/// Diagnostics for the gateway session lock. The wording is the gateway's own;
+/// only the `flock` mechanics are shared.
+static GATEWAY_SESSION_LOCK: shared::file_lock::FileLockKind = shared::file_lock::FileLockKind {
+    lock_name: "gateway session lock",
+    contention_hint: "Another `shunt gateway token` is holding it — most likely one whose gateway \
+                      accepted the connection and never answered. If no such process is running, \
+                      remove that file",
+    task_context: "gateway session lock task failed",
+    unsupported_warning: "Warning: this platform has no advisory file lock, so concurrent `shunt \
+                          gateway token` runs are not serialized. If two run at once they can \
+                          replay the same single-use refresh token, which signs this machine out \
+                          of the gateway; run `shunt gateway login <url>` again if that happens.",
+    #[cfg(not(unix))]
+    warned: std::sync::Once::new(),
+};
 
 /// Take an exclusive advisory lock over the session for this deployment.
 ///
@@ -210,16 +213,14 @@ pub(crate) async fn lock_session_for(
     path: &Path,
     timeout: Duration,
 ) -> anyhow::Result<SessionLock> {
-    let lock_path = lock_path(path);
-    tokio::task::spawn_blocking(move || lock_blocking(&lock_path, timeout))
-        .await
-        .context("gateway session lock task failed")?
+    shared::file_lock::lock_file(path, &GATEWAY_SESSION_LOCK, timeout).await
 }
 
+/// Only the tests name the lock file directly; production code reaches it
+/// through the shared module.
+#[cfg(test)]
 fn lock_path(path: &Path) -> PathBuf {
-    let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(".lock");
-    path.with_file_name(name)
+    shared::file_lock::lock_path(path)
 }
 
 /// Slack the waiter keeps beyond the worst-case legitimate hold, covering the
@@ -235,146 +236,6 @@ const LOCK_HEADROOM_SECS: u64 = 30;
 /// same instant it succeeded, reporting contention for a refresh that worked.
 pub(crate) const LOCK_TIMEOUT: Duration =
     Duration::from_secs(2 * super::auth::NETWORK_TIMEOUT.as_secs() + LOCK_HEADROOM_SECS);
-/// Re-try cadence for the non-blocking acquire. Short relative to a refresh, so
-/// the waiter picks the lock up promptly once the holder is done.
-const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(50);
-
-#[cfg(unix)]
-fn lock_blocking(lock_path: &Path, timeout: Duration) -> anyhow::Result<SessionLock> {
-    use std::os::unix::{fs::OpenOptionsExt, io::AsRawFd};
-
-    if let Some(parent) = lock_path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        shared::create_private_dir(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    let file = fs::OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .mode(0o600)
-        .open(lock_path)
-        .with_context(|| format!("failed to open {}", lock_path.display()))?;
-    // Non-blocking acquire on a deadline rather than a bare `LOCK_EX`. Waiting
-    // is what the waiter wants — the holder is doing one token refresh, and the
-    // waiter re-reads afterwards and usually finds the refreshed token already
-    // on disk — but waiting *without bound* means a wedged holder hangs every
-    // other session with no output to explain it.
-    let deadline = std::time::Instant::now() + timeout;
-    // Test-only, and only ever `Some` once the lock is genuinely contended:
-    // registering on the fast path would report a waiter that never waited.
-    // Held to the end of this function, so `Drop` is what deregisters — the
-    // acquire, the hard-error return, and the deadline bail all exit through
-    // it without any of them naming it.
-    #[cfg(test)]
-    let mut blocked: Option<BlockedWaiter> = None;
-    loop {
-        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
-            return Ok(SessionLock { file });
-        }
-        let error = io::Error::last_os_error();
-        // Only contention is retried; a real failure (bad descriptor, an
-        // filesystem that cannot lock) is reported immediately rather than
-        // being retried until the deadline and then misreported as contention.
-        if error.kind() != io::ErrorKind::WouldBlock {
-            return Err(error).with_context(|| format!("failed to lock {}", lock_path.display()));
-        }
-        // Past the `WouldBlock` check, so this caller is about to wait for a
-        // holder rather than to fail.
-        #[cfg(test)]
-        blocked.get_or_insert_with(|| BlockedWaiter::register(lock_path));
-        if std::time::Instant::now() >= deadline {
-            anyhow::bail!(
-                "timed out after {:?} waiting for the gateway session lock at {}. Another \
-                 `shunt gateway token` is holding it — most likely one whose gateway accepted \
-                 the connection and never answered. If no such process is running, remove that \
-                 file",
-                timeout,
-                lock_path.display()
-            );
-        }
-        std::thread::sleep(LOCK_RETRY_INTERVAL.min(timeout));
-    }
-}
-
-/// Documented no-op off Unix: `flock(2)` has no `std` equivalent there, so the
-/// concurrent-refresh guard degrades to nothing rather than failing to build.
-/// Two simultaneous `shunt gateway token` runs on such a platform can still
-/// race each other into a single-use refresh-token replay.
-///
-/// It says so once per process rather than degrading silently: the symptom is a
-/// surprise family-wide logout much later, which is impossible to trace back to
-/// an absent lock with nothing in the output to connect them.
-#[cfg(not(unix))]
-fn lock_blocking(_lock_path: &Path, _timeout: Duration) -> anyhow::Result<SessionLock> {
-    static WARNED: std::sync::Once = std::sync::Once::new();
-    WARNED.call_once(|| {
-        eprintln!(
-            "Warning: this platform has no advisory file lock, so concurrent `shunt gateway \
-             token` runs are not serialized. If two run at once they can replay the same \
-             single-use refresh token, which signs this machine out of the gateway; run \
-             `shunt gateway login <url>` again if that happens."
-        );
-    });
-    Ok(SessionLock {})
-}
-
-#[cfg(test)]
-pub(crate) static TEST_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-/// Test-only registry of callers currently parked on a session lock.
-///
-/// Exists because "blocked on `flock`" is otherwise invisible from outside the
-/// process, which forces a test that cares about it to guess with a timeout —
-/// and any finite guess loses to a slow enough runner. Counting the waiters
-/// turns that guess into an observation.
-///
-/// Keyed by lock path, never a single global count: sibling tests take session
-/// locks of their own, in parallel, and a global counter would let one of them
-/// satisfy another's wait.
-#[cfg(test)]
-fn blocked_waiters() -> &'static std::sync::Mutex<std::collections::HashMap<PathBuf, usize>> {
-    static WAITERS: std::sync::OnceLock<
-        std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
-    > = std::sync::OnceLock::new();
-    WAITERS.get_or_init(Default::default)
-}
-
-/// RAII registration in [`blocked_waiters`]. A guard rather than paired
-/// register/deregister calls because [`lock_blocking`] leaves by four different
-/// paths, and one of them forgetting to deregister would leave a phantom waiter
-/// that makes a later test observe a block that already ended.
-#[cfg(test)]
-struct BlockedWaiter(PathBuf);
-
-#[cfg(test)]
-impl BlockedWaiter {
-    fn register(lock_path: &Path) -> Self {
-        *blocked_waiters()
-            .lock()
-            .expect("waiter registry")
-            .entry(lock_path.to_path_buf())
-            .or_insert(0) += 1;
-        Self(lock_path.to_path_buf())
-    }
-}
-
-#[cfg(test)]
-impl Drop for BlockedWaiter {
-    fn drop(&mut self) {
-        let mut waiters = blocked_waiters().lock().expect("waiter registry");
-        // Removed at zero rather than left as a 0 entry, so `waiters_blocked_on`
-        // and a map lookup agree on "nobody is waiting".
-        if let Some(count) = waiters.get_mut(&self.0) {
-            *count -= 1;
-            if *count == 0 {
-                waiters.remove(&self.0);
-            }
-        }
-    }
-}
 
 /// How many callers are parked waiting for `path`'s session lock right now.
 ///
@@ -382,13 +243,11 @@ impl Drop for BlockedWaiter {
 /// [`lock_path`] about which file the count is keyed by.
 #[cfg(test)]
 pub(crate) fn waiters_blocked_on(path: &Path) -> usize {
-    blocked_waiters()
-        .lock()
-        .expect("waiter registry")
-        .get(&lock_path(path))
-        .copied()
-        .unwrap_or(0)
+    shared::file_lock::waiters_blocked_on(path)
 }
+
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[cfg(test)]
 pub(crate) fn temp_dir(tag: &str) -> PathBuf {

--- a/src/auth/gateway/store.rs
+++ b/src/auth/gateway/store.rs
@@ -168,8 +168,10 @@ pub type SessionLock = shared::file_lock::FileLock;
 static GATEWAY_SESSION_LOCK: shared::file_lock::FileLockKind = shared::file_lock::FileLockKind {
     lock_name: "gateway session lock",
     contention_hint: "Another `shunt gateway token` is holding it — most likely one whose gateway \
-                      accepted the connection and never answered. If no such process is running, \
-                      remove that file",
+                      accepted the connection and never answered. The lock releases when that \
+                      process exits, so wait for it and retry. Do not delete the lock file: \
+                      removing it while a writer holds it lets the next writer lock a new inode \
+                      and serialize against nothing",
     task_context: "gateway session lock task failed",
     unsupported_warning: "Warning: this platform has no advisory file lock, so concurrent `shunt \
                           gateway token` runs are not serialized. If two run at once they can \

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -340,9 +340,13 @@ const ANTIGRAVITY_CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Wrap a credential-resolution future with a timeout, mapping expiry to a
 /// clear auth error. A dropped future here does not tear a credential file
-/// mid-write: writeback (see `AntigravityAuthStore::write`) goes through
-/// `tokio::task::spawn_blocking`, which runs the write to completion on the
-/// blocking pool even once the awaiting future is cancelled.
+/// mid-write: writeback (see `AntigravityAuthStore::write_unlocked`) goes
+/// through `tokio::task::spawn_blocking`, which runs the write to completion on
+/// the blocking pool even once the awaiting future is cancelled. Cancellation
+/// does release the `CREDENTIAL_FILE_LOCK` guard early, so another writer can
+/// acquire while that write is still in flight — but both writes land by atomic
+/// rename, so the file is still never torn; the loser is simply overwritten,
+/// exactly as it would be without the lock.
 async fn with_credential_timeout<T>(
     duration: Duration,
     future: impl std::future::Future<Output = Result<T, AdapterError>>,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -340,13 +340,13 @@ const ANTIGRAVITY_CREDENTIAL_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Wrap a credential-resolution future with a timeout, mapping expiry to a
 /// clear auth error. A dropped future here does not tear a credential file
-/// mid-write: writeback (see `AntigravityAuthStore::write_unlocked`) goes
+/// mid-write: writeback (see `AntigravityAuthStore::write_holding_lock`) goes
 /// through `tokio::task::spawn_blocking`, which runs the write to completion on
-/// the blocking pool even once the awaiting future is cancelled. Cancellation
-/// does release the `CREDENTIAL_FILE_LOCK` guard early, so another writer can
-/// acquire while that write is still in flight — but both writes land by atomic
-/// rename, so the file is still never torn; the loser is simply overwritten,
-/// exactly as it would be without the lock.
+/// the blocking pool even once the awaiting future is cancelled. The
+/// `CREDENTIAL_FILE_LOCK` guard travels *into* that blocking task rather than
+/// staying a local of the cancelled future, so the lock outlives the write
+/// too — cancellation cannot hand the file to another writer while a rename is
+/// still in flight.
 async fn with_credential_timeout<T>(
     duration: Duration,
     future: impl std::future::Future<Output = Result<T, AdapterError>>,

--- a/src/auth/shared.rs
+++ b/src/auth/shared.rs
@@ -22,6 +22,8 @@ use sha2::{Digest, Sha256};
 
 use crate::{accounts::StoreFamily, config::AccountConfig};
 
+pub mod file_lock;
+
 const EXPIRY_BUFFER: Duration = Duration::from_secs(5 * 60);
 
 /// A freshly generated PKCE verifier/challenge plus an independent OAuth state.

--- a/src/auth/shared/file_lock.rs
+++ b/src/auth/shared/file_lock.rs
@@ -1,0 +1,357 @@
+//! Advisory `flock(2)` over a credential/session file, on a sibling `.lock`.
+//!
+//! Extracted verbatim from the gateway session store, which needed it first
+//! (two `shunt gateway token` runs replaying one single-use refresh token), and
+//! generalized because the Antigravity credential file has the same shape of
+//! race: `shunt login antigravity` rewrites it from a **separate process**
+//! while the gateway is serving requests, so no in-process mutex can exclude
+//! it.
+//!
+//! The lock is taken on a sibling `<file>.lock` rather than on the file itself:
+//! every writeback here renames a temp file over the target, so its inode
+//! changes and a lock held on the old inode would guard nothing. That also
+//! means the `.lock` file must never be unlinked — a stable inode is the whole
+//! mechanism.
+//!
+//! Acquisition is always bounded rather than an unconditional `LOCK_EX`: a
+//! wedged holder must be reported on one caller instead of hanging every other
+//! one silently. The bound is supplied by the caller, because the worst-case
+//! legitimate hold differs per site (the gateway holds it across two network
+//! round trips; Antigravity's project-id merge holds it across two file
+//! operations and nothing else).
+
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+// Only the Unix arm touches the filesystem directly; off Unix the lock is a
+// documented no-op that opens nothing.
+#[cfg(unix)]
+use std::{fs, io};
+
+use anyhow::Context;
+
+/// The human-readable identity of one lock, so a shared implementation can
+/// still produce the site-specific diagnostics each caller needs.
+///
+/// Carries its own `Once` rather than sharing a single global: the non-Unix
+/// warning is "once per process **per lock kind**", and a shared latch would
+/// let whichever kind warned first silence the other one forever.
+pub struct FileLockKind {
+    /// Names the lock in the timeout message ("gateway session lock").
+    pub lock_name: &'static str,
+    /// Sentence appended after the timeout message names the lock file: who is
+    /// most likely holding it and what to do about it.
+    pub contention_hint: &'static str,
+    /// Context for a `spawn_blocking` join failure.
+    pub task_context: &'static str,
+    /// Printed once per process off Unix, where the lock is a documented no-op.
+    pub unsupported_warning: &'static str,
+    #[cfg(not(unix))]
+    pub warned: std::sync::Once,
+}
+
+/// Held for the duration of a read -> modify -> write critical section.
+/// Dropping it releases the advisory lock.
+///
+/// `Debug` is derived rather than redacted: this holds a descriptor on an empty
+/// lock file, never any credential material.
+#[derive(Debug)]
+pub struct FileLock {
+    #[cfg(unix)]
+    file: fs::File,
+}
+
+#[cfg(unix)]
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        use std::os::unix::io::AsRawFd;
+        // Closing the descriptor would release the lock anyway; unlocking
+        // explicitly keeps the release ordered with respect to the writeback
+        // that just happened rather than with an implicit close.
+        unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+/// Take the exclusive advisory lock for `path`, off the async runtime.
+///
+/// Returns a guard that is `Send`, so it can be held across `.await` points —
+/// which is what a read/modify/write critical section spanning two
+/// `spawn_blocking` file operations needs.
+pub async fn lock_file(
+    path: &Path,
+    kind: &'static FileLockKind,
+    timeout: Duration,
+) -> anyhow::Result<FileLock> {
+    let lock_path = lock_path(path);
+    tokio::task::spawn_blocking(move || lock_blocking_at(&lock_path, kind, timeout))
+        .await
+        .context(kind.task_context)?
+}
+
+/// [`lock_file`] for a caller that is already inside a `spawn_blocking` (or is
+/// plain synchronous code). Blocks the calling thread.
+pub fn lock_file_blocking(
+    path: &Path,
+    kind: &'static FileLockKind,
+    timeout: Duration,
+) -> anyhow::Result<FileLock> {
+    lock_blocking_at(&lock_path(path), kind, timeout)
+}
+
+/// The sibling `.lock` file guarding `path`.
+pub fn lock_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    path.with_file_name(name)
+}
+
+/// Re-try cadence for the non-blocking acquire. Short relative to any
+/// legitimate hold, so the waiter picks the lock up promptly once the holder
+/// is done.
+#[cfg(unix)]
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+#[cfg(unix)]
+fn lock_blocking_at(
+    lock_path: &Path,
+    kind: &'static FileLockKind,
+    timeout: Duration,
+) -> anyhow::Result<FileLock> {
+    use std::os::unix::{fs::OpenOptionsExt, io::AsRawFd};
+
+    if let Some(parent) = lock_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        super::create_private_dir(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .mode(0o600)
+        .open(lock_path)
+        .with_context(|| format!("failed to open {}", lock_path.display()))?;
+    // Non-blocking acquire on a deadline rather than a bare `LOCK_EX`. Waiting
+    // is what the waiter wants — the holder is doing one short critical
+    // section, and the waiter re-reads afterwards and usually finds the result
+    // already on disk — but waiting *without bound* means a wedged holder
+    // hangs every other caller with no output to explain it.
+    let deadline = std::time::Instant::now() + timeout;
+    // Test-only, and only ever `Some` once the lock is genuinely contended:
+    // registering on the fast path would report a waiter that never waited.
+    // Held to the end of this function, so `Drop` is what deregisters — the
+    // acquire, the hard-error return, and the deadline bail all exit through
+    // it without any of them naming it.
+    #[cfg(test)]
+    let mut blocked: Option<BlockedWaiter> = None;
+    loop {
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(FileLock { file });
+        }
+        let error = io::Error::last_os_error();
+        // Only contention is retried; a real failure (bad descriptor, a
+        // filesystem that cannot lock) is reported immediately rather than
+        // being retried until the deadline and then misreported as contention.
+        if error.kind() != io::ErrorKind::WouldBlock {
+            return Err(error).with_context(|| format!("failed to lock {}", lock_path.display()));
+        }
+        // Past the `WouldBlock` check, so this caller is about to wait for a
+        // holder rather than to fail.
+        #[cfg(test)]
+        blocked.get_or_insert_with(|| BlockedWaiter::register(lock_path));
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out after {:?} waiting for the {} at {}. {}",
+                timeout,
+                kind.lock_name,
+                lock_path.display(),
+                kind.contention_hint
+            );
+        }
+        std::thread::sleep(LOCK_RETRY_INTERVAL.min(timeout));
+    }
+}
+
+/// Documented no-op off Unix: `flock(2)` has no `std` equivalent there, so the
+/// concurrency guard degrades to nothing rather than failing to build.
+///
+/// It says so once per process rather than degrading silently: the symptom is
+/// a lost credential much later, which is impossible to trace back to an
+/// absent lock with nothing in the output to connect them.
+#[cfg(not(unix))]
+fn lock_blocking_at(
+    _lock_path: &Path,
+    kind: &'static FileLockKind,
+    _timeout: Duration,
+) -> anyhow::Result<FileLock> {
+    kind.warned.call_once(|| {
+        eprintln!("{}", kind.unsupported_warning);
+    });
+    Ok(FileLock {})
+}
+
+/// Test-only registry of callers currently parked on a file lock.
+///
+/// Exists because "blocked on `flock`" is otherwise invisible from outside the
+/// process, which forces a test that cares about it to guess with a timeout —
+/// and any finite guess loses to a slow enough runner. Counting the waiters
+/// turns that guess into an observation.
+///
+/// Keyed by lock path, never a single global count: sibling tests take locks
+/// of their own, in parallel, and a global counter would let one of them
+/// satisfy another's wait.
+#[cfg(test)]
+fn blocked_waiters() -> &'static std::sync::Mutex<std::collections::HashMap<PathBuf, usize>> {
+    static WAITERS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
+    > = std::sync::OnceLock::new();
+    WAITERS.get_or_init(Default::default)
+}
+
+/// RAII registration in [`blocked_waiters`]. A guard rather than paired
+/// register/deregister calls because [`lock_blocking_at`] leaves by four
+/// different paths, and one of them forgetting to deregister would leave a
+/// phantom waiter that makes a later test observe a block that already ended.
+#[cfg(test)]
+struct BlockedWaiter(PathBuf);
+
+#[cfg(test)]
+impl BlockedWaiter {
+    fn register(lock_path: &Path) -> Self {
+        *blocked_waiters()
+            .lock()
+            .expect("waiter registry")
+            .entry(lock_path.to_path_buf())
+            .or_insert(0) += 1;
+        Self(lock_path.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+impl Drop for BlockedWaiter {
+    fn drop(&mut self) {
+        let mut waiters = blocked_waiters().lock().expect("waiter registry");
+        // Removed at zero rather than left as a 0 entry, so `waiters_blocked_on`
+        // and a map lookup agree on "nobody is waiting".
+        if let Some(count) = waiters.get_mut(&self.0) {
+            *count -= 1;
+            if *count == 0 {
+                waiters.remove(&self.0);
+            }
+        }
+    }
+}
+
+/// How many callers are parked waiting for `path`'s lock right now.
+///
+/// Takes the *guarded* path, not the lock path, so callers cannot disagree
+/// with [`lock_path`] about which file the count is keyed by.
+#[cfg(test)]
+pub(crate) fn waiters_blocked_on(path: &Path) -> usize {
+    blocked_waiters()
+        .lock()
+        .expect("waiter registry")
+        .get(&lock_path(path))
+        .copied()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_LOCK: FileLockKind = FileLockKind {
+        lock_name: "test file lock",
+        contention_hint: "Another test is holding it.",
+        task_context: "test file lock task failed",
+        unsupported_warning: "Warning: no advisory file lock on this platform.",
+        #[cfg(not(unix))]
+        warned: std::sync::Once::new(),
+    };
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        std::env::temp_dir().join(format!(
+            "shunt-file-lock-{tag}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn lock_path_is_a_sibling_of_the_guarded_file() {
+        assert_eq!(
+            lock_path(Path::new("/tmp/shunt/creds.json")),
+            PathBuf::from("/tmp/shunt/creds.json.lock")
+        );
+    }
+
+    /// The async and blocking entry points must contend with each other, not
+    /// just each with itself: `write_stored` uses the blocking one from inside
+    /// `spawn_blocking` while the project-id merge holds the async one.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_blocking_entry_point_waits_for_an_async_holder() {
+        let dir = temp_dir("cross-entry");
+        let path = dir.join("creds.json");
+        let held = lock_file(&path, &TEST_LOCK, Duration::from_secs(10))
+            .await
+            .expect("async acquisition");
+
+        let error = tokio::task::spawn_blocking({
+            let path = path.clone();
+            move || lock_file_blocking(&path, &TEST_LOCK, Duration::from_millis(200))
+        })
+        .await
+        .expect("join")
+        .expect_err("a held lock must block the blocking entry point too");
+        assert!(error.to_string().contains("test file lock"), "got: {error}");
+
+        drop(held);
+        tokio::task::spawn_blocking({
+            let path = path.clone();
+            move || lock_file_blocking(&path, &TEST_LOCK, Duration::from_secs(10))
+        })
+        .await
+        .expect("join")
+        .expect("the lock is free once the async guard drops");
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// The timeout message must name the kind and the lock file, or an
+    /// operator has nothing to act on.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_timeout_names_the_kind_and_the_lock_file() {
+        let dir = temp_dir("timeout-text");
+        let path = dir.join("creds.json");
+        let held = lock_file(&path, &TEST_LOCK, Duration::from_secs(10))
+            .await
+            .expect("first acquisition");
+
+        let error = lock_file(&path, &TEST_LOCK, Duration::from_millis(200))
+            .await
+            .expect_err("a held lock must time out rather than block forever");
+        let message = error.to_string();
+        assert!(message.contains("test file lock"), "got: {message}");
+        assert!(
+            message.contains(&lock_path(&path).display().to_string()),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("Another test is holding it."),
+            "got: {message}"
+        );
+
+        drop(held);
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/src/auth/shared/file_lock.rs
+++ b/src/auth/shared/file_lock.rs
@@ -172,7 +172,12 @@ fn lock_blocking_at(
                 kind.contention_hint
             );
         }
-        std::thread::sleep(LOCK_RETRY_INTERVAL.min(timeout));
+        // Clamped to what is left of the budget, not to the whole of it:
+        // `timeout` never shrinks, so retrying on it would let the last sleep
+        // run past `deadline` and report the timeout up to one retry interval
+        // late.
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        std::thread::sleep(remaining.min(LOCK_RETRY_INTERVAL));
     }
 }
 

--- a/src/auth/shared/file_lock.rs
+++ b/src/auth/shared/file_lock.rs
@@ -43,6 +43,12 @@ pub struct FileLockKind {
     pub lock_name: &'static str,
     /// Sentence appended after the timeout message names the lock file: who is
     /// most likely holding it and what to do about it.
+    ///
+    /// Never advise removing the lock file. `flock(2)` releases on holder exit,
+    /// so a "stale" lock is never actually held and deleting it fixes nothing —
+    /// but deleting one that *is* held lets the next writer lock a fresh inode
+    /// and exclude no one, which is the failure this module exists to prevent
+    /// (see the module docs on why the `.lock` inode must stay stable).
     pub contention_hint: &'static str,
     /// Context for a `spawn_blocking` join failure.
     pub task_context: &'static str,


### PR DESCRIPTION
Closes #384.

`AntigravityAuthStore::project_id` re-read the credential file and merged only `project_id` before writing (`c19d923`). That narrowed the clobber window — `discover_project` can run for minutes on first-time onboarding, so the pre-discovery snapshot was routinely stale — but it did not make the operation atomic. Atomic rename makes each *individual* write all-or-nothing; it does not make a read/merge/write a transaction. A refresh, or a `shunt login antigravity` running in its own process, landing between the two awaits was still silently lost, and a lost rotated refresh token costs the operator a full re-login.

## The mechanism

An advisory `flock(2)` on a sibling `antigravity-auth.json.lock` — the same mechanism the gateway session store already used, extracted here into `src/auth/shared/file_lock.rs`.

**Why a file lock and not a mutex.** The competing writer can be a *different process*: `shunt login antigravity` (`src/auth/antigravity/login.rs:216`) rewrites the same file while the gateway is running. No in-process mutex can exclude it.

**`REFRESH_LOCK` is deliberately not involved.** `get_valid` already holds it on two of `project_id`'s three call sites and `tokio::sync::Mutex` is not reentrant, so taking it in `project_id` would deadlock. Beyond that, #373 exists to *narrow* `REFRESH_LOCK`'s scope, so widening it is the one direction both #383 and #384 name as wrong.

## The new mutual-exclusion boundary

Sites that **take** `CREDENTIAL_FILE_LOCK`:

| Site | Kind | Variant |
| --- | --- | --- |
| `AntigravityAuthStore::write` (`auth.rs:456`) — refresh writeback from `get_valid` | writer | async |
| project-id merge: guard taken before the re-read (`auth.rs:621`), held across `same_identity`/`already_resolved`, then **consumed by** the write (`auth.rs:681`) | read half + write half of the CAS | async, one guard for both |
| `write_stored` (`auth.rs:1191`) ← `login.rs:216`, **separate process**; also the test helpers at `auth.rs:1239` and `auth/mod.rs:507` | writer | blocking (callers are already inside `spawn_blocking`) |

Sites that deliberately **do not**:

| Site | Kind | Why not |
| --- | --- | --- |
| `AntigravityAuthStore::read` (`auth.rs:399`), standalone calls from `get_valid` (`auth.rs:328`, `auth.rs:354`) | reader | Every writer replaces the file by atomic rename, so a reader always sees one complete record. Locking here would add contention and a timeout failure mode without adding any exclusion. Documented at the definition. |
| `routed_antigravity_credential_error` → `default_antigravity_auth_path().exists()` (`antigravity/mod.rs:124`) | existence probe | Rename never makes the path transiently absent. |

Antigravity is single-credential: `StoreFamily` (`src/accounts.rs:21`) has only `Claude`/`Chatgpt`/`Kimi`, so there is no pooled-accounts-directory writer to cover.

**The lock is never held across a network call.** `discover_project` has already returned by the time the merge section opens. **Lock ordering:** `REFRESH_LOCK` is only ever taken *before* the file lock, never after — so the two cannot deadlock, and `project_id` remains safe to call whether or not its caller holds `REFRESH_LOCK`.

Inside the critical section the merge calls `read()` and the new `write_unlocked()` — **never** the locking `write()`, which would deadlock against this same process (`flock` on a second descriptor to the same file blocks even within one process). `write_unlocked`'s doc comment says so.

`same_identity` and `already_resolved` are preserved verbatim and still load-bearing: the lock excludes a *concurrent* writer, but one that already landed before the guard was taken still has to be detected.

**Timeout.** `CREDENTIAL_LOCK_TIMEOUT = 5s`, derived from what the lock actually covers — one `read` plus one atomic write of a sub-kilobyte JSON file, two `spawn_blocking` round trips — not from the gateway's network-derived `LOCK_TIMEOUT`. On acquire failure: the merge warns and skips the persist (matching the block's existing best-effort semantics); `write` and `write_stored` propagate.

## Commits

1. **`refactor(auth)`** — pure move of the gateway's `flock` into `auth::shared::file_lock`, parameterized by a `FileLockKind` descriptor (lock name, contention hint, join context, off-Unix warning + its own `Once`) and a caller-supplied timeout. Both entry points exposed: async `lock_file` (guard is `Send`, holdable across `.await`) and `lock_file_blocking`. Gateway keeps identical wording, timeout, and drop semantics; all six of its locking tests pass unchanged.
2. **`fix(antigravity)`** — the CAS and its test.
3. **`fix(antigravity)`** — two defects found by the review pass over commit 2: the guard is now *moved into* the blocking write task (`write_holding_lock` consumes it) so cancellation cannot release the lock while a rename is still in flight; and the test's two-stage wait no longer falls through silently, since a silent fallthrough would let an unlocked implementation pass.
4. **`docs(antigravity)`** — the `cli.mdx` sentence overclaimed twice: it asserted the serialization unconditionally (false off Unix, where the lock is a documented no-op) and asserted a rotated refresh token is "never lost" (false on Unix too — `get_valid` reads before taking the lock, so the residual below still applies). Restated as the Unix behaviour scoped to the read-modify-write it actually covers, plus the residual and the off-Unix degradation.

## Test

The issue states it outright: a test that does not control the interleaving passes against the current code and proves nothing. `project_id_writeback_serializes_against_a_concurrent_relogin` forces it through a `#[cfg(test)]` hook fired inside the critical section, which releases a competing writer thread (`relogin-access`/`relogin-refresh`, **same** email so `same_identity` cannot mask the race) and then waits in two stages — returning the instant the writer is observed parked on the lock via the shared blocked-waiter registry (fixed), or the instant its record appears on disk (unfixed). The bounded 500ms grace is a cost the passing case never pays; the test runs in ~0.06s.

Non-vacuity proved: reverting *only* the merge-path acquisition gives a genuine assertion failure, not a compile error —

```
test auth::antigravity::auth::tests::project_id_writeback_serializes_against_a_concurrent_relogin ... FAILED
assertion `left == right` failed: the re-login's rotated refresh token was lost, so the merge is not a compare-and-swap
  left: "old-refresh"
 right: "relogin-refresh"
```

The four pre-existing writeback tests are untouched and still green.

## Composition with #373 and #383

- **#373 (narrow `REFRESH_LOCK`)**: this adds a *finer-grained, per-file* lock strictly below `REFRESH_LOCK` in the ordering, and it covers exactly the file operations `REFRESH_LOCK` was incidentally covering. Narrowing `REFRESH_LOCK` to `refresh_call` + `write` — or removing it from the discovery path entirely — leaves this correct, because credential-file integrity no longer depends on it.
- **#383 (serialize request-path discovery)**: orthogonal. That is about *duplicated provisioning work* against the control plane, not file correctness, and its fix belongs around `discover_project` (a discovery-scoped lock or a long-lived `project_cache`) — outside this lock's critical section, which opens only after discovery returns.

## Known residual (documented, not fixed)

`get_valid`'s refresh path is itself a read → `refresh_call` → write sequence guarded only by the in-process `REFRESH_LOCK`, so it is still not a CAS against the separate login process. Closing it would mean holding the file lock across a network call, which is exactly what #373 is undoing. Behavior there is unchanged by this PR; follow-up.

## Non-Unix arm

`#[cfg(not(unix))]` compiles on neither CI (ubuntu) nor macOS, so a type error there would ship. Since this PR moves that arm, the cfg gate was temporarily inverted and a **native** `cargo check --all-features` run with no `RUSTFLAGS` (cross-compiling is not an option — `ring`'s C build dies): clean, no errors and no warnings. Gate restored.

## Doc surfaces considered

- **`README.md` + `README.ko.md` / `.ja.md` / `.zh-CN.md`** — no change. No config key, endpoint, CLI, default, or provider/model support changes.
- **`docs/`** — grepped for antigravity credential-writeback notes; none understate the guarantee. Updated the doc comment at `src/auth/mod.rs` that described writeback as going through the atomic writer, since it named `AntigravityAuthStore::write` and now also has to describe what cancellation does to the guard.
- **`site/src/content/docs/`** — updated `reference/cli.mdx` under `shunt login antigravity`, because the sibling `.lock` file is a user-observable filesystem artifact and the gateway's equivalent is documented the same way. The claim is qualified by platform and scoped to what the lock actually covers (see commit 4). The `ko`/`ja`/`zh-cn` copies of `cli.mdx` have no `shunt login antigravity` section at all — their login lists jump `xai` → `kimi` — so there is no translated counterpart to update. That is a pre-existing translation gap, not introduced or widened here.
- **`wiki/`** — generated by memex; not hand-edited, not part of this PR.

## Sign-off

AGENTS.md's "ask before changing credential-file writeback behavior" — the maintainer asked for #384 by name. The boundary is stated explicitly above. No provider other than Antigravity has its writeback semantics changed; the gateway's change is a mechanical delegation.


## CI note

`fmt · clippy · test` is red on this PR with four `clippy::result_large_err` errors in `src/codex_endpoint.rs`, `src/http_tuning.rs`, and `src/proxy/failover.rs` — none of which this branch touches (`git diff --name-only ecf5664..HEAD` lists only the six files above). This is a repo-wide break from a newer stable clippy, not from this change: unrelated PR #415 fails with the identical four errors, and `main` was last green two days ago on an older stable. Needs a separate fix on `main`.
