### PR TITLE
fix(lint): box oversized Err variants to unbreak CI on clippy 1.98

### DIFF
--- a/src/codex_endpoint.rs
+++ b/src/codex_endpoint.rs
@@ -215,7 +215,7 @@ pub async fn post(
                 // client) pointed here expects the OpenAI `{"error":{...}}` envelope,
                 // so re-shape at this single boundary (status preserved). Relayed
                 // upstream errors never reach here — they return verbatim as `Ok`.
-                crate::error::into_openai_error_shape(error.response).await
+                crate::error::into_openai_error_shape(*error.response).await
             }
         }
     }
@@ -230,14 +230,16 @@ pub async fn post(
 /// resolution/transport) surface here.
 struct ForwardError {
     message: String,
-    response: axum::response::Response,
+    /// Boxed to keep `Result<_, ForwardError>` small: an `axum` `Response` alone
+    /// is 128 bytes, which trips `clippy::result_large_err` on [`forward`].
+    response: Box<axum::response::Response>,
 }
 
 impl From<AdapterError> for ForwardError {
     fn from(error: AdapterError) -> Self {
         Self {
             message: error.message,
-            response: *error.response,
+            response: error.response,
         }
     }
 }
@@ -255,8 +257,10 @@ async fn forward(
     let Some(codex_endpoint) = &state.config.server.codex_endpoint else {
         return Err(ForwardError {
             message: "codex endpoint is not configured".to_string(),
-            response: ShuntError::bad_gateway("codex endpoint is not configured".to_string())
-                .into_response(),
+            response: Box::new(
+                ShuntError::bad_gateway("codex endpoint is not configured".to_string())
+                    .into_response(),
+            ),
         });
     };
     let provider = codex_endpoint.provider.clone();
@@ -289,12 +293,10 @@ async fn forward(
                 );
                 return Err(ForwardError {
                     message: "inbound authentication failed".to_string(),
-                    response: ShuntError::new(
-                        StatusCode::UNAUTHORIZED,
-                        "authentication_error",
-                        message,
-                    )
-                    .into_response(),
+                    response: Box::new(
+                        ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
+                            .into_response(),
+                    ),
                 });
             }
         }
@@ -306,7 +308,7 @@ async fn forward(
     if crate::http_tuning::content_length_exceeds(&headers, max_request_bytes) {
         return Err(ForwardError {
             message: "request body exceeds the configured limit".to_string(),
-            response: crate::http_tuning::request_too_large(true).await,
+            response: Box::new(crate::http_tuning::request_too_large(true).await),
         });
     }
     let body = crate::http_tuning::read_body(body, max_request_bytes, true)

--- a/src/http_tuning.rs
+++ b/src/http_tuning.rs
@@ -108,11 +108,16 @@ pub(crate) async fn read_body(
     body: Body,
     limit: usize,
     codex_shape: bool,
-) -> Result<Bytes, Response> {
+) -> Result<Bytes, Box<Response>> {
+    // The error is boxed to keep this `Result` small: an `axum` `Response` is far
+    // larger than the `Bytes` success value, and every caller only moves the error
+    // into its own boxed error payload.
     match to_bytes(body, limit).await {
         Ok(body) => Ok(body),
-        Err(error) if body_limit_exceeded(&error) => Err(request_too_large(codex_shape).await),
-        Err(error) => Err(body_read_error(error, codex_shape).await),
+        Err(error) if body_limit_exceeded(&error) => {
+            Err(Box::new(request_too_large(codex_shape).await))
+        }
+        Err(error) => Err(Box::new(body_read_error(error, codex_shape).await)),
     }
 }
 
@@ -322,7 +327,7 @@ mod tests {
             .await
             .expect_err("six streamed bytes exceed the four-byte limit");
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
-        assert_eq!(body(response).await["error"]["type"], "request_too_large");
+        assert_eq!(body(*response).await["error"]["type"], "request_too_large");
     }
 
     #[tokio::test]
@@ -335,7 +340,7 @@ mod tests {
                 .await
                 .expect_err("the body source error should be preserved");
             assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
-            let response = body(response).await;
+            let response = body(*response).await;
             if codex_shape {
                 assert!(response.get("type").is_none());
                 assert_eq!(response["error"]["type"], expected_type);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -87,12 +87,14 @@ pub async fn post(
 
 pub(crate) struct ForwardError {
     message: String,
-    response: axum::response::Response,
+    /// Boxed to keep `Result<_, ForwardError>` small: an `axum` `Response` alone
+    /// is 128 bytes, which trips `clippy::result_large_err` on every `forward`.
+    response: Box<axum::response::Response>,
 }
 
 impl IntoResponse for ForwardError {
     fn into_response(self) -> axum::response::Response {
-        self.response
+        *self.response
     }
 }
 

--- a/src/proxy/failover.rs
+++ b/src/proxy/failover.rs
@@ -32,7 +32,7 @@ pub(super) async fn forward(
     if crate::http_tuning::content_length_exceeds(headers, max_request_bytes) {
         return Err(ForwardError {
             message: "request body exceeds the configured limit".to_string(),
-            response: crate::http_tuning::request_too_large(false).await,
+            response: Box::new(crate::http_tuning::request_too_large(false).await),
         });
     }
     let body = crate::http_tuning::read_body(body, max_request_bytes, false)
@@ -50,14 +50,14 @@ pub(super) async fn forward(
         .map_err(routing::invalid_routing_request)
         .map_err(|error| ForwardError {
             message: "failed to route request".to_string(),
-            response: error.into_response(),
+            response: Box::new(error.into_response()),
         })?;
     normalize_request_body(&mut body);
     let (mut routes, requested_model) =
         routing::resolve_request_chain_value(&state.config, body.json()).map_err(|error| {
             ForwardError {
                 message: "failed to route request".to_string(),
-                response: error.into_response(),
+                response: Box::new(error.into_response()),
             }
         })?;
     crate::observability::record_requested_model(&requested_model);
@@ -216,10 +216,7 @@ pub(super) async fn forward(
                     }
                     _ => {
                         finish(&provider, response.status());
-                        return Err(ForwardError {
-                            message,
-                            response: *response,
-                        });
+                        return Err(ForwardError { message, response });
                     }
                 }
             }
@@ -246,10 +243,7 @@ pub(super) async fn forward(
             }
             FinalResponse::MappedError { message, response } => {
                 finish(&failure.provider, response.status());
-                Err(ForwardError {
-                    message,
-                    response: *response,
-                })
+                Err(ForwardError { message, response })
             }
         };
     }
@@ -264,7 +258,10 @@ pub(super) async fn forward(
         &last_route.upstream_model,
     );
     finish(&last_route.provider, StatusCode::BAD_GATEWAY);
-    Err(ForwardError { message, response })
+    Err(ForwardError {
+        message,
+        response: Box::new(response),
+    })
 }
 
 async fn count_tokens_response(
@@ -326,7 +323,7 @@ async fn count_tokens_response(
             Ok((status, response))
         }
         Err(error) => {
-            let mut response = *error.response;
+            let mut response = error.response;
             stamp_gateway_headers(&mut response, &provider, requested_model, &upstream_model);
             let status = response.status();
             crate::observability::record_span_outcome(&provider, status);
@@ -473,8 +470,10 @@ fn enforce_managed_model_policy(
         format!("model \"{requested_model}\" is not permitted by this gateway's managed policy");
     Err(Box::new(ForwardError {
         message: message.clone(),
-        response: ShuntError::new(StatusCode::BAD_REQUEST, "invalid_request_error", message)
-            .into_response(),
+        response: Box::new(
+            ShuntError::new(StatusCode::BAD_REQUEST, "invalid_request_error", message)
+                .into_response(),
+        ),
     }))
 }
 
@@ -559,8 +558,10 @@ pub(crate) fn check_inbound_auth(
     };
     Err(Box::new(ForwardError {
         message: "inbound authentication failed".to_string(),
-        response: ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
-            .into_response(),
+        response: Box::new(
+            ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
+                .into_response(),
+        ),
     }))
 }
 


### PR DESCRIPTION
## What

CI (`fmt · clippy · test`) is failing on **every open PR** — this is a toolchain-drift break in `main`, not a defect in any one branch.

Clippy's `stable` in CI floated from **1.94 → 1.98**, which tightened `clippy::result_large_err`. Four functions now fail `cargo clippy --all-targets --all-features -- -D warnings`:

| Site | `Err` variant | Type |
| --- | --- | --- |
| `src/codex_endpoint.rs:251` | ≥ 152 bytes | `codex_endpoint::ForwardError` |
| `src/http_tuning.rs:111` | ≥ 128 bytes | `axum::response::Response` |
| `src/proxy/failover.rs:30` | ≥ 152 bytes | `proxy::ForwardError` |
| `src/proxy/failover.rs:278` | ≥ 152 bytes | `proxy::ForwardError` |

Evidence it is repo-wide and not branch-specific:

- #415 (`fix/openrouter-strip-deferred-tools`) fails with the identical four.
- #416 (a credential-locking change touching none of those files) fails with the identical four.
- `main` last ran green on 2026-08-20 (`ecf5664`); no source change since explains it.

**Both #415 and #416 are blocked on this PR.**

## The fix

Three of the four sites share a root cause: an `axum::response::Response` stored by value inside an error type. `Response` measures **128 bytes** on its own, and each `ForwardError` adds a `String`, landing at 152.

So the payload is boxed, mirroring the idiom already in the codebase — `adapters::AdapterError` has held `pub response: Box<Response>` for some time:

- `proxy::ForwardError.response` → `Box<axum::response::Response>`
- `codex_endpoint::ForwardError.response` → `Box<axum::response::Response>`
- `http_tuning::read_body` → `Result<Bytes, Box<Response>>`

Measured with `std::mem::size_of` (temporary probe, not committed):

| Type | Before | After |
| --- | --- | --- |
| `axum::response::Response` | 128 B | 128 B (unchanged) |
| `ForwardError` | 152 B | **32 B** |
| `read_body` `Err` | 128 B | **8 B** |

No `#[allow(clippy::result_large_err)]` was needed anywhere — every site is genuinely fixed, and there is no crate-level allow.

### No public API change

Both `ForwardError` types are crate-internal (`pub(crate)` and private) with private fields; `read_body` is `pub(crate)`. The genuinely `pub` `AdapterError` is untouched. Error statuses and response bodies are byte-for-byte unchanged — the diff is mechanical `Box::new(...)` at construction and `*` at consumption.

## Verification

Because local dev machines were on 1.94 and would report **zero** errors, the failure was reproduced on 1.98 first, before any edit:

```
error: the `Err`-variant returned from this function is very large
   --> src/codex_endpoint.rs:251:6
    |
251 | ) -> Result<(StatusCode, axum::response::Response), ForwardError> {
    |      ^^^^ the `Err`-variant is at least 152 bytes
...
error: could not compile `shunt-gateway` (lib) due to 4 previous errors
```

After the fix:

| Gate | Result |
| --- | --- |
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy` on **1.98** (matches CI) | **exit 0** |
| `cargo clippy` on 1.94 (contrast) | exit 0 |
| `cargo test --all-features --workspace` | exit 0 — 1690 passed, 0 failed, 2 ignored (+ 20 further suites, all 0 failed) |

## Follow-up proposal: pin the toolchain (deliberately *not* done here)

The underlying cause is that this repo has **no `rust-toolchain` / `rust-toolchain.toml`**, so CI's `stable` floats while contributors sit on whatever they last installed. That is precisely why local gates did not predict this break — and during the work on this PR the machine-wide `stable` silently moved from 1.94.1 to 1.98.0 mid-session, which is the same failure mode in miniature.

A pin is **not** included here, because it is a repo-wide policy change binding every contributor and CI job, and that is a maintainer's call rather than something to slip into a CI fix. Stating the trade-off honestly:

- **For:** local and CI agree, so `cargo clippy` locally actually predicts the gate; no more surprise repo-wide breakage from an upstream release landing on an unrelated PR.
- **Against:** it defers new lints and genuine compiler improvements until someone bumps the pin, and that bump needs to be deliberate and scheduled or it rots — trading surprise breakage for maintenance the team must remember to do.

Happy to open that as a separate PR if maintainers want it.

## Docs

Per `AGENTS.md`, each surface was considered rather than skipped:

- **`README.md`** (+ `ko`/`ja`/`zh-CN`) — no change: no capability, setup, quickstart, or provider/model support change.
- **`docs/`** — no change: no implementation behavior deviates from any milestone/spec; error shapes and statuses are identical.
- **`site/src/content/docs/`** (+ locales) — no change: no user-facing behavior, config key, endpoint, or CLI change.
- **`wiki/`** — generated by memex; not hand-edited, and correctly excluded from this code PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boxes oversized Err variants to satisfy `clippy::result_large_err` on stable 1.98, restoring green CI. Previously `ForwardError` and `read_body` carried `axum::response::Response` by value and tripped the lint; now they use `Box<Response>` with no change to error bodies, statuses, or public API.

- `proxy::ForwardError.response` and `codex_endpoint::ForwardError.response` now hold `Box<axum::response::Response>`.
- `http_tuning::read_body` now returns `Result<Bytes, Box<Response>>`; call sites box on construction and deref on consumption.
- Scope is crate-internal and mirrors existing `AdapterError` which already stores `Box<Response>`.

<sup>Written for commit d47bd0dfb24781fc9a3b884c12cdcfa250516d1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

