### PR TITLE
fix(proxy): box forward errors for clippy on Rust 1.98

### DIFF
--- a/src/codex_endpoint.rs
+++ b/src/codex_endpoint.rs
@@ -319,7 +319,7 @@ async fn forward(
                     "failed to read request body"
                 }
                 .to_string(),
-                response,
+                response: *response,
             })
         })?;
 

--- a/src/codex_endpoint.rs
+++ b/src/codex_endpoint.rs
@@ -248,16 +248,16 @@ async fn forward(
     headers: HeaderMap,
     body: Body,
     started_at: Instant,
-) -> Result<(StatusCode, axum::response::Response), ForwardError> {
+) -> Result<(StatusCode, axum::response::Response), Box<ForwardError>> {
     // The routes are only registered when `[server.codex_endpoint]` is set, but
     // read the snapshot defensively; config validation guarantees the named
     // provider exists and uses `chatgpt_oauth`.
     let Some(codex_endpoint) = &state.config.server.codex_endpoint else {
-        return Err(ForwardError {
+        return Err(Box::new(ForwardError {
             message: "codex endpoint is not configured".to_string(),
             response: ShuntError::bad_gateway("codex endpoint is not configured".to_string())
                 .into_response(),
-        });
+        }));
     };
     let provider = codex_endpoint.provider.clone();
 
@@ -287,7 +287,7 @@ async fn forward(
                     "missing or invalid client token for the inbound codex endpoint: provide it via the `{}` header or `Authorization: Bearer <token>` (e.g. OPENAI_API_KEY); ask the operator for one",
                     auth.header()
                 );
-                return Err(ForwardError {
+                return Err(Box::new(ForwardError {
                     message: "inbound authentication failed".to_string(),
                     response: ShuntError::new(
                         StatusCode::UNAUTHORIZED,
@@ -295,7 +295,7 @@ async fn forward(
                         message,
                     )
                     .into_response(),
-                });
+                }));
             }
         }
     } else {
@@ -304,21 +304,23 @@ async fn forward(
 
     let max_request_bytes = state.config.server.limits.max_request_bytes;
     if crate::http_tuning::content_length_exceeds(&headers, max_request_bytes) {
-        return Err(ForwardError {
+        return Err(Box::new(ForwardError {
             message: "request body exceeds the configured limit".to_string(),
             response: crate::http_tuning::request_too_large(true).await,
-        });
+        }));
     }
     let body = crate::http_tuning::read_body(body, max_request_bytes, true)
         .await
-        .map_err(|response| ForwardError {
-            message: if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
-                "request body exceeds the configured limit"
-            } else {
-                "failed to read request body"
-            }
-            .to_string(),
-            response,
+        .map_err(|response| {
+            Box::new(ForwardError {
+                message: if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+                    "request body exceeds the configured limit"
+                } else {
+                    "failed to read request body"
+                }
+                .to_string(),
+                response,
+            })
         })?;
 
     // Read the model for metrics/logging only; the body forwards verbatim.
@@ -371,7 +373,7 @@ async fn forward(
             );
             (status, response)
         })
-        .map_err(ForwardError::from)
+        .map_err(|error| Box::new(ForwardError::from(error)))
 }
 
 /// The label used when the request's model cannot be read (see [`model_label`]).

--- a/src/http_tuning.rs
+++ b/src/http_tuning.rs
@@ -108,11 +108,13 @@ pub(crate) async fn read_body(
     body: Body,
     limit: usize,
     codex_shape: bool,
-) -> Result<Bytes, Response> {
+) -> Result<Bytes, Box<Response>> {
     match to_bytes(body, limit).await {
         Ok(body) => Ok(body),
-        Err(error) if body_limit_exceeded(&error) => Err(request_too_large(codex_shape).await),
-        Err(error) => Err(body_read_error(error, codex_shape).await),
+        Err(error) if body_limit_exceeded(&error) => {
+            Err(Box::new(request_too_large(codex_shape).await))
+        }
+        Err(error) => Err(Box::new(body_read_error(error, codex_shape).await)),
     }
 }
 
@@ -322,7 +324,7 @@ mod tests {
             .await
             .expect_err("six streamed bytes exceed the four-byte limit");
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
-        assert_eq!(body(response).await["error"]["type"], "request_too_large");
+        assert_eq!(body(*response).await["error"]["type"], "request_too_large");
     }
 
     #[tokio::test]
@@ -335,7 +337,7 @@ mod tests {
                 .await
                 .expect_err("the body source error should be preserved");
             assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
-            let response = body(response).await;
+            let response = body(*response).await;
             if codex_shape {
                 assert!(response.get("type").is_none());
                 assert_eq!(response["error"]["type"], expected_type);

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -45,7 +45,7 @@ pub(super) async fn forward(
                     "failed to read request body"
                 }
                 .to_string(),
-                response,
+                response: *response,
             })
         })?;
     let mut body = crate::request::RequestBody::parse(body.to_vec())

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -27,38 +27,42 @@ pub(super) async fn forward(
     headers: &HeaderMap,
     body: Body,
     started_at: Instant,
-) -> Result<(StatusCode, axum::response::Response), ForwardError> {
+) -> Result<(StatusCode, axum::response::Response), Box<ForwardError>> {
     let max_request_bytes = state.config.server.limits.max_request_bytes;
     if crate::http_tuning::content_length_exceeds(headers, max_request_bytes) {
-        return Err(ForwardError {
+        return Err(Box::new(ForwardError {
             message: "request body exceeds the configured limit".to_string(),
             response: crate::http_tuning::request_too_large(false).await,
-        });
+        }));
     }
     let body = crate::http_tuning::read_body(body, max_request_bytes, false)
         .await
-        .map_err(|response| ForwardError {
-            message: if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
-                "request body exceeds the configured limit"
-            } else {
-                "failed to read request body"
-            }
-            .to_string(),
-            response,
+        .map_err(|response| {
+            Box::new(ForwardError {
+                message: if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+                    "request body exceeds the configured limit"
+                } else {
+                    "failed to read request body"
+                }
+                .to_string(),
+                response,
+            })
         })?;
     let mut body = crate::request::RequestBody::parse(body.to_vec())
         .map_err(routing::invalid_routing_request)
-        .map_err(|error| ForwardError {
-            message: "failed to route request".to_string(),
-            response: error.into_response(),
+        .map_err(|error| {
+            Box::new(ForwardError {
+                message: "failed to route request".to_string(),
+                response: error.into_response(),
+            })
         })?;
     normalize_request_body(&mut body);
     let (mut routes, requested_model) =
         routing::resolve_request_chain_value(&state.config, body.json()).map_err(|error| {
-            ForwardError {
+            Box::new(ForwardError {
                 message: "failed to route request".to_string(),
                 response: error.into_response(),
-            }
+            })
         })?;
     crate::observability::record_requested_model(&requested_model);
     // Records the request's final outcome exactly once, at whichever terminal
@@ -77,10 +81,8 @@ pub(super) async fn forward(
         // count_tokens request.
         routes.truncate(1);
     }
-    let (base_headers, inbound) =
-        check_inbound_auth(&state, &routes, headers).map_err(|error| *error)?;
-    enforce_managed_model_policy(&state, inbound.gateway_claims.as_ref(), &requested_model)
-        .map_err(|error| *error)?;
+    let (base_headers, inbound) = check_inbound_auth(&state, &routes, headers)?;
+    enforce_managed_model_policy(&state, inbound.gateway_claims.as_ref(), &requested_model)?;
 
     let first_route = routes
         .first()
@@ -216,10 +218,10 @@ pub(super) async fn forward(
                     }
                     _ => {
                         finish(&provider, response.status());
-                        return Err(ForwardError {
+                        return Err(Box::new(ForwardError {
                             message,
                             response: *response,
-                        });
+                        }));
                     }
                 }
             }
@@ -246,10 +248,10 @@ pub(super) async fn forward(
             }
             FinalResponse::MappedError { message, response } => {
                 finish(&failure.provider, response.status());
-                Err(ForwardError {
+                Err(Box::new(ForwardError {
                     message,
                     response: *response,
-                })
+                }))
             }
         };
     }
@@ -264,7 +266,7 @@ pub(super) async fn forward(
         &last_route.upstream_model,
     );
     finish(&last_route.provider, StatusCode::BAD_GATEWAY);
-    Err(ForwardError { message, response })
+    Err(Box::new(ForwardError { message, response }))
 }
 
 async fn count_tokens_response(
@@ -275,7 +277,7 @@ async fn count_tokens_response(
     inbound: &InboundContext,
     body: crate::request::RequestBody,
     requested_model: &str,
-) -> Result<(StatusCode, axum::response::Response), ForwardError> {
+) -> Result<(StatusCode, axum::response::Response), Box<ForwardError>> {
     let provider = route.provider.clone();
     let upstream_model = route.upstream_model.clone();
     let result = if matches!(
@@ -331,10 +333,10 @@ async fn count_tokens_response(
             let status = response.status();
             crate::observability::record_span_outcome(&provider, status);
             crate::observability::capture_upstream_outcome(&provider, requested_model, status);
-            Err(ForwardError {
+            Err(Box::new(ForwardError {
                 message: error.message,
                 response,
-            })
+            }))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Box `ForwardError` across proxy failover, token-count, and Codex forwarding paths so `clippy::result_large_err` passes on Rust 1.98 CI.
- Box `read_body` error responses for the same lint in `http_tuning.rs`.

Unblocks CI on PRs #370, #410, #411, #414, and #415.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (Rust 1.98)
- [x] `cargo test --all-features --workspace`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boxes `ForwardError` and `Response` in proxy failover, Codex forwarding, and `http_tuning` to satisfy `clippy::result_large_err` on Rust 1.98 and restore CI. Previously these functions returned large error types by value; now they return boxed errors. HTTP behavior and metrics remain unchanged.

- Review focus: verify updated signatures in `proxy/failover.rs` (`forward`, `count_tokens_response`), `codex_endpoint.rs` (`forward`), and `http_tuning::read_body` now return boxed errors and that call sites deref only in tests and response mapping.
- No migration for external users; internal callers must handle `Box<ForwardError>` and `Box<Response>` (tests updated to deref when asserting).

<sup>Written for commit 84fe2da3091c2111e3ecdc4802a26f35aa3ed865. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

