### PR TITLE
fix(antigravity): reach the daily backend with the agent envelope and effort-suffixed model ids

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,7 +145,7 @@ codex-fallback = "gpt-5.6-sol"
 | `grok` | `responses` | xAI OAuth | `cli-chat-proxy.grok.com/v1` — Grok CLI プロキシ。`~/.shunt/xai-auth.json` を再利用（SuperGrok / X Premium+ サブスクリプションで `shunt login xai`） |
 | `cursor` | `cursor` | Cursor OAuth | `api2.cursor.sh` — `~/.shunt/cursor-auth.json`（`shunt login cursor`）を再利用 |
 | `gemini` | `gemini` | Google OAuth | `cloudcode-pa.googleapis.com` — Google Code Assist バックエンド、`~/.gemini/oauth_creds.json` を再利用 |
-| `antigravity` | `antigravity` | Antigravity OAuth | `cloudcode-pa.googleapis.com` — HTTP 経由の Google Antigravity バックエンド、`~/.shunt/antigravity-auth.json`（`shunt login antigravity`）を使用 |
+| `antigravity` | `antigravity` | Antigravity OAuth | `daily-cloudcode-pa.googleapis.com` — HTTP 経由の Google Antigravity バックエンド、`~/.shunt/antigravity-auth.json`（`shunt login antigravity`）を使用 |
 | `antigravity-cli` | `antigravity_cli` | なし（ローカル CLI） | **非推奨。** ローカルの `agy` バイナリ — サブプロセス経由で同じバックエンドを利用。上記の `antigravity` に置き換えられました |
 
 xAI はサブスクリプションのティアによって OAuth アクセスを制限する場合があります。`grok` が 403 を返す場合は、代わりに `xai` API キープロバイダーを使用してください。詳細は [`docs/m6-xai-provider.md`](docs/m6-xai-provider.md) を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -142,7 +142,7 @@ codex-fallback = "gpt-5.6-sol"
 | `grok` | `responses` | xAI OAuth | `cli-chat-proxy.grok.com/v1` — Grok CLI 프록시, `~/.shunt/xai-auth.json`을 재사용(SuperGrok / X Premium+ 구독으로 `shunt login xai`) |
 | `cursor` | `cursor` | Cursor OAuth | `api2.cursor.sh` — `~/.shunt/cursor-auth.json`(`shunt login cursor`)을 재사용 |
 | `gemini` | `gemini` | Google OAuth | `cloudcode-pa.googleapis.com` — Google Code Assist 백엔드, `~/.gemini/oauth_creds.json`을 재사용 |
-| `antigravity` | `antigravity` | Antigravity OAuth | `cloudcode-pa.googleapis.com` — HTTP로 통신하는 Google Antigravity 백엔드, `~/.shunt/antigravity-auth.json`(`shunt login antigravity`)을 사용 |
+| `antigravity` | `antigravity` | Antigravity OAuth | `daily-cloudcode-pa.googleapis.com` — HTTP로 통신하는 Google Antigravity 백엔드, `~/.shunt/antigravity-auth.json`(`shunt login antigravity`)을 사용 |
 | `antigravity-cli` | `antigravity_cli` | 없음(로컬 CLI) | **Deprecated.** 로컬 `agy` 바이너리 — 서브프로세스로 동일한 백엔드를 사용하며, 위의 `antigravity`로 대체되었습니다 |
 
 xAI는 구독 등급에 따라 OAuth 접근을 제한할 수 있습니다. `grok`이 403을 반환하면 `xai` API 키 프로바이더를 대신 사용하세요. 자세한 내용은 [`docs/m6-xai-provider.md`](docs/m6-xai-provider.md)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This chain tries `anthropic-primary` and then `codex-fallback`. `auth` accepts e
 | `grok` | `responses` | xAI OAuth | `cli-chat-proxy.grok.com/v1` — the Grok CLI proxy; reuses `~/.shunt/xai-auth.json` (`shunt login xai` with a SuperGrok / X Premium+ subscription) |
 | `cursor` | `cursor` | Cursor OAuth | `api2.cursor.sh` — reuses `~/.shunt/cursor-auth.json` (`shunt login cursor`) |
 | `gemini` | `gemini` | Google OAuth | `cloudcode-pa.googleapis.com` — Google Code Assist backend; reuses `~/.gemini/oauth_creds.json` |
-| `antigravity` | `antigravity` | Antigravity OAuth | `cloudcode-pa.googleapis.com` — Google Antigravity backend over HTTP; uses `~/.shunt/antigravity-auth.json` (`shunt login antigravity`) |
+| `antigravity` | `antigravity` | Antigravity OAuth | `daily-cloudcode-pa.googleapis.com` — Google Antigravity backend over HTTP; uses `~/.shunt/antigravity-auth.json` (`shunt login antigravity`) |
 | `antigravity-cli` | `antigravity_cli` | None (local CLI) | **Deprecated.** Local `agy` binary — same backend via subprocess; superseded by `antigravity` above |
 
 xAI may gate OAuth access by subscription tier — if `grok` returns 403, use the `xai` API-key provider instead. Details in [`docs/m6-xai-provider.md`](docs/m6-xai-provider.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,7 +140,7 @@ codex-fallback = "gpt-5.6-sol"
 | `grok` | `responses` | xAI OAuth | `cli-chat-proxy.grok.com/v1` —— Grok CLI 代理;复用 `~/.shunt/xai-auth.json`(使用 SuperGrok / X Premium+ 订阅执行 `shunt login xai`) |
 | `cursor` | `cursor` | Cursor OAuth | `api2.cursor.sh` —— 复用 `~/.shunt/cursor-auth.json`(`shunt login cursor`) |
 | `gemini` | `gemini` | Google OAuth | `cloudcode-pa.googleapis.com` —— Google Code Assist 后端,复用 `~/.gemini/oauth_creds.json` |
-| `antigravity` | `antigravity` | Antigravity OAuth | `cloudcode-pa.googleapis.com` —— 通过 HTTP 访问的 Google Antigravity 后端,使用 `~/.shunt/antigravity-auth.json`(`shunt login antigravity`) |
+| `antigravity` | `antigravity` | Antigravity OAuth | `daily-cloudcode-pa.googleapis.com` —— 通过 HTTP 访问的 Google Antigravity 后端,使用 `~/.shunt/antigravity-auth.json`(`shunt login antigravity`) |
 | `antigravity-cli` | `antigravity_cli` | 无(本地 CLI) | **已弃用。** 本地 `agy` 二进制 —— 通过子进程访问同一后端,已被上面的 `antigravity` 取代 |
 
 xAI 可能按订阅层级限制 OAuth 访问 —— 如果 `grok` 返回 403,请改用 `xai` API 密钥提供方。详见 [`docs/m6-xai-provider.md`](docs/m6-xai-provider.md)。

--- a/blueprints/upstream/antigravity.md
+++ b/blueprints/upstream/antigravity.md
@@ -20,7 +20,7 @@ There is **no `antigravity` preset**, so an ordered upstream must set `kind`, `b
 [[upstreams]]
 name = "antigravity"
 kind = "antigravity"
-base_url = "https://cloudcode-pa.googleapis.com"
+base_url = "https://daily-cloudcode-pa.googleapis.com"
 auth = "antigravity_oauth"
 ```
 
@@ -32,7 +32,7 @@ name = "anthropic"
 provider = "anthropic"
 ```
 
-Do not mix `[[upstreams]]` with the legacy `[providers.*]` table form in one file. `base_url` must stay HTTPS on `cloudcode-pa.googleapis.com` itself — no other `googleapis.com` host passes validation (a loopback host is allowed for a local proxy). Anything else is refused at validation rather than sending the subscription token off-origin.
+Do not mix `[[upstreams]]` with the legacy `[providers.*]` table form in one file. `base_url` must stay HTTPS on `daily-cloudcode-pa.googleapis.com` (the default, and the `daily-` control plane the Antigravity client itself addresses for both discovery and inference) or on `cloudcode-pa.googleapis.com` — no other `googleapis.com` host passes validation, `daily-cloudcode-pa.sandbox.googleapis.com` included (a loopback host is allowed for a local proxy). Anything else is refused at validation rather than sending the subscription token off-origin.
 
 ## Credentials
 
@@ -46,7 +46,7 @@ This writes `~/.shunt/antigravity-auth.json` (override the path with `SHUNT_ANTI
 
 ## Optional model routing
 
-shunt keeps no model allowlist for this provider: the resolved `upstream_model` reaches the backend as written. Antigravity serves the Gemini-family slugs, including `gemini-3.5-flash` and `gemini-3.6-flash` — slugs the Code Assist `gemini` provider does not accept.
+shunt keeps no model allowlist for this provider: the resolved `upstream_model` reaches the backend as written. Antigravity serves Gemini-family slugs the Code Assist `gemini` provider does not accept, and publishes them with the effort tier in the id — `-low`, `-medium`, or `-high` (`gemini-3.1-pro` has only `-low` and `-high`). Run `agy models` for the current catalog. A bare slug is not served: the daily host answers it with a `404`. Against the production host, shunt's earlier request — a bare id and the plain Code Assist envelope together — returned a misleading `429 RESOURCE_EXHAUSTED`, and the probes do not establish which of the two inputs caused it. shunt fills the suffix in for a bare `gemini-*` id — from `effort` on the route or provider, else the request's `output_config.effort`, else an enabled `thinking` budget, else `medium` — so either spelling works. `xhigh` and `max` fold onto `high` from either source.
 
 Expose one through a Claude-named discovery alias:
 
@@ -56,10 +56,10 @@ id = "claude-gemini-3.6-flash-via-antigravity"
 display_name = "[AGY ] Gemini-3.6-Flash"
 
 [models.upstream_model]
-antigravity = "gemini-3.6-flash"
+antigravity = "gemini-3.6-flash-medium"
 ```
 
-The map key is the upstream name. A legacy exact `[[routes]]` entry may instead use `provider = "antigravity"` and `upstream_model = "gemini-3.6-flash"`; do not define both forms for one id.
+The map key is the upstream name. A legacy exact `[[routes]]` entry may instead use `provider = "antigravity"` and `upstream_model = "gemini-3.6-flash-medium"`; do not define both forms for one id.
 
 Antigravity also offers Claude models, but shunt does not yet implement the request rewrites they need. Nothing rejects such a slug locally — it reaches the backend as written — so route only Gemini-family slugs.
 
@@ -94,6 +94,6 @@ Confirm a successful response and that the selected upstream is `antigravity`.
 
 - Never print, log, or commit OAuth tokens or credential files.
 - Keep credentials outside config.
-- Never point `base_url` at any host other than `cloudcode-pa.googleapis.com` (or a loopback proxy) to "test" the upstream; validation refuses it because it would ship a subscription token off-origin.
+- Never point `base_url` at any host other than `daily-cloudcode-pa.googleapis.com`, `cloudcode-pa.googleapis.com`, or a loopback proxy to "test" the upstream; validation refuses it because it would ship a subscription token off-origin.
 - Preserve all unrelated config entries and security controls.
 - Make the smallest reversible edit, validate it, and report exactly what changed.

--- a/docs/notes/antigravity-daily-host.md
+++ b/docs/notes/antigravity-daily-host.md
@@ -1,0 +1,135 @@
+# Antigravity: the daily backend host and effort-suffixed model ids
+
+## Overview
+
+Every request the built-in `antigravity` provider sent to
+`cloudcode-pa.googleapis.com` failed with:
+
+```json
+{
+  "error": {
+    "code": 429,
+    "message": "Resource has been exhausted (e.g. check quota).",
+    "status": "RESOURCE_EXHAUSTED"
+  }
+}
+```
+
+The message reads as a rate limit. It is not one. Two separate defects
+produced it, and both were reproduced against a live Antigravity token.
+
+## Probe matrix
+
+| host | model | envelope | result |
+| --- | --- | --- | --- |
+| `cloudcode-pa.googleapis.com` (old default) | `gemini-3.8-flash` | shunt's `{model, project, request}` | 429 "check quota" |
+| `cloudcode-pa.googleapis.com` | `gemini-3.8-flash-medium` | shunt's | 503 |
+| `daily-cloudcode-pa.googleapis.com` | `gemini-3.8-flash-medium` | plus `userAgent`, `requestType`, `requestId`, `request.sessionId` | **200** |
+| `daily-cloudcode-pa.googleapis.com` | `gemini-3.8-flash` | full envelope | 404 `NOT_FOUND` |
+
+Read together: on the daily host a **bare model slug does not exist** —
+that row varied only the id, so the `404` is attributable to it. The
+production `429` is *not*: that request differed from the working one in
+both the model id (bare) and the envelope (plain Code Assist), so the
+probes do not establish which input produced it. What the matrix does
+establish is the working combination — suffixed id plus the full envelope
+on the daily host — not a cause for each individual failure.
+
+## The catalog
+
+The Antigravity client is served effort-suffixed Gemini ids:
+
+- `gemini-3.8-flash-{high,medium,low}`
+- `gemini-3.7-flash-{high,medium,low}`
+- `gemini-3.6-flash-{high,medium,low}`
+- `gemini-3.1-pro-{high,low}` — Pro has **no** `-medium`
+- `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, `gpt-oss-120b-medium`
+  (not Gemini, no suffix synthesis)
+
+`agy models` lists the catalog as it currently stands. Note that other
+proxy implementations query `fetchAvailableModels` on more than one host,
+so "only the daily host serves this catalog" is *not* established here —
+what is established is that the `agy` client addresses the daily host for
+both discovery and inference.
+
+## Reference implementation
+
+router-for-me/CLIProxyAPI,
+`internal/runtime/executor/antigravity_executor_request.go`:
+
+- `resolveAntigravityRequestBaseURL` sends inference to the `daily-` host.
+- `geminiToAntigravity` adds `userAgent: "antigravity"`,
+  `requestType: "agent"`, `requestId: "agent-<uuid v4>"`, and
+  `request.sessionId: "-<up to 19 decimal digits>"`.
+- `generateStableSessionID` derives the session id from the conversation
+  rather than drawing it at random, so follow-up turns stay in one
+  session.
+
+The `agy` CLI itself also calls `loadCodeAssist` and
+`fetchAvailableModels` on the daily host, so the daily host is the right
+target for discovery as well as inference.
+
+## Resulting shunt behaviour
+
+**Host.** The built-in `antigravity` provider is seeded at
+`https://daily-cloudcode-pa.googleapis.com`, and
+`shunt login antigravity` falls back to the same host when no config
+loads, so login provisions its project against the backend inference
+uses. The `gemini` (Code Assist) provider stays on
+`cloudcode-pa.googleapis.com`.
+
+The `antigravity_oauth` config guard accepts exactly two non-loopback
+hosts — the daily host and production — through its own predicate rather
+than borrowing Code Assist's. No other `googleapis.com` host qualifies,
+`daily-cloudcode-pa.sandbox.googleapis.com` included, and the
+`google_oauth` guard is unchanged. Onboarding still redirects to the
+daily control plane for a production-pinned `base_url`, and travels with
+the configured host for a loopback proxy.
+
+**Envelope.** `AuthMode::AntigravityOauth` requests use
+`wrap_antigravity_envelope` instead of `wrap_code_assist_envelope`,
+mirroring the identity the Antigravity client sends:
+
+```json
+{
+  "model": "gemini-3.6-flash-medium",
+  "project": "<project id>",
+  "userAgent": "antigravity",
+  "requestType": "agent",
+  "requestId": "agent-<uuid v4>",
+  "request": { "...": "...", "sessionId": "-<digits>" }
+}
+```
+
+The session id is FNV-1a over the first user turn's first text part in
+the *translated* request, rendered as at most 19 decimal digits behind a
+leading `-`, bounded by the reference client's `Int63n` modulus
+(9e18) so every id fits in a signed 64-bit integer; a request with no
+user text falls back to a random value in the same range so such
+requests do not all collide on one session. The Code Assist path
+sends none of these four fields.
+
+**Model id.** `antigravity_upstream_model` resolves the tier for a bare
+`gemini-*` id, taking the first signal that applies:
+
+1. `effort` on the route or provider — an explicit pin.
+2. The request's `output_config.effort`.
+3. `thinking.type == "enabled"` — `budget_tokens` ≤ 2048 is `low`,
+   ≤ 8192 is `medium`, above that is `high`. An enabled block naming no
+   budget uses the same `1024` default `translate_thinking_config`
+   sends in `thinkingConfig.thinkingBudget`, so it lands in `low` — the
+   tier and the budget describe one request rather than two.
+4. Otherwise `medium`.
+
+The two effort sources are normalized the same way: Claude Code sends
+`low|medium|high|xhigh|max`, and `xhigh` and `max` fold onto `high`
+because the catalog stops there. They differ only in what happens to a
+level outside that vocabulary — a configured one passes through unchanged
+(the catalog, not shunt, decides which tiers exist, so an operator can
+name a future one), while an unrecognised request value falls back to
+`medium` rather than being pasted into the upstream model id.
+
+The result is clamped to the tiers the family publishes, so `medium` on
+a `-pro` id becomes `high`. Ids that already end in a tier, and ids that
+are not `gemini-*`, are sent exactly as written. The resolved id and the
+signal that decided it are logged at debug level.

--- a/docs/notes/antigravity-daily-host.md
+++ b/docs/notes/antigravity-daily-host.md
@@ -101,8 +101,9 @@ mirroring the identity the Antigravity client sends:
 }
 ```
 
-The session id is FNV-1a over the first user turn's first text part in
-the *translated* request, rendered as at most 19 decimal digits behind a
+The session id is FNV-1a over the earliest non-empty user text part in
+the *translated* request — every user turn is scanned, so an image-only
+opening turn does not force a random id — rendered as at most 19 decimal digits behind a
 leading `-`, bounded by the reference client's `Int63n` modulus
 (9e18) so every id fits in a signed 64-bit integer; a request with no
 user text falls back to a random value in the same range so such
@@ -123,13 +124,18 @@ sends none of these four fields.
 
 The two effort sources are normalized the same way: Claude Code sends
 `low|medium|high|xhigh|max`, and `xhigh` and `max` fold onto `high`
-because the catalog stops there. They differ only in what happens to a
-level outside that vocabulary — a configured one passes through unchanged
-(the catalog, not shunt, decides which tiers exist, so an operator can
-name a future one), while an unrecognised request value falls back to
-`medium` rather than being pasted into the upstream model id.
+because the catalog stops there. Matching ignores case and surrounding
+whitespace, so `High` names the published tier. The sources differ only
+in what happens to a level outside that vocabulary. A configured one
+passes through trimmed and lower-cased: the catalog, not shunt, decides
+which tiers exist, so an operator can name a future one. An unrecognised
+request value falls back to `medium` rather than being pasted into the
+upstream model id.
 
-The result is clamped to the tiers the family publishes, so `medium` on
-a `-pro` id becomes `high`. Ids that already end in a tier, and ids that
-are not `gemini-*`, are sent exactly as written. The resolved id and the
-signal that decided it are logged at debug level.
+A recognised tier is clamped to the tiers the family publishes, so
+`medium` on a `-pro` id becomes `high`. An unrecognised configured level
+is appended as written and never clamped. The family is read from the
+id's `-`-separated segments: `gemini-3-pro-preview` is Pro, and an id
+that merely contains the letters is not. Ids that already end in a tier,
+and ids that are not `gemini-*`, are sent exactly as written. The
+resolved id and the signal that decided it are logged at debug level.

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -23,7 +23,7 @@ Providers are a **name → config map**. Anthropic-compatible and Responses-comp
 | [`grok`](/guides/xai/) | `responses` | `xai_oauth` | `cli-chat-proxy.grok.com/v1` — the Grok CLI proxy; reuses `~/.shunt/xai-auth.json` |
 | [`cursor`](/providers/cursor/) | `cursor` | `cursor_oauth` | `api2.cursor.sh` — reuses `~/.shunt/cursor-auth.json` (`shunt login cursor`) |
 | `gemini` | `gemini` | `google_oauth` | `cloudcode-pa.googleapis.com` — reuses `~/.gemini/oauth_creds.json` |
-| [`antigravity`](/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `cloudcode-pa.googleapis.com` — reuses `~/.shunt/antigravity-auth.json` (`shunt login antigravity`) |
+| [`antigravity`](/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `daily-cloudcode-pa.googleapis.com` — reuses `~/.shunt/antigravity-auth.json` (`shunt login antigravity`) |
 | `antigravity-cli` | `antigravity_cli` | `none` | **Deprecated.** Local `agy` CLI — same backend via subprocess |
 
 Each linked name opens its dedicated setup page. `shunt add upstream <name>` prints a step-by-step blueprint for built-in providers; see the [CLI reference](/reference/cli/#shunt-add).
@@ -43,7 +43,7 @@ provider = "gemini"
 upstream_model = "gemini-2.5-flash"
 ```
 
-Code Assist also recognizes preview slugs such as `gemini-3.1-pro-preview` and `gemini-3-flash-preview`, subject to account entitlement and provider capacity. It does not accept the Antigravity-only `gemini-3.5-flash` and `gemini-3.6-flash` slugs.
+Code Assist also recognizes preview slugs such as `gemini-3.1-pro-preview` and `gemini-3-flash-preview`, subject to account entitlement and provider capacity. It does not accept the Antigravity-only slugs such as `gemini-3.6-flash-medium`.
 
 The separate `antigravity` provider reaches the same backend over HTTP. Authenticate it with `shunt login antigravity`: a Google
 authorization-code flow using Antigravity's own OAuth client, which asks for two scopes (`cclog`, `experimentsandconfigs`) a Gemini CLI
@@ -60,8 +60,12 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+Antigravity publishes its Gemini models with the effort tier in the id (`-low`, `-medium`, `-high`;
+Pro has only `-low` and `-high`) and does not serve a bare slug. A bare `gemini-*` id is resolved to a tier
+for you — from `effort`, the request, or `medium` — so both spellings work.
 
 For the full setup — login and scopes, project discovery, model slugs, thinking, and what the
 adapter carries — see the dedicated [Antigravity provider page](/providers/antigravity/).

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -23,7 +23,7 @@ description: 組み込みプロバイダーと、TOML テーブルで任意の A
 | [`grok`](/ja/guides/xai/) | `responses` | `xai_oauth` | `cli-chat-proxy.grok.com/v1` — `shunt login xai` 経由の SuperGrok / X Premium+ サブスクリプション |
 | [`cursor`](/ja/providers/cursor/) | `cursor` | `cursor_oauth` | `api2.cursor.sh` — `~/.shunt/cursor-auth.json`（`shunt login cursor`）を再利用 |
 | `gemini` | `gemini` | `google_oauth` | `cloudcode-pa.googleapis.com` — `~/.gemini/oauth_creds.json` を再利用 |
-| [`antigravity`](/ja/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `cloudcode-pa.googleapis.com` — `~/.shunt/antigravity-auth.json`（`shunt login antigravity`）を再利用 |
+| [`antigravity`](/ja/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `daily-cloudcode-pa.googleapis.com` — `~/.shunt/antigravity-auth.json`（`shunt login antigravity`）を再利用 |
 | `antigravity-cli` | `antigravity_cli` | `none` | **非推奨。** ローカルの `agy` CLI — サブプロセス経由で同じバックエンド |
 
 各名前から、そのプロバイダーの完全なセットアップを説明する専用ページへ移動できます。`shunt add upstream <name>` は、任意の組み込みプロバイダーについて手順を追ったブループリントを出力します。コーディングエージェントへパイプすれば（`shunt add upstream codex --print | claude`）、エージェントに設定を組み込ませることができます。[CLI リファレンス](/ja/reference/cli/#shunt-add)も参照してください。
@@ -46,8 +46,13 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+Antigravity は Gemini モデルを effort ティア付きの id（`-low`、`-medium`、`-high`。Pro は `-low` と
+`-high` のみ）で公開しており、サフィックスのないスラッグは提供しません。サフィックスのない `gemini-*` の
+id は、`effort` かリクエストから、いずれもなければ `medium` として shunt がティアを解決するため、
+どちらの書き方でも動きます。
 
 ログインとスコープ、プロジェクトディスカバリー、モデルスラッグ、thinking、アダプターが伝えるものを含む完全なセットアップに
 ついては、専用の [Antigravity プロバイダーページ](/ja/providers/antigravity/)を参照してください。

--- a/site/src/content/docs/ja/providers/antigravity.mdx
+++ b/site/src/content/docs/ja/providers/antigravity.mdx
@@ -111,8 +111,8 @@ upstream_model = "gemini-3.6-flash-medium"
 ティアを解決して付与します。最初に当てはまったシグナルが使われます:
 
 1. `[[routes]]` エントリまたはプロバイダーの `effort` — 明示的な指定です。ここでも `xhigh` と `max`
-   は `high` に畳まれ、shunt が知らないティアはそのまま通るので、カタログに後から追加されるティアを
-   先に指定できます。
+   は `high` に畳まれ、大文字小文字と前後の空白は無視されます。shunt が知らないティアは書かれたまま
+   （空白を取り除き小文字にして）通るので、カタログに後から追加されるティアを先に指定できます。
 2. リクエストの `output_config.effort`（Claude Code は `low`/`medium`/`high`/`xhigh`/`max` を送り、
    `xhigh` と `max` は `high` に畳まれます）。
 3. `thinking.type = "enabled"` — `budget_tokens` が 2048 以下なら `low`、8192 以下なら `medium`、
@@ -120,9 +120,10 @@ upstream_model = "gemini-3.6-flash-medium"
    のと同じデフォルトの `1024` を使うため、`low` になります。
 4. それ以外は `medium` です。
 
-結果はそのファミリーが実際に公開しているティアに丸められるため、`-pro` の id での `medium` は `-high` に
-なります。すでにティアで終わる id と、Gemini 以外の id（`claude-sonnet-4-6`、`gpt-oss-120b-medium`）は
-書かれたまま送られます。認識できない `output_config.effort` は、モデル id に反映されずに `medium` へ
+認識されたティアはそのファミリーが実際に公開しているティアに丸められるため、`-pro` の id での `medium`
+は `-high` になります。設定に書かれた認識できない `effort` はルール 1 のとおり書かれたまま付与され、
+丸められません。すでにティアで終わる id と、Gemini 以外の id（`claude-sonnet-4-6`、`gpt-oss-120b-medium`）
+は書かれたまま送られます。認識できない `output_config.effort` は、モデル id に反映されずに `medium` へ
 フォールバックします。
 
 Antigravity は Claude モデルも提供していますが、shunt はそれらが必要とするリクエストの書き換えをまだ実装して
@@ -144,7 +145,7 @@ Antigravity は Claude モデルも提供していますが、shunt はそれら
 
 さらにすべてのリクエストは、Antigravity クライアントが送る**エージェント識別情報**を伴います:
 `userAgent: "antigravity"`、`requestType: "agent"`、リクエストごとの `requestId`、そして続きのターンが
-同じセッションに届くよう最初のユーザーターンから導出した `sessionId` です。`gemini` プロバイダーの
+同じセッションに届くよう会話中で最初に現れるユーザーテキストから導出した `sessionId` です。`gemini` プロバイダーの
 Code Assist リクエストは、これらをいずれも送りません。
 
 本番トラフィックをルーティングする前に知っておく価値のある制限が 2 つあります。

--- a/site/src/content/docs/ja/providers/antigravity.mdx
+++ b/site/src/content/docs/ja/providers/antigravity.mdx
@@ -3,8 +3,9 @@ title: Antigravity
 description: HTTP 経由で Google Antigravity バックエンドに接続する — ログイン、プロジェクトディスカバリー、モデルスラッグ、thinking、そしてアダプターが伝えるもの。
 ---
 
-組み込みの **`antigravity`** プロバイダーは、`cloudcode-pa.googleapis.com` において HTTP 経由で Google の
-**Antigravity** バックエンドに到達します。`gemini` プロバイダーと同じ Code Assist プロトコルを話し —
+組み込みの **`antigravity`** プロバイダーは、`daily-cloudcode-pa.googleapis.com` において HTTP 経由で
+Google の **Antigravity** バックエンドに到達します。このホストは Antigravity クライアント自身が
+ディスカバリーと推論の両方に使う `daily-` コントロールプレーンです。`gemini` プロバイダーと同じ Code Assist プロトコルを話し —
 shunt は Anthropic Messages を `generateContent` / `streamGenerateContent` へ変換します — ただし
 Antigravity のサブスクリプショントークンで認証し、プロジェクトディスカバリーの際に自身を
 `ideType: ANTIGRAVITY` として名乗ります。
@@ -68,7 +69,7 @@ provider = "anthropic"   # ルーティングされないモデル（例 claude-
 [[upstreams]]
 name = "antigravity"
 kind = "antigravity"
-base_url = "https://cloudcode-pa.googleapis.com"
+base_url = "https://daily-cloudcode-pa.googleapis.com"
 auth = "antigravity_oauth"
 ```
 
@@ -81,9 +82,17 @@ auth = "antigravity_oauth"
 ## 3. モデルをルーティングする
 
 shunt はこのプロバイダーについてモデルの許可リストを持ちません。解決された `upstream_model` はそのまま
-バックエンドへ送られ、判断はバックエンドが行います。Antigravity は Gemini ファミリーのスラッグを提供して
-おり、`gemini-3.5-flash` と `gemini-3.6-flash` を含みます — Code Assist の `gemini` プロバイダーが**受け付け
-ない**スラッグです。
+バックエンドへ送られ、判断はバックエンドが行います。Antigravity は Code Assist の `gemini` プロバイダーが
+**受け付けない** Gemini ファミリーのスラッグを提供します — ただし **effort のティアを id に** `-low`、
+`-medium`、`-high` というサフィックスとして付けて公開します（Pro には `-low` と `-high` しかありません）。
+現在のカタログは `agy models` で一覧できます。本稿の執筆時点では `gemini-3.8-flash-*`、
+`gemini-3.7-flash-*`、`gemini-3.6-flash-*`、`gemini-3.1-pro-low` / `-high`、`claude-sonnet-4-6`、
+`claude-opus-4-6-thinking`、`gpt-oss-120b-medium` が含まれます。
+
+サフィックスのないスラッグは**提供されません**。`daily-cloudcode-pa.googleapis.com` は `404` を返します。
+本番ホストでは、以前の shunt のリクエスト — サフィックスのない id と素の Code Assist エンベロープ — が
+レート制限のように見える `429 RESOURCE_EXHAUSTED`（"check quota"）で返ってきました。ただしプローブは
+両方の入力を同時に変えているため、そのどちらが 429 を生んだのかは確認できていません。
 
 ローカルのエイリアスを、正確な Antigravity のモデルスラッグへマッピングします:
 
@@ -95,8 +104,26 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+サフィックスを自分で書く必要はありません。サフィックスのない `gemini-*` の id については、shunt が
+ティアを解決して付与します。最初に当てはまったシグナルが使われます:
+
+1. `[[routes]]` エントリまたはプロバイダーの `effort` — 明示的な指定です。ここでも `xhigh` と `max`
+   は `high` に畳まれ、shunt が知らないティアはそのまま通るので、カタログに後から追加されるティアを
+   先に指定できます。
+2. リクエストの `output_config.effort`（Claude Code は `low`/`medium`/`high`/`xhigh`/`max` を送り、
+   `xhigh` と `max` は `high` に畳まれます）。
+3. `thinking.type = "enabled"` — `budget_tokens` が 2048 以下なら `low`、8192 以下なら `medium`、
+   それより大きい場合は `high` です。budget を指定しない有効なブロックは、変換後のリクエストが載せる
+   のと同じデフォルトの `1024` を使うため、`low` になります。
+4. それ以外は `medium` です。
+
+結果はそのファミリーが実際に公開しているティアに丸められるため、`-pro` の id での `medium` は `-high` に
+なります。すでにティアで終わる id と、Gemini 以外の id（`claude-sonnet-4-6`、`gpt-oss-120b-medium`）は
+書かれたまま送られます。認識できない `output_config.effort` は、モデル id に反映されずに `medium` へ
+フォールバックします。
 
 Antigravity は Claude モデルも提供していますが、shunt はそれらが必要とするリクエストの書き換えをまだ実装して
 いません（[#368](https://github.com/pleaseai/shunt/issues/368)）。そうしたスラッグをローカルで拒否するものは
@@ -112,9 +139,13 @@ Antigravity は Claude モデルも提供していますが、shunt はそれら
 `candidatesTokenCount` が `input_tokens` と `output_tokens` に対応します。
 
 **Thinking** はリクエストに従います: `thinking.type = "enabled"` は `budget_tokens`（デフォルト `1024`）から
-`thinkingConfig.thinkingBudget` を設定し、`"disabled"` はそれを `0` にします。この転送に **`effort` 設定は
-ありません** — `effort` は非推奨の CLI プロバイダーのものであり、そちらは有効なモデル / effort の組み合わせを
-`agy models` から取得します。
+`thinkingConfig.thinkingBudget` を設定し、`"disabled"` はそれを `0` にします。有効な `thinking` ブロックは、
+上の**モデルをルーティングする**で説明したとおり、モデルの effort ティアを決めるシグナルの 1 つでもあります。
+
+さらにすべてのリクエストは、Antigravity クライアントが送る**エージェント識別情報**を伴います:
+`userAgent: "antigravity"`、`requestType: "agent"`、リクエストごとの `requestId`、そして続きのターンが
+同じセッションに届くよう最初のユーザーターンから導出した `sessionId` です。`gemini` プロバイダーの
+Code Assist リクエストは、これらをいずれも送りません。
 
 本番トラフィックをルーティングする前に知っておく価値のある制限が 2 つあります。
 
@@ -140,25 +171,27 @@ curl -sS http://127.0.0.1:3001/v1/messages \
 <Aside type="note" title="オーバーライド">
 
 `SHUNT_ANTIGRAVITY_AUTH_FILE` は認証情報のパスを上書きします（空の値はデフォルトへフォールバックします）。
-`antigravity_oauth` の upstream は 1 つのホストに固定されます。受け入れられるループバック以外の `base_url` は
-`cloudcode-pa.googleapis.com` そのものへの HTTPS だけで — **ほかの `googleapis.com` ホストは該当しません**。
-ローカルプロキシのためにループバックホストは許可されます。それ以外は、サブスクリプショントークンを黙って
-オリジン外へ送るのではなく、設定検証の段階で拒否されます —
+`antigravity_oauth` の upstream は 2 つのホストに固定されます。受け入れられるループバック以外の `base_url`
+は `daily-cloudcode-pa.googleapis.com`（デフォルト）か、必要な運用者のために引き続き有効な
+`cloudcode-pa.googleapis.com` への HTTPS だけです — `daily-cloudcode-pa.sandbox.googleapis.com` を含め、
+**ほかの `googleapis.com` ホストは該当しません**。ローカルプロキシのためにループバックホストは許可されます。
+それ以外は、サブスクリプショントークンを黙ってオリジン外へ送るのではなく、設定検証の段階で拒否されます —
 `providers.<name> uses auth = "antigravity_oauth" but base_url is not https; refusing to send a
-subscription token over plaintext`、または対応する `... host <host> is not a googleapis.com host;
-refusing to send a subscription token off-origin` です（このメッセージは "googleapis.com host" と言いますが、
-その背後のチェックは正確な Code Assist ホストです）。
+subscription token over plaintext`、または対応する `... host <host> is neither
+daily-cloudcode-pa.googleapis.com nor cloudcode-pa.googleapis.com; refusing to send a subscription
+token off-origin` です。
 
-`onboardUser` は別のコントロールプレーンにあります。素の本番を指す `base_url` — `cloudcode-pa.googleapis.com`
-への HTTPS で、ポートもパスプレフィックスもないもの — は `daily-cloudcode-pa.googleapis.com` に対して
-onboard します。バックエンドの手前に何かが挟まっている場合（ループバックプロキシ、あるいは明示的なポートや
-パスプレフィックスを伴う同じホスト）は、それ自身を通して onboard します。
+`onboardUser` は `daily-` コントロールプレーンにあり、デフォルトの `base_url` はすでにそこを指しています。
+素の本番に固定した `base_url` — `cloudcode-pa.googleapis.com` への HTTPS で、ポートもパスプレフィックスも
+ないもの — は推論こそそのままそこで行いますが、onboard は `daily-cloudcode-pa.googleapis.com` に対して
+行います。バックエンドの手前に何かが挟まっている場合（ループバックプロキシ、あるいはどちらかのホストに
+明示的なポートやパスプレフィックスを伴うもの）は、それ自身を通して onboard します。
 
 [`shunt login antigravity`](/reference/cli/#shunt-login-antigravity) は、あなたの**ルーティングされた**
 Antigravity upstream に対してディスカバリーを行います — あるいは、まだルートを組んでいなければ、宣言した
 Antigravity upstream に対して行います。候補が 1 つならそれが無条件に選ばれ、複数が該当する場合は
 **`antigravity` という名前の**ものが選ばれます。複数が該当し、どれもその名前を持たない場合、ログインは推測を
-拒否します — 警告をログに出して本番エンドポイントへフォールバックするため、プロビジョニングされる
+拒否します — 警告をログに出してデフォルトのエンドポイントへフォールバックするため、プロビジョニングされる
 プロジェクトがあなたのルートの使うバックエンドと一致しない可能性があります。ディスカバリーさせたい upstream に
 `antigravity` という名前を付けてください。
 

--- a/site/src/content/docs/ja/reference/configuration.md
+++ b/site/src/content/docs/ja/reference/configuration.md
@@ -310,7 +310,7 @@ origin に関係なく、保持された各スロットはそのスロットが�
 | `auth` | `passthrough` \| `api_key` \| `chatgpt_oauth` \| `claude_oauth` \| `xai_oauth` \| `cursor_oauth` \| `google_oauth` \| `antigravity_oauth` \| `none` | `passthrough` はクライアント自身の credential を転送。`api_key` は `api_key_env` からキーを注入。`chatgpt_oauth` は `~/.codex/auth.json` を再利用。`claude_oauth` は明示的な Anthropic アカウントから選択。`xai_oauth` は `shunt login xai` からの `~/.shunt/xai-auth.json` を再利用（HTTPS 上の x.ai/grok.com ホストへのみ送信）。`cursor_oauth` は `~/.shunt/cursor-auth.json`（`shunt login cursor`）を再利用。`google_oauth` は gemini CLI ログインの `~/.gemini/oauth_creds.json` を再利用し、`kind = "gemini"` でのみ有効。`antigravity_oauth` は `shunt login antigravity` からの `~/.shunt/antigravity-auth.json` を再利用し、`kind = "antigravity"` でのみ有効で、`google_oauth` とは**互換性がありません** — Antigravity は Gemini CLI のトークンには含まれない 2 つのスコープ（`cclog`、`experimentsandconfigs`）を要求します。`none` は認証すべき上流を持たないアダプター（`kind = "antigravity_cli"`）向けに、credential を一切送信しません。 |
 | `api_key_env` | 環境変数名 | `auth = "api_key"` のとき、キーを読み取る場所。この値自体も `${VAR}` / `${file:...}` で書けます([Secret 参照](#secret-参照)を参照)。 |
 | `api_key_header` | `bearer`（デフォルト） \| `x_api_key` | 注入されたキーを送るヘッダー。 |
-| `effort` | `low` … `max` | オプションのデフォルト reasoning エフォート（`responses` プロバイダー）。 |
+| `effort` | `low` … `max` | オプションのデフォルト reasoning エフォート（`responses` プロバイダー）。`kind = "antigravity"` にも適用され、サフィックスのない `gemini-*` の `upstream_model` にカタログの effort サフィックスとして付与されます。 |
 | `count_tokens` | `tiktoken`（デフォルト） \| `estimate` | `responses` および `cursor` provider: ローカルの tiktoken カウント vs. `501 not_supported` フォールバック（[詳細](/ja/guides/effort-and-context/#token-counting-count_tokens)）。 |
 | `tool_search` | 未設定（「auto」、デフォルト） \| `true` \| `false` | gpt-5.4+ モデルかつフレーバーが xAI/Grok でない場合に、Claude Code のツール検索へネイティブなクライアント実行 `tool_search` プロトコルを使う。未設定時は、すでに動作確認済みのホスト — ChatGPT/Codex バックエンドと `api.openai.com` — でのみネイティブがデフォルトになり、LiteLLM・vLLM・OpenRouter・自前ホストのプロキシなど他のすべての OpenAI 互換エンドポイントはテキストベースのシムのまま。検証済みのカスタムエンドポイントをネイティブへオプトインするには `true`、常にシムを強制するには `false` を設定する。[Codex → ツール検索](/ja/guides/codex/#ネイティブプロトコル) を参照。 |
 
@@ -327,7 +327,7 @@ origin に関係なく、保持された各スロットはそのスロットが�
 | `model` | ✅ | Claude Code が送る正確な `model` id |
 | `provider` | ✅ | 設定済みアップストリーム名 |
 | `upstream_model` | — | 上流へ転送するモデル id を書き換える |
-| `effort` | — | ルート単位の reasoning エフォートオーバーライド |
+| `effort` | — | ルート単位の reasoning エフォートオーバーライド。`antigravity` のルートでは、サフィックスのない `gemini-*` の `upstream_model` に合成される effort サフィックスを固定します。 |
 
 ## `[[route_prefixes]]`
 

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -23,7 +23,7 @@ description: 내장 프로바이더와 TOML 테이블로 Anthropic 호환 백엔
 | [`grok`](/ko/guides/xai/) | `responses` | `xai_oauth` | `cli-chat-proxy.grok.com/v1` — `shunt login xai`를 통한 SuperGrok / X Premium+ 구독 |
 | [`cursor`](/ko/providers/cursor/) | `cursor` | `cursor_oauth` | `api2.cursor.sh` — `~/.shunt/cursor-auth.json` 재사용 (`shunt login cursor`) |
 | `gemini` | `gemini` | `google_oauth` | `cloudcode-pa.googleapis.com` — `~/.gemini/oauth_creds.json` 재사용 |
-| [`antigravity`](/ko/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `cloudcode-pa.googleapis.com` — `~/.shunt/antigravity-auth.json` 재사용 (`shunt login antigravity`) |
+| [`antigravity`](/ko/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `daily-cloudcode-pa.googleapis.com` — `~/.shunt/antigravity-auth.json` 재사용 (`shunt login antigravity`) |
 | `antigravity-cli` | `antigravity_cli` | `none` | **더 이상 사용되지 않습니다.** 로컬 `agy` CLI — 서브프로세스를 통해 동일한 백엔드 |
 
 각 이름은 전체 설정을 설명하는 해당 프로바이더의 전용 페이지로 연결됩니다. `shunt add upstream <name>`은 모든 내장 프로바이더의 단계별 블루프린트를 출력합니다. 이를 코딩 에이전트에 파이프로 전달하면(`shunt add upstream codex --print | claude`) 에이전트가 구성을 연결하도록 할 수 있습니다. [CLI 레퍼런스](/ko/reference/cli/#shunt-add)를 참고하세요.
@@ -46,8 +46,12 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+Antigravity는 Gemini 모델을 effort 등급이 id에 붙은 형태(`-low`, `-medium`, `-high`; Pro는 `-low`와
+`-high`만)로 게시하며, 접미사가 없는 슬러그는 제공하지 않습니다. 접미사가 없는 `gemini-*` id는 shunt가
+`effort`나 요청에서, 그것도 없으면 `medium`으로 등급을 정해 붙여 주므로 두 표기 모두 동작합니다.
 
 전체 설정 — 로그인과 스코프, 프로젝트 디스커버리, 모델 슬러그, thinking, 어댑터가 전달하는 것 — 은 전용
 [Antigravity 프로바이더 페이지](/ko/providers/antigravity/)를 참고하세요.

--- a/site/src/content/docs/ko/providers/antigravity.mdx
+++ b/site/src/content/docs/ko/providers/antigravity.mdx
@@ -3,8 +3,9 @@ title: Antigravity
 description: HTTP를 통해 Google Antigravity 백엔드에 도달하기 — 로그인, 프로젝트 디스커버리, 모델 슬러그, thinking, 어댑터가 전달하는 것.
 ---
 
-내장 **`antigravity`** 프로바이더는 HTTP를 통해 `cloudcode-pa.googleapis.com`에 있는 Google의
-**Antigravity** 백엔드에 도달합니다. `gemini` 프로바이더와 동일한 Code Assist 프로토콜을 사용하며 —
+내장 **`antigravity`** 프로바이더는 HTTP를 통해 `daily-cloudcode-pa.googleapis.com`에 있는 Google의
+**Antigravity** 백엔드에 도달합니다. 이 호스트는 Antigravity 클라이언트 자신이 디스커버리와 추론
+양쪽에 사용하는 `daily-` 컨트롤 플레인입니다. `gemini` 프로바이더와 동일한 Code Assist 프로토콜을 사용하며 —
 shunt는 Anthropic Messages를 `generateContent` / `streamGenerateContent`로 변환합니다 — 다만
 Antigravity 구독 토큰으로 인증하고 프로젝트 디스커버리 과정에서 자신을 `ideType: ANTIGRAVITY`로
 식별합니다.
@@ -66,7 +67,7 @@ provider = "anthropic"   # 라우트가 없는 모델(예: claude-*)의 기본�
 [[upstreams]]
 name = "antigravity"
 kind = "antigravity"
-base_url = "https://cloudcode-pa.googleapis.com"
+base_url = "https://daily-cloudcode-pa.googleapis.com"
 auth = "antigravity_oauth"
 ```
 
@@ -79,9 +80,17 @@ auth = "antigravity_oauth"
 ## 3. 모델 라우팅
 
 shunt는 이 프로바이더에 대해 모델 허용 목록을 두지 않습니다: 해석된 `upstream_model`이 적힌 그대로
-백엔드로 전송되고, 판단은 백엔드가 합니다. Antigravity는 Gemini 계열 슬러그를 제공하며, 여기에는
-Code Assist `gemini` 프로바이더가 받아들이지 **않는** 슬러그인 `gemini-3.5-flash`와 `gemini-3.6-flash`도
-포함됩니다.
+백엔드로 전송되고, 판단은 백엔드가 합니다. Antigravity는 Code Assist `gemini` 프로바이더가 받아들이지
+**않는** Gemini 계열 슬러그를 제공합니다 — 다만 **effort 등급을 id에** `-low`, `-medium`, `-high`
+접미사로 붙여 게시합니다(Pro에는 `-low`와 `-high`만 있습니다). 현재 카탈로그는 `agy models`로 확인할 수
+있으며, 이 글을 쓰는 시점에는 `gemini-3.8-flash-*`, `gemini-3.7-flash-*`, `gemini-3.6-flash-*`,
+`gemini-3.1-pro-low` / `-high`, `claude-sonnet-4-6`, `claude-opus-4-6-thinking`,
+`gpt-oss-120b-medium`이 들어 있습니다.
+
+접미사가 없는 슬러그는 **제공되지 않습니다**: `daily-cloudcode-pa.googleapis.com`은 `404`로 답합니다.
+프로덕션 호스트에서는 이전의 shunt 요청 — 접미사 없는 id와 평범한 Code Assist 엔벨로프 — 이 요청량
+제한처럼 보이는 `429 RESOURCE_EXHAUSTED`("check quota")로 돌아왔습니다. 다만 탐침에서 두 입력을 함께
+바꾸었기 때문에 둘 중 무엇이 그 429를 만들었는지는 확인되지 않았습니다.
 
 로컬 별칭을 정확한 Antigravity 슬러그에 매핑하세요:
 
@@ -93,8 +102,25 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+접미사를 직접 쓸 필요는 없습니다. 접미사가 없는 `gemini-*` id에 대해서는 shunt가 등급을 직접 해석해
+붙이며, 다음 신호 중 먼저 적용되는 것을 따릅니다:
+
+1. `[[routes]]` 항목이나 프로바이더의 `effort` — 명시적 지정입니다. 여기서도 `xhigh`와 `max`는
+   `high`로 접히며, shunt가 모르는 등급은 그대로 통과하므로 카탈로그에 나중에 추가될 등급을 미리
+   지정할 수 있습니다.
+2. 요청의 `output_config.effort`(Claude Code는 `low`/`medium`/`high`/`xhigh`/`max`를 보내며,
+   `xhigh`와 `max`는 `high`로 접힙니다).
+3. `thinking.type = "enabled"` — `budget_tokens`가 2048 이하이면 `low`, 8192 이하이면 `medium`,
+   그보다 크면 `high`입니다. budget을 명시하지 않은 활성 블록은 변환된 요청이 싣는 것과 같은 기본값
+   `1024`를 사용하므로 `low`가 됩니다.
+4. 그 외에는 `medium`입니다.
+
+결과는 해당 계열이 실제로 게시하는 등급으로 조정되므로, `-pro` id의 `medium`은 `-high`가 됩니다. 이미
+등급으로 끝나는 id와 Gemini가 아닌 id(`claude-sonnet-4-6`, `gpt-oss-120b-medium`)는 적힌 그대로
+전송됩니다. 인식되지 않는 `output_config.effort`는 모델 id에 반영되지 않고 `medium`으로 되돌아갑니다.
 
 Antigravity는 Claude 모델도 제공하지만, shunt는 아직 그 모델들이 필요로 하는 요청 재작성을 구현하지
 않았습니다([#368](https://github.com/pleaseai/shunt/issues/368)). 로컬에서 그런 슬러그를 거부하는 것은
@@ -109,9 +135,13 @@ Antigravity는 Claude 모델도 제공하지만, shunt는 아직 그 모델들�
 `output_tokens`에 매핑됩니다.
 
 **Thinking**은 요청을 따릅니다: `thinking.type = "enabled"`는 `budget_tokens`(기본값 `1024`)로부터
-`thinkingConfig.thinkingBudget`을 설정하고, `"disabled"`는 이를 `0`으로 설정합니다. 이 전송에는
-**`effort` 설정이 없습니다** — `effort`는 더 이상 사용되지 않는 CLI 프로바이더의 것이며, 그쪽은 유효한
-모델/effort 쌍을 `agy models`에서 발견합니다.
+`thinkingConfig.thinkingBudget`을 설정하고, `"disabled"`는 이를 `0`으로 설정합니다. 활성화된
+`thinking` 블록은 위 **모델 라우팅**에서 설명한 대로 모델의 effort 등급을 고르는 신호이기도 합니다.
+
+또한 모든 요청은 Antigravity 클라이언트가 보내는 **에이전트 신원**을 함께 전달합니다:
+`userAgent: "antigravity"`, `requestType: "agent"`, 요청마다 생성되는 `requestId`, 그리고 후속 턴이
+같은 세션에 도달하도록 첫 사용자 턴에서 유도한 `sessionId`입니다. `gemini` 프로바이더의 Code Assist
+요청은 이 중 어느 것도 보내지 않습니다.
 
 프로덕션 트래픽을 라우팅하기 전에 알아둘 만한 제한이 두 가지 있습니다:
 
@@ -137,25 +167,27 @@ curl -sS http://127.0.0.1:3001/v1/messages \
 <Aside type="note" title="오버라이드">
 
 `SHUNT_ANTIGRAVITY_AUTH_FILE`은 자격 증명 경로를 오버라이드합니다(빈 값이면 기본값으로 폴백합니다).
-`antigravity_oauth` 업스트림은 하나의 호스트에 고정됩니다: 받아들이는 유일한 비루프백 `base_url`은
-`cloudcode-pa.googleapis.com` 자체에 대한 HTTPS입니다 — **다른 어떤 `googleapis.com` 호스트도 자격이
-없습니다**. 로컬 프록시를 위해 루프백 호스트는 허용됩니다. 그 외에는 구독 토큰을 조용히 오프오리진으로
-내보내는 대신 구성 검증 단계에서 거부됩니다 —
+`antigravity_oauth` 업스트림은 두 호스트에 고정됩니다: 받아들이는 비루프백 `base_url`은
+`daily-cloudcode-pa.googleapis.com`(기본값) 또는 필요한 운영자를 위해 여전히 유효한
+`cloudcode-pa.googleapis.com`에 대한 HTTPS뿐입니다 — `daily-cloudcode-pa.sandbox.googleapis.com`을
+포함해 **다른 어떤 `googleapis.com` 호스트도 자격이 없습니다**. 로컬 프록시를 위해 루프백 호스트는
+허용됩니다. 그 외에는 구독 토큰을 조용히 오프오리진으로 내보내는 대신 구성 검증 단계에서 거부됩니다 —
 `providers.<name> uses auth = "antigravity_oauth" but base_url is not https; refusing to send a
-subscription token over plaintext`, 또는 이에 대응하는 `... host <host> is not a googleapis.com host;
-refusing to send a subscription token off-origin`(이 메시지는 "googleapis.com host"라고 말하지만, 그
-뒤의 검사는 정확한 Code Assist 호스트를 봅니다).
+subscription token over plaintext`, 또는 이에 대응하는 `... host <host> is neither
+daily-cloudcode-pa.googleapis.com nor cloudcode-pa.googleapis.com; refusing to send a subscription
+token off-origin`입니다.
 
-`onboardUser`는 별도의 컨트롤 플레인에 있습니다. 평범한 프로덕션 `base_url` — 포트도 경로 프리픽스도 없는
-`cloudcode-pa.googleapis.com`에 대한 HTTPS — 은 `daily-cloudcode-pa.googleapis.com`을 상대로
-온보딩합니다. 백엔드 앞에 무언가가 놓여 있다면(루프백 프록시, 또는 명시적 포트나 경로 프리픽스가 붙은 그
-호스트) 자기 자신을 통해 온보딩합니다.
+`onboardUser`는 `daily-` 컨트롤 플레인에 있으며, 기본 `base_url`이 이미 그곳을 가리킵니다. 평범한
+프로덕션에 고정된 `base_url` — 포트도 경로 프리픽스도 없는 `cloudcode-pa.googleapis.com`에 대한
+HTTPS — 은 추론은 그대로 그곳에서 하되 온보딩은 `daily-cloudcode-pa.googleapis.com`을 상대로 합니다.
+백엔드 앞에 무언가가 놓여 있다면(루프백 프록시, 또는 두 호스트 중 하나에 명시적 포트나 경로 프리픽스가
+붙은 것) 자기 자신을 통해 온보딩합니다.
 
 [`shunt login antigravity`](/reference/cli/#shunt-login-antigravity)는 **라우팅된** Antigravity
 업스트림을 상대로 — 또는 라우트를 아직 연결하지 않았다면 선언한 Antigravity 업스트림을 상대로 —
 디스커버리를 수행합니다. 후보가 하나면 그대로 이기고, 여럿이 자격을 갖추면 **`antigravity`라는 이름의**
 후보가 이깁니다. 여럿이 자격을 갖추었는데 그 이름을 가진 것이 없으면 로그인은 추측하기를 거부합니다 —
-경고를 로그에 남기고 프로덕션 엔드포인트로 폴백하므로, 프로비저닝하는 프로젝트가 라우트가 사용하는
+경고를 로그에 남기고 기본 엔드포인트로 폴백하므로, 프로비저닝하는 프로젝트가 라우트가 사용하는
 백엔드의 것이 아닐 수 있습니다. 디스커버리 대상으로 삼고 싶은 업스트림의 이름을 `antigravity`로 지으세요.
 
 </Aside>

--- a/site/src/content/docs/ko/providers/antigravity.mdx
+++ b/site/src/content/docs/ko/providers/antigravity.mdx
@@ -109,8 +109,8 @@ upstream_model = "gemini-3.6-flash-medium"
 붙이며, 다음 신호 중 먼저 적용되는 것을 따릅니다:
 
 1. `[[routes]]` 항목이나 프로바이더의 `effort` — 명시적 지정입니다. 여기서도 `xhigh`와 `max`는
-   `high`로 접히며, shunt가 모르는 등급은 그대로 통과하므로 카탈로그에 나중에 추가될 등급을 미리
-   지정할 수 있습니다.
+   `high`로 접히며, 대소문자와 앞뒤 공백은 무시됩니다. shunt가 모르는 등급은 적힌 대로(공백을 제거하고
+   소문자로) 통과하므로 카탈로그에 나중에 추가될 등급을 미리 지정할 수 있습니다.
 2. 요청의 `output_config.effort`(Claude Code는 `low`/`medium`/`high`/`xhigh`/`max`를 보내며,
    `xhigh`와 `max`는 `high`로 접힙니다).
 3. `thinking.type = "enabled"` — `budget_tokens`가 2048 이하이면 `low`, 8192 이하이면 `medium`,
@@ -118,7 +118,8 @@ upstream_model = "gemini-3.6-flash-medium"
    `1024`를 사용하므로 `low`가 됩니다.
 4. 그 외에는 `medium`입니다.
 
-결과는 해당 계열이 실제로 게시하는 등급으로 조정되므로, `-pro` id의 `medium`은 `-high`가 됩니다. 이미
+인식된 등급은 해당 계열이 실제로 게시하는 등급으로 조정되므로, `-pro` id의 `medium`은 `-high`가 됩니다.
+설정에 적힌 인식되지 않는 `effort`는 1번 규칙대로 적힌 그대로 덧붙여지며 조정되지 않습니다. 이미
 등급으로 끝나는 id와 Gemini가 아닌 id(`claude-sonnet-4-6`, `gpt-oss-120b-medium`)는 적힌 그대로
 전송됩니다. 인식되지 않는 `output_config.effort`는 모델 id에 반영되지 않고 `medium`으로 되돌아갑니다.
 
@@ -140,7 +141,7 @@ Antigravity는 Claude 모델도 제공하지만, shunt는 아직 그 모델들�
 
 또한 모든 요청은 Antigravity 클라이언트가 보내는 **에이전트 신원**을 함께 전달합니다:
 `userAgent: "antigravity"`, `requestType: "agent"`, 요청마다 생성되는 `requestId`, 그리고 후속 턴이
-같은 세션에 도달하도록 첫 사용자 턴에서 유도한 `sessionId`입니다. `gemini` 프로바이더의 Code Assist
+같은 세션에 도달하도록 대화에서 가장 먼저 나오는 사용자 텍스트에서 유도한 `sessionId`입니다. `gemini` 프로바이더의 Code Assist
 요청은 이 중 어느 것도 보내지 않습니다.
 
 프로덕션 트래픽을 라우팅하기 전에 알아둘 만한 제한이 두 가지 있습니다:

--- a/site/src/content/docs/ko/reference/configuration.md
+++ b/site/src/content/docs/ko/reference/configuration.md
@@ -340,7 +340,7 @@ origin과 무관하게, 유지된 각 슬롯은 그 슬롯이 실제로 담고 �
 | `api_key_env` | env 변수 이름 | `auth = "api_key"`일 때 키를 읽어오는 곳. 이 값 자신도 `${VAR}` / `${file:...}`로 쓸 수 있음([Secret 참조](#secret-참조) 참고). |
 | `api_key_header` | `bearer`(기본) \| `x_api_key` | 주입된 키가 전송되는 헤더. |
 | `accounts` | 계정 테이블 배열 | Anthropic OAuth 계정 풀. `kind = "anthropic"`이고 `auth = "claude_oauth"`일 때만 유효; 아래 참고. |
-| `effort` | `low` … `max` | 선택적 기본 추론 노력(`responses` 프로바이더). |
+| `effort` | `low` … `max` | 선택적 기본 추론 노력(`responses` 프로바이더). `kind = "antigravity"`에도 적용되며, 접미사가 없는 `gemini-*` `upstream_model`에 카탈로그의 effort 접미사로 붙습니다. |
 | `count_tokens` | `tiktoken`(기본) \| `estimate` | `responses` 및 `cursor` provider: 로컬 tiktoken 카운트 대 `501 not_supported` fallback([상세](/ko/guides/effort-and-context/#token-counting-count_tokens)). |
 | `tool_search` | 미설정("auto", 기본) \| `true` \| `false` | gpt-5.4+ 모델이면서 계열이 xAI/Grok이 아닐 때 Claude Code의 도구 검색에 네이티브 클라이언트 실행 `tool_search` 프로토콜을 사용합니다. 미설정 시에는 이미 검증된 호스트 — ChatGPT/Codex 백엔드와 `api.openai.com` — 에서만 기본으로 네이티브를 사용하고, LiteLLM·vLLM·OpenRouter·자체 호스팅 프록시 등 그 외 모든 OpenAI 호환 엔드포인트는 텍스트 shim을 유지합니다. 검증된 커스텀 엔드포인트를 네이티브에 옵트인하려면 `true`로, shim을 항상 강제하려면 `false`로 설정하세요. [Codex → 도구 검색](/ko/guides/codex/#네이티브-프로토콜)을 참고하세요. |
 
@@ -357,7 +357,7 @@ origin과 무관하게, 유지된 각 슬롯은 그 슬롯이 실제로 담고 �
 | `model` | ✅ | Claude Code가 보내는 정확한 `model` id |
 | `provider` | ✅ | 설정된 업스트림 이름 |
 | `upstream_model` | — | 업스트림으로 전달되는 모델 id를 다시 씀 |
-| `effort` | — | 라우트별 추론 노력 오버라이드 |
+| `effort` | — | 라우트별 추론 노력 오버라이드. `antigravity` 라우트에서는 접미사가 없는 `gemini-*` `upstream_model`에 붙일 effort 접미사를 고정합니다. |
 
 ## `[[route_prefixes]]`
 

--- a/site/src/content/docs/providers/antigravity.mdx
+++ b/site/src/content/docs/providers/antigravity.mdx
@@ -110,8 +110,9 @@ You do not have to write the suffix by hand. For a bare `gemini-*` id, shunt res
 itself and appends it, taking the first signal that applies:
 
 1. `effort` on the `[[routes]]` entry, or on the provider — an explicit pin. `xhigh` and `max` fold
-   onto `high` here too; a level shunt does not recognise is passed through unchanged, so you can
-   name a tier the catalog adds later.
+   onto `high` here too, and matching ignores case and surrounding whitespace. A level shunt does
+   not recognise is passed through as written (trimmed and lower-cased), so you can name a tier
+   the catalog adds later.
 2. The request's `output_config.effort` (Claude Code sends `low`/`medium`/`high`/`xhigh`/`max`;
    `xhigh` and `max` fold onto `high`).
 3. `thinking.type = "enabled"` — `budget_tokens` at or below 2048 is `low`, at or below 8192 is
@@ -119,8 +120,9 @@ itself and appends it, taking the first signal that applies:
    default the translated request carries, so it lands in `low`.
 4. Otherwise `medium`.
 
-The result is clamped to the tiers the family actually publishes, so a `medium` on a `-pro` id
-becomes `-high`. An id that already ends in a tier, and any non-Gemini id (`claude-sonnet-4-6`,
+A recognised tier is clamped to the ones the family actually publishes, so a `medium` on a `-pro`
+id becomes `-high`; an unrecognised configured `effort` is appended as written, per rule 1, and is
+never clamped. An id that already ends in a tier, and any non-Gemini id (`claude-sonnet-4-6`,
 `gpt-oss-120b-medium`), is sent exactly as written. An unrecognised `output_config.effort` falls
 back to `medium` rather than reaching the model id.
 
@@ -143,7 +145,8 @@ above.
 
 Every request additionally carries the **agent identity the Antigravity client sends**:
 `userAgent: "antigravity"`, `requestType: "agent"`, a per-request `requestId`, and a `sessionId`
-derived from the opening user turn so follow-up turns land on the same session. The `gemini`
+derived from the earliest user text in the conversation so follow-up turns land on the same
+session. The `gemini`
 provider's Code Assist requests carry none of these.
 
 Two limits are worth knowing before you route production traffic:

--- a/site/src/content/docs/providers/antigravity.mdx
+++ b/site/src/content/docs/providers/antigravity.mdx
@@ -4,10 +4,11 @@ description: Reach the Google Antigravity backend over HTTP — login, project d
 ---
 
 The built-in **`antigravity`** provider reaches Google's **Antigravity** backend over HTTP at
-`cloudcode-pa.googleapis.com`. It speaks the same Code Assist protocol as the `gemini` provider —
-shunt translates Anthropic Messages to `generateContent` / `streamGenerateContent` — but it
-authenticates with an Antigravity subscription token and identifies itself as `ideType: ANTIGRAVITY`
-during project discovery.
+`daily-cloudcode-pa.googleapis.com` — the `daily-` control plane the Antigravity client itself
+addresses for both discovery and inference. It speaks the same Code
+Assist protocol as the `gemini` provider — shunt translates Anthropic Messages to
+`generateContent` / `streamGenerateContent` — but it authenticates with an Antigravity subscription
+token and identifies itself as `ideType: ANTIGRAVITY` during project discovery.
 
 Antigravity has a second, older transport. `kind = "antigravity_cli"` runs the local `agy` binary
 as a subprocess and is **deprecated** — see
@@ -67,7 +68,7 @@ provider = "anthropic"   # keep Anthropic as the default for unrouted models (e.
 [[upstreams]]
 name = "antigravity"
 kind = "antigravity"
-base_url = "https://cloudcode-pa.googleapis.com"
+base_url = "https://daily-cloudcode-pa.googleapis.com"
 auth = "antigravity_oauth"
 ```
 
@@ -80,9 +81,17 @@ and `[providers.*]` in one file.
 ## 3. Route a model
 
 shunt keeps no model allowlist for this provider: the resolved `upstream_model` is sent to the
-backend as written, and the backend decides. Antigravity serves the Gemini-family slugs, including
-`gemini-3.5-flash` and `gemini-3.6-flash` — slugs the Code Assist `gemini` provider does **not**
-accept.
+backend as written, and the backend decides. Antigravity serves the Gemini-family slugs the Code
+Assist `gemini` provider does **not** accept — but it publishes them with the **effort tier in the
+id**, as a `-low`, `-medium`, or `-high` suffix (Pro has only `-low` and `-high`). Run `agy models`
+to list the catalog as it stands today; at the time of writing it holds `gemini-3.8-flash-*`,
+`gemini-3.7-flash-*`, `gemini-3.6-flash-*`, `gemini-3.1-pro-low` / `-high`, `claude-sonnet-4-6`,
+`claude-opus-4-6-thinking`, and `gpt-oss-120b-medium`.
+
+A bare slug is **not served**: `daily-cloudcode-pa.googleapis.com` answers it with a `404`.
+Against the production host, shunt's earlier request — a bare id *and* the plain Code Assist
+envelope — came back as a misleading `429 RESOURCE_EXHAUSTED` ("check quota"), which reads as a rate
+limit; the probes changed both inputs together, so which one produced that 429 is not established.
 
 Map a local alias to the exact Antigravity slug:
 
@@ -94,8 +103,26 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+You do not have to write the suffix by hand. For a bare `gemini-*` id, shunt resolves the tier
+itself and appends it, taking the first signal that applies:
+
+1. `effort` on the `[[routes]]` entry, or on the provider — an explicit pin. `xhigh` and `max` fold
+   onto `high` here too; a level shunt does not recognise is passed through unchanged, so you can
+   name a tier the catalog adds later.
+2. The request's `output_config.effort` (Claude Code sends `low`/`medium`/`high`/`xhigh`/`max`;
+   `xhigh` and `max` fold onto `high`).
+3. `thinking.type = "enabled"` — `budget_tokens` at or below 2048 is `low`, at or below 8192 is
+   `medium`, above that is `high`. An enabled block that names no budget uses the same `1024`
+   default the translated request carries, so it lands in `low`.
+4. Otherwise `medium`.
+
+The result is clamped to the tiers the family actually publishes, so a `medium` on a `-pro` id
+becomes `-high`. An id that already ends in a tier, and any non-Gemini id (`claude-sonnet-4-6`,
+`gpt-oss-120b-medium`), is sent exactly as written. An unrecognised `output_config.effort` falls
+back to `medium` rather than reaching the model id.
 
 Antigravity also offers Claude models, but shunt does not yet implement the request rewrites they
 need ([#368](https://github.com/pleaseai/shunt/issues/368)). Nothing rejects such a slug locally —
@@ -110,9 +137,14 @@ become `systemInstruction`. Token usage is Google's reported count — `promptTo
 `candidatesTokenCount` map to `input_tokens` and `output_tokens`.
 
 **Thinking** follows the request: `thinking.type = "enabled"` sets `thinkingConfig.thinkingBudget`
-from `budget_tokens` (default `1024`), and `"disabled"` sets it to `0`. This transport has **no
-`effort` setting** — `effort` belongs to the deprecated CLI provider, which discovers its valid
-model/effort pairs from `agy models`.
+from `budget_tokens` (default `1024`), and `"disabled"` sets it to `0`. An enabled `thinking` block
+is also one of the signals that picks the model's effort tier, as described under **Route a model**
+above.
+
+Every request additionally carries the **agent identity the Antigravity client sends**:
+`userAgent: "antigravity"`, `requestType: "agent"`, a per-request `requestId`, and a `sessionId`
+derived from the opening user turn so follow-up turns land on the same session. The `gemini`
+provider's Code Assist requests carry none of these.
 
 Two limits are worth knowing before you route production traffic:
 
@@ -138,25 +170,28 @@ Confirm the response's `x-gateway-upstream` header names `antigravity`, then
 <Aside type="note" title="Overrides">
 
 `SHUNT_ANTIGRAVITY_AUTH_FILE` overrides the credential path (an empty value falls back to the
-default). An `antigravity_oauth` upstream is pinned to one host: the only non-loopback `base_url` it
-accepts is HTTPS on `cloudcode-pa.googleapis.com` itself — **no other `googleapis.com` host
-qualifies**. A loopback host is allowed for a local proxy. Anything else is refused at config
-validation rather than silently shipping your subscription token off-origin —
+default). An `antigravity_oauth` upstream is pinned to two hosts: the only non-loopback `base_url`
+it accepts is HTTPS on `daily-cloudcode-pa.googleapis.com` (the default) or on
+`cloudcode-pa.googleapis.com`, which stays valid for operators who need it — **no other
+`googleapis.com` host qualifies**, `daily-cloudcode-pa.sandbox.googleapis.com` included. A loopback
+host is allowed for a local proxy. Anything else is refused at config validation rather than
+silently shipping your subscription token off-origin —
 `providers.<name> uses auth = "antigravity_oauth" but base_url is not https; refusing to send a
-subscription token over plaintext`, or the matching `... host <host> is not a googleapis.com host;
-refusing to send a subscription token off-origin` (that message says "googleapis.com host", but the
-check behind it is the exact Code Assist host).
+subscription token over plaintext`, or the matching `... host <host> is neither
+daily-cloudcode-pa.googleapis.com nor cloudcode-pa.googleapis.com; refusing to send a subscription
+token off-origin`.
 
-`onboardUser` lives on a separate control plane. A `base_url` that is plain production — HTTPS on
-`cloudcode-pa.googleapis.com`, no port, no path prefix — onboards against
-`daily-cloudcode-pa.googleapis.com`. Anything sitting in front of the backend (a loopback proxy, or
-that host with an explicit port or path prefix) onboards through itself.
+`onboardUser` lives on the `daily-` control plane, which is where the default `base_url` already
+points. A `base_url` pinned at plain production — HTTPS on `cloudcode-pa.googleapis.com`, no port,
+no path prefix — keeps inference there but onboards against `daily-cloudcode-pa.googleapis.com`
+anyway. Anything sitting in front of the backend (a loopback proxy, or either host with an explicit
+port or path prefix) onboards through itself.
 
 [`shunt login antigravity`](/reference/cli/#shunt-login-antigravity) discovers against your
 **routed** Antigravity upstreams — or, before you have wired up routes, the Antigravity upstreams you
 declared. A single candidate wins outright, and when several qualify the one
 **named `antigravity`** wins. If several qualify and none carries that name, login refuses to guess —
-it logs a warning and falls back to the production endpoint, so the project it provisions may not be
+it logs a warning and falls back to the default endpoint, so the project it provisions may not be
 the backend your routes use. Name the upstream you want discovered `antigravity`.
 
 </Aside>

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -456,7 +456,7 @@ Each provider is a table under a name of your choosing. Built-ins (`anthropic`, 
 | `api_key_env` | env var name | Where the key is read from, when `auth = "api_key"`. Its own value can also be written as `${VAR}` / `${file:...}` (see [Secret references](#secret-references)). |
 | `api_key_header` | `bearer` (default) \| `x_api_key` | Header the injected key is sent in. |
 | `accounts` | array of account tables | OAuth account pool. Valid only with `auth = "claude_oauth"`, `"chatgpt_oauth"`, or `"kimi_oauth"`; see below. |
-| `effort` | `low` … `max` | Optional default reasoning effort (`responses` providers). |
+| `effort` | `low` … `max` | Optional default reasoning effort (`responses` providers). Also applies to `kind = "antigravity"`, where it is appended to a bare `gemini-*` `upstream_model` as the catalog's effort suffix. |
 | `service_tier` | `fast` \| `priority` \| `flex` \| `default` | Optional default Codex "Fast" mode opt-in (`responses` providers) — sent as the Responses API `service_tier` field. `fast` normalizes to `priority`; `default` is a client-only sentinel that is never sent on the wire. Off by default. Withheld for the `xai`/`grok` flavors even when configured (xAI 400s on it). A route-level `service_tier` (including an explicit `default`) overrides this value — see below. See [Codex → Fast mode](/guides/codex/#fast-mode). |
 | `count_tokens` | `tiktoken` (default) \| `estimate` | `responses` and `cursor` providers: local tiktoken count vs. `501 not_supported` fallback ([details](/guides/effort-and-context/#token-counting-count_tokens)). |
 | `websocket` | `true` \| `false` (default) | Opt in to the Codex Responses WebSocket v2 transport (ChatGPT/Codex backend only; falls back to HTTP on any transport failure before the first event reaches the client, so it can never do worse than plain HTTP). |
@@ -535,7 +535,7 @@ Legacy exact-match routing entries — checked after a matching `[models.upstrea
 | `model` | ✅ | The exact `model` id Claude Code sends |
 | `provider` | ✅ | Configured upstream name |
 | `upstream_model` | — | Rewrite the model id forwarded upstream |
-| `effort` | — | Per-route reasoning-effort override |
+| `effort` | — | Per-route reasoning-effort override. On an `antigravity` route it pins the effort suffix synthesized onto a bare `gemini-*` `upstream_model`. |
 | `service_tier` | — | Per-route Codex "Fast" mode override; see `[providers.*]` `service_tier` above. An explicit route-level `default` opts the route out of a provider-level `priority`/`flex` tier instead of inheriting it. |
 
 ## `[[route_prefixes]]`

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -23,7 +23,7 @@ description: 内置的提供方,以及如何用一个 TOML 表添加任意兼容
 | [`grok`](/zh-cn/guides/xai/) | `responses` | `xai_oauth` | `cli-chat-proxy.grok.com/v1` —— 通过 `shunt login xai` 使用 SuperGrok / X Premium+ 订阅 |
 | [`cursor`](/zh-cn/providers/cursor/) | `cursor` | `cursor_oauth` | `api2.cursor.sh` —— 复用 `~/.shunt/cursor-auth.json`(`shunt login cursor`) |
 | `gemini` | `gemini` | `google_oauth` | `cloudcode-pa.googleapis.com` —— 复用 `~/.gemini/oauth_creds.json` |
-| [`antigravity`](/zh-cn/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `cloudcode-pa.googleapis.com` —— 复用 `~/.shunt/antigravity-auth.json`(`shunt login antigravity`) |
+| [`antigravity`](/zh-cn/providers/antigravity/) | `antigravity` | `antigravity_oauth` | `daily-cloudcode-pa.googleapis.com` —— 复用 `~/.shunt/antigravity-auth.json`(`shunt login antigravity`) |
 | `antigravity-cli` | `antigravity_cli` | `none` | **已废弃。** 本地 `agy` CLI —— 经由子进程访问同一后端 |
 
 每个名称都链接到对应提供方的专门页面,其中包含完整设置。`shunt add upstream <name>`
@@ -48,8 +48,12 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+Antigravity 把 Gemini 模型的 effort 档位写进 id 发布(`-low`、`-medium`、`-high`;Pro 只有 `-low` 和
+`-high`),并不提供不带后缀的 slug。不带后缀的 `gemini-*` id 会由 shunt 依据 `effort`、请求、否则按
+`medium` 解析出档位并追加,所以两种写法都能用。
 
 完整设置 —— 登录与 scope、项目发现、模型 slug、thinking,以及适配器承载的内容 —— 见专门的
 [Antigravity 提供方页面](/zh-cn/providers/antigravity/)。

--- a/site/src/content/docs/zh-cn/providers/antigravity.mdx
+++ b/site/src/content/docs/zh-cn/providers/antigravity.mdx
@@ -105,15 +105,17 @@ upstream_model = "gemini-3.6-flash-medium"
 适用的信号:
 
 1. `[[routes]]` 条目或提供方上的 `effort` —— 显式指定。这里 `xhigh` 和 `max` 同样会折叠为 `high`;
-   shunt 不认识的档位会原样通过,因此你可以指定目录以后才加入的档位。
+   匹配忽略大小写和前后空白。shunt 不认识的档位会按所写(去除空白并转为小写)通过,因此你可以指定
+   目录以后才加入的档位。
 2. 请求中的 `output_config.effort`(Claude Code 会发送 `low`/`medium`/`high`/`xhigh`/`max`,
    其中 `xhigh` 和 `max` 会折叠为 `high`)。
 3. `thinking.type = "enabled"` —— `budget_tokens` 不超过 2048 为 `low`,不超过 8192 为 `medium`,
    更大则为 `high`。启用但未指定 budget 的块会使用与转换后请求相同的默认值 `1024`,因此落在 `low`。
 4. 其余情况为 `medium`。
 
-结果会被收敛到该家族实际发布的档位,因此 `-pro` id 上的 `medium` 会变成 `-high`。已经以档位结尾的
-id,以及非 Gemini 的 id(`claude-sonnet-4-6`、`gpt-oss-120b-medium`),都会原样发送。无法识别的
+已识别的档位会被收敛到该家族实际发布的档位,因此 `-pro` id 上的 `medium` 会变成 `-high`;配置中
+未识别的 `effort` 会按规则 1 所述原样追加,不会被收敛。已经以档位结尾的 id,以及非 Gemini 的
+id(`claude-sonnet-4-6`、`gpt-oss-120b-medium`),都会原样发送。无法识别的
 `output_config.effort` 会回退到 `medium`,不会进入模型 id。
 
 Antigravity 也提供 Claude 模型,但 shunt 尚未实现它们所需的请求改写
@@ -133,7 +135,7 @@ Antigravity 也提供 Claude 模型,但 shunt 尚未实现它们所需的请求�
 挑选模型 effort 档位的信号之一,见上面的**路由一个模型**。
 
 此外,每个请求都会带上 Antigravity 客户端所发送的**代理身份**:`userAgent: "antigravity"`、
-`requestType: "agent"`、每个请求各自的 `requestId`,以及从首个用户轮次推导出的 `sessionId`,好让后续
+`requestType: "agent"`、每个请求各自的 `requestId`,以及从对话中最早出现的用户文本推导出的 `sessionId`,好让后续
 轮次落到同一个会话。`gemini` 提供方的 Code Assist 请求不会发送其中任何一项。
 
 在把生产流量路由过来之前,有两项限制值得知道:

--- a/site/src/content/docs/zh-cn/providers/antigravity.mdx
+++ b/site/src/content/docs/zh-cn/providers/antigravity.mdx
@@ -3,8 +3,8 @@ title: Antigravity
 description: 通过 HTTP 触达 Google Antigravity 后端 —— 登录、项目发现、模型 slug、thinking,以及适配器承载的内容。
 ---
 
-内置的 **`antigravity`** 提供方通过 HTTP 在 `cloudcode-pa.googleapis.com` 触达 Google 的 **Antigravity**
-后端。它讲的是与 `gemini` 提供方相同的 Code Assist 协议 ——
+内置的 **`antigravity`** 提供方通过 HTTP 在 `daily-cloudcode-pa.googleapis.com` 触达 Google 的
+**Antigravity** 后端。该主机就是 Antigravity 客户端自身在发现和推理时都会访问的 `daily-` 控制平面。它讲的是与 `gemini` 提供方相同的 Code Assist 协议 ——
 shunt 将 Anthropic Messages 转换为 `generateContent` / `streamGenerateContent` —— 但它
 用 Antigravity 订阅 token 认证,并在项目发现期间把自己标识为 `ideType: ANTIGRAVITY`。
 
@@ -64,7 +64,7 @@ provider = "anthropic"   # 让 Anthropic 作为无路由匹配模型(例如 clau
 [[upstreams]]
 name = "antigravity"
 kind = "antigravity"
-base_url = "https://cloudcode-pa.googleapis.com"
+base_url = "https://daily-cloudcode-pa.googleapis.com"
 auth = "antigravity_oauth"
 ```
 
@@ -77,9 +77,16 @@ auth = "antigravity_oauth"
 ## 3. 路由一个模型
 
 shunt 不为该提供方保留任何模型白名单:解析出的 `upstream_model` 会原样发送到
-后端,由后端决定。Antigravity 提供 Gemini 家族的 slug,包括
-`gemini-3.5-flash` 和 `gemini-3.6-flash` —— 这些 slug 是 Code Assist 的 `gemini` 提供方**不**
-接受的。
+后端,由后端决定。Antigravity 提供 Code Assist 的 `gemini` 提供方**不**接受的 Gemini 家族 slug ——
+但它把 **effort 档位写进 id**,以 `-low`、`-medium`、`-high` 后缀的形式发布(Pro 只有 `-low` 和
+`-high`)。用 `agy models` 可以列出当前目录;撰写本文时其中包含 `gemini-3.8-flash-*`、
+`gemini-3.7-flash-*`、`gemini-3.6-flash-*`、`gemini-3.1-pro-low` / `-high`、`claude-sonnet-4-6`、
+`claude-opus-4-6-thinking` 和 `gpt-oss-120b-medium`。
+
+不带后缀的 slug **不会被提供**:`daily-cloudcode-pa.googleapis.com` 会回 `404`。在生产主机上,shunt
+早先的请求 —— 不带后缀的 id 加上普通的 Code Assist 信封 —— 返回了看起来像限流的、具有误导性的
+`429 RESOURCE_EXHAUSTED`(“check quota”);但探测同时改变了这两个输入,因此无法确定是哪一个导致了
+这个 429。
 
 把每个本地别名映射到确切的 Antigravity slug:
 
@@ -91,8 +98,23 @@ display_name = "[AGY ] Gemini-3.6-Flash"
 [[routes]]
 model = "claude-gemini-3.6-flash-via-antigravity"
 provider = "antigravity"
-upstream_model = "gemini-3.6-flash"
+upstream_model = "gemini-3.6-flash-medium"
 ```
+
+你不必手写这个后缀。对于不带后缀的 `gemini-*` id,shunt 会自行解析档位并追加,按以下顺序取第一个
+适用的信号:
+
+1. `[[routes]]` 条目或提供方上的 `effort` —— 显式指定。这里 `xhigh` 和 `max` 同样会折叠为 `high`;
+   shunt 不认识的档位会原样通过,因此你可以指定目录以后才加入的档位。
+2. 请求中的 `output_config.effort`(Claude Code 会发送 `low`/`medium`/`high`/`xhigh`/`max`,
+   其中 `xhigh` 和 `max` 会折叠为 `high`)。
+3. `thinking.type = "enabled"` —— `budget_tokens` 不超过 2048 为 `low`,不超过 8192 为 `medium`,
+   更大则为 `high`。启用但未指定 budget 的块会使用与转换后请求相同的默认值 `1024`,因此落在 `low`。
+4. 其余情况为 `medium`。
+
+结果会被收敛到该家族实际发布的档位,因此 `-pro` id 上的 `medium` 会变成 `-high`。已经以档位结尾的
+id,以及非 Gemini 的 id(`claude-sonnet-4-6`、`gpt-oss-120b-medium`),都会原样发送。无法识别的
+`output_config.effort` 会回退到 `medium`,不会进入模型 id。
 
 Antigravity 也提供 Claude 模型,但 shunt 尚未实现它们所需的请求改写
 ([#368](https://github.com/pleaseai/shunt/issues/368))。本地没有任何东西会拒绝这样的 slug ——
@@ -107,9 +129,12 @@ Antigravity 也提供 Claude 模型,但 shunt 尚未实现它们所需的请求�
 `candidatesTokenCount` 映射到 `input_tokens` 和 `output_tokens`。
 
 **Thinking** 跟随请求:`thinking.type = "enabled"` 会用 `budget_tokens` 设置
-`thinkingConfig.thinkingBudget`(默认 `1024`),`"disabled"` 则把它设为 `0`。这条传输**没有
-`effort` 设置** —— `effort` 属于已废弃的 CLI 提供方,后者从 `agy models` 发现其有效的
-模型 / effort 组合。
+`thinkingConfig.thinkingBudget`(默认 `1024`),`"disabled"` 则把它设为 `0`。启用的 `thinking` 块也是
+挑选模型 effort 档位的信号之一,见上面的**路由一个模型**。
+
+此外,每个请求都会带上 Antigravity 客户端所发送的**代理身份**:`userAgent: "antigravity"`、
+`requestType: "agent"`、每个请求各自的 `requestId`,以及从首个用户轮次推导出的 `sessionId`,好让后续
+轮次落到同一个会话。`gemini` 提供方的 Code Assist 请求不会发送其中任何一项。
 
 在把生产流量路由过来之前,有两项限制值得知道:
 
@@ -134,24 +159,25 @@ curl -sS http://127.0.0.1:3001/v1/messages \
 <Aside type="note" title="覆盖项">
 
 `SHUNT_ANTIGRAVITY_AUTH_FILE` 可覆盖凭据路径(空值会回退到
-默认值)。`antigravity_oauth` 上游被固定到一个主机:它接受的唯一非回环 `base_url`
-是 `cloudcode-pa.googleapis.com` 本身上的 HTTPS —— **没有其他 `googleapis.com` 主机
-合格**。回环主机可用于本地代理。其他任何情况都会在配置
+默认值)。`antigravity_oauth` 上游被固定到两个主机:它接受的非回环 `base_url` 只能是
+`daily-cloudcode-pa.googleapis.com`(默认)或仍然有效、供确有需要的运维者使用的
+`cloudcode-pa.googleapis.com` 上的 HTTPS —— 包括 `daily-cloudcode-pa.sandbox.googleapis.com` 在内,
+**没有其他 `googleapis.com` 主机合格**。回环主机可用于本地代理。其他任何情况都会在配置
 校验阶段被拒绝,而不是悄悄把你的订阅 token 发往别的 origin ——
 `providers.<name> uses auth = "antigravity_oauth" but base_url is not https; refusing to send a
-subscription token over plaintext`,或者与之对应的 `... host <host> is not a googleapis.com host;
-refusing to send a subscription token off-origin`(该消息写的是 “googleapis.com host”,但它背后的
-检查针对的是确切的那个 Code Assist 主机)。
+subscription token over plaintext`,或者与之对应的 `... host <host> is neither
+daily-cloudcode-pa.googleapis.com nor cloudcode-pa.googleapis.com; refusing to send a subscription
+token off-origin`。
 
-`onboardUser` 位于一个独立的控制平面。一个纯生产的 `base_url` —— `cloudcode-pa.googleapis.com`
-上的 HTTPS,无端口,无路径前缀 —— 会针对
-`daily-cloudcode-pa.googleapis.com` 开通。任何挡在后端前面的东西(一个回环代理,或
-带显式端口或路径前缀的该主机)则通过它自身开通。
+`onboardUser` 位于 `daily-` 控制平面,而默认的 `base_url` 已经指向那里。一个固定在纯生产的
+`base_url` —— `cloudcode-pa.googleapis.com` 上的 HTTPS,无端口,无路径前缀 —— 推理仍留在那里,但
+开通仍会针对 `daily-cloudcode-pa.googleapis.com`。任何挡在后端前面的东西(一个回环代理,或带显式
+端口或路径前缀的这两个主机之一)则通过它自身开通。
 
 [`shunt login antigravity`](/reference/cli/#shunt-login-antigravity) 会针对你**已路由的**
 Antigravity 上游做发现 —— 或者在你还没接好路由之前,针对你所声明的 Antigravity 上游。
 只有一个候选时它直接胜出,而当有多个候选合格时,**名为 `antigravity`** 的那个胜出。如果有
-多个合格却都不叫这个名字,登录会拒绝猜测 —— 它记录一条警告并回退到生产端点,因此它开通的
+多个合格却都不叫这个名字,登录会拒绝猜测 —— 它记录一条警告并回退到默认端点,因此它开通的
 项目可能并不是你的路由所用的那个后端。请把你希望被发现的那个上游命名为 `antigravity`。
 
 </Aside>

--- a/site/src/content/docs/zh-cn/reference/configuration.md
+++ b/site/src/content/docs/zh-cn/reference/configuration.md
@@ -310,7 +310,7 @@ codex-fallback = "gpt-5.2"
 | `auth` | `passthrough` \| `api_key` \| `chatgpt_oauth` \| `claude_oauth` \| `xai_oauth` \| `cursor_oauth` \| `google_oauth` \| `antigravity_oauth` \| `none` | `passthrough` 转发客户端自己的 credential;`api_key` 从 `api_key_env` 注入一个密钥;`chatgpt_oauth` 复用 `~/.codex/auth.json`;`claude_oauth` 从显式 Anthropic 账户中选择;`xai_oauth` 复用来自 `shunt login xai` 的 `~/.shunt/xai-auth.json`(仅经由 HTTPS 发送到 x.ai/grok.com 主机);`cursor_oauth` 复用 `~/.shunt/cursor-auth.json`(`shunt login cursor`);`google_oauth` 复用 gemini CLI 登录的 `~/.gemini/oauth_creds.json`,仅在 `kind = "gemini"` 下有效;`antigravity_oauth` 复用来自 `shunt login antigravity` 的 `~/.shunt/antigravity-auth.json`,仅在 `kind = "antigravity"` 下有效,且与 `google_oauth` **不可互换** —— Antigravity 会请求 Gemini CLI 令牌所没有的两个 scope(`cclog`、`experimentsandconfigs`);`none` 完全不发送 credential,用于没有上游需要认证的适配器(`kind = "antigravity_cli"`)。 |
 | `api_key_env` | 环境变量名 | 当 `auth = "api_key"` 时,从何处读取密钥。该值自身也可以写成 `${VAR}` / `${file:...}`(见 [Secret 引用](#secret-引用))。 |
 | `api_key_header` | `bearer`(默认) \| `x_api_key` | 注入的密钥在哪个头部中发送。 |
-| `effort` | `low` … `max` | 可选的默认推理力度(`responses` 提供方)。 |
+| `effort` | `low` … `max` | 可选的默认推理力度(`responses` 提供方)。也适用于 `kind = "antigravity"`,会作为目录的 effort 后缀追加到不带后缀的 `gemini-*` `upstream_model` 上。 |
 | `count_tokens` | `tiktoken`(默认) \| `estimate` | `responses` 与 `cursor` provider:本地 tiktoken 计数 vs. `501 not_supported` 回退([详情](/zh-cn/guides/effort-and-context/#token-counting-count_tokens))。 |
 | `tool_search` | 未设置("auto",默认) \| `true` \| `false` | 在模型为 GPT-5.4+ 且风格不是 xAI/Grok 时,为 Claude Code 的工具搜索使用原生的客户端执行 `tool_search` 协议。未设置时仅对已验证支持的主机 —— ChatGPT/Codex 后端与 `api.openai.com` —— 默认使用原生协议,LiteLLM、vLLM、OpenRouter、自托管代理等其他所有 OpenAI 兼容端点都保留文本 shim。设为 `true` 可让已验证的自定义端点选择加入原生协议;设为 `false` 则始终强制使用 shim。见 [Codex → 工具搜索](/zh-cn/guides/codex/#原生协议)。 |
 
@@ -327,7 +327,7 @@ codex-fallback = "gpt-5.2"
 | `model` | ✅ | Claude Code 发送的精确 `model` id |
 | `provider` | ✅ | 已配置的上游名称 |
 | `upstream_model` | — | 重写转发给上游的模型 id |
-| `effort` | — | 按路由的推理力度覆盖 |
+| `effort` | — | 按路由的推理力度覆盖。在 `antigravity` 路由上,它会固定合成到不带后缀的 `gemini-*` `upstream_model` 上的 effort 后缀。 |
 
 ## `[[route_prefixes]]`
 

--- a/src/adapters/gemini/mod.rs
+++ b/src/adapters/gemini/mod.rs
@@ -12,6 +12,10 @@ use crate::{
     adapters::{Adapter, AdapterError, AdapterFuture},
     auth::{resolve_credential, Credential},
     config::AuthMode,
+    model::antigravity_request::{
+        antigravity_request_id, antigravity_session_id, antigravity_upstream_model,
+        wrap_antigravity_envelope,
+    },
     model::gemini::{map_gemini_error, GeminiSseMachine},
     model::gemini_request::{translate_request_for_model, wrap_code_assist_envelope},
     request::RequestBody,
@@ -114,7 +118,24 @@ async fn forward(
         provider.auth,
         AuthMode::GoogleOauth | AuthMode::AntigravityOauth
     );
-    let (endpoint, payload) = if is_code_assist {
+    let (endpoint, payload) = if provider.auth == AuthMode::AntigravityOauth {
+        // Antigravity speaks the same `v1internal` methods, but the client
+        // identifies itself as the agent and names a session, and its catalog
+        // ids carry their effort tier. See `wrap_antigravity_envelope` and
+        // `antigravity_upstream_model`.
+        let endpoint = format!("{base_url}/v1internal:{method}");
+        let model =
+            antigravity_upstream_model(&route.upstream_model, route.effort.as_deref(), json_body);
+        let session_id = antigravity_session_id(&inner_req);
+        let envelope = wrap_antigravity_envelope(
+            &model,
+            &project_id,
+            inner_req,
+            &antigravity_request_id(),
+            &session_id,
+        );
+        (endpoint, envelope)
+    } else if is_code_assist {
         let endpoint = format!("{base_url}/v1internal:{method}");
         let envelope = wrap_code_assist_envelope(&route.upstream_model, &project_id, inner_req);
         (endpoint, envelope)

--- a/src/auth/antigravity/auth.rs
+++ b/src/auth/antigravity/auth.rs
@@ -1,8 +1,9 @@
 //! Antigravity subscription OAuth credential store.
 //!
 //! Antigravity reaches the same Code Assist backend the `gemini` provider uses
-//! — `cloudcode-pa.googleapis.com/v1internal` by default, or whatever host the
-//! provider's `base_url` configures (see [`AntigravityAuthStore::new`]) — but
+//! — `v1internal` methods on `daily-cloudcode-pa.googleapis.com` by default,
+//! or whatever host the provider's `base_url` configures (see
+//! [`AntigravityAuthStore::new`]) — but
 //! with its own OAuth client and scopes, and it identifies itself as
 //! `ideType: ANTIGRAVITY` during project discovery. The two credentials are
 //! therefore not interchangeable, which is why this store exists alongside
@@ -54,16 +55,27 @@ pub(crate) const AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth"
 pub(crate) const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 pub(crate) const USERINFO_URL: &str = "https://www.googleapis.com/oauth2/v2/userinfo?alt=json";
 
-/// Production Code Assist backend. This is only the default: `discover_project`
-/// and inference (`adapters::gemini`) both address the provider's configured
-/// `base_url`, which `AntigravityAuthStore::new` derives `api_endpoint` from —
-/// see there for why. This constant remains the production value that
-/// `main.rs`'s login command falls back to when no config is available.
+/// Production Code Assist backend. This is *not* the Antigravity default —
+/// see [`DEFAULT_API_ENDPOINT`]. It is the value
+/// [`addresses_production_backend`] recognises, so an operator who pins their
+/// provider at production still gets onboarding on the `daily-` control
+/// plane; that predicate parses the operator's own spelling rather than
+/// comparing against this constant, which is why nothing outside tests names
+/// it.
+#[cfg(test)]
 pub(crate) const API_ENDPOINT: &str = "https://cloudcode-pa.googleapis.com";
-/// Onboarding is served from the `daily-` host, not the production one — but
-/// only when the configured backend actually is production; see
-/// `AntigravityAuthStore::new` for the non-production case.
+/// The `daily-` control plane — the host the Antigravity client itself
+/// addresses for both discovery and inference. Onboarding is served from here
+/// rather than from production, and a live probe reached `200` here for a
+/// suffixed catalog id where production returned `429 RESOURCE_EXHAUSTED` for
+/// a bare one.
 pub(crate) const DAILY_API_ENDPOINT: &str = "https://daily-cloudcode-pa.googleapis.com";
+/// The backend `shunt login antigravity` addresses when no config is available
+/// (see `main.rs`), and the `base_url` the built-in `antigravity` provider is
+/// seeded with (`Config::default` in `src/config.rs`). The two must name the
+/// same host, or login provisions a project against one backend while
+/// inference runs against another.
+pub(crate) const DEFAULT_API_ENDPOINT: &str = DAILY_API_ENDPOINT;
 pub(crate) const API_VERSION: &str = "v1internal";
 
 /// Antigravity requests two scopes the Gemini CLI never asks for — `cclog` and
@@ -243,21 +255,24 @@ impl AntigravityAuthStore {
     /// configured, rather than always reaching the hardcoded production host
     /// regardless of `base_url`. Trailing slashes are trimmed once here,
     /// mirroring the Gemini adapter's own normalization at the point it
-    /// builds a request URL; no fallback to [`API_ENDPOINT`] is applied for an
-    /// empty or malformed value — config validation already parses every
+    /// builds a request URL; no fallback to a built-in endpoint is applied for
+    /// an empty or malformed value — config validation already parses every
     /// provider `base_url` (`provider_base_url` in `src/config.rs`), and
     /// silently falling back here would fail open to the production host.
     pub fn new(path: PathBuf, client: reqwest::Client, base_url: impl Into<String>) -> Self {
         let api_endpoint = base_url.into().trim_end_matches('/').to_string();
-        // The `daily-` control-plane host that serves onboarding only exists
-        // for the production backend. Anything else config validation admits
-        // (the `AuthMode::AntigravityOauth` block in `src/config.rs`) is a
-        // loopback host — the operator's proxy standing in for the whole
-        // backend — so sending `onboardUser` to the real `daily-` host there
-        // would egress straight past the very endpoint the operator
-        // configured. `discover_project` chains into `onboard_user` on the same
-        // request path, so this has to travel with `api_endpoint` rather than
-        // stay pinned to the production default.
+        // Onboarding is served from the `daily-` control plane. On the default
+        // `base_url` that is already `api_endpoint`, so this branch is a no-op
+        // there. It still matters for the two other shapes config validation
+        // admits (the `AuthMode::AntigravityOauth` block in `src/config.rs`):
+        // a `base_url` pinned at production, which does not serve
+        // `onboardUser` and so has to be redirected here; and a loopback host
+        // — the operator's proxy standing in for the whole backend — where
+        // sending `onboardUser` to the real `daily-` host would egress
+        // straight past the very endpoint the operator configured.
+        // `discover_project` chains into `onboard_user` on the same request
+        // path, so this has to travel with `api_endpoint` rather than stay
+        // pinned to a constant.
         let daily_api_endpoint = if addresses_production_backend(&api_endpoint) {
             DAILY_API_ENDPOINT.to_string()
         } else {
@@ -1140,13 +1155,26 @@ pub(crate) fn default_tier_id(load_response: &Value) -> String {
 /// production" — those address something in front of the backend, which is
 /// exactly the case that must carry onboarding with it.
 pub(super) fn addresses_production_backend(endpoint: &str) -> bool {
+    addresses_bare_backend(endpoint, crate::config::host_is_google_codeassist)
+}
+
+/// Whether `endpoint` addresses the default Antigravity backend itself — the
+/// `daily-` control plane both [`DEFAULT_API_ENDPOINT`] and the seeded
+/// `antigravity` provider name.
+///
+/// Used by `login_base_url` to tell a slot left at the built-in default from
+/// one the operator actually declared. Same parse-don't-compare reasoning as
+/// [`addresses_production_backend`].
+pub(super) fn addresses_default_backend(endpoint: &str) -> bool {
+    addresses_bare_backend(endpoint, crate::config::host_is_antigravity_daily)
+}
+
+fn addresses_bare_backend(endpoint: &str, is_host: impl Fn(&str) -> bool) -> bool {
     reqwest::Url::parse(endpoint).is_ok_and(|url| {
         url.scheme() == "https"
             && url.port().is_none()
             && url.path() == "/"
-            && url
-                .host_str()
-                .is_some_and(crate::config::host_is_google_codeassist)
+            && url.host_str().is_some_and(is_host)
     })
 }
 
@@ -1340,12 +1368,25 @@ mod tests {
     }
 
     #[test]
-    fn the_production_default_still_routes_onboarding_to_the_daily_host() {
-        // When the configured base_url resolves to the production default,
-        // onboarding must keep using the dedicated `daily-` control-plane
-        // host — only a genuinely non-production base_url (necessarily
-        // loopback, per the AntigravityOauth validation guard in
-        // src/config.rs) collapses daily_api_endpoint onto api_endpoint.
+    fn the_default_base_url_puts_both_endpoints_on_the_daily_host() {
+        // The default `base_url` is the `daily-` control plane, so onboarding
+        // and inference address the same backend and nothing is redirected.
+        let store = AntigravityAuthStore::new(
+            temp_auth_file("default_daily_host"),
+            reqwest::Client::new(),
+            DEFAULT_API_ENDPOINT,
+        );
+        assert_eq!(store.api_endpoint, DAILY_API_ENDPOINT);
+        assert_eq!(store.daily_api_endpoint, DAILY_API_ENDPOINT);
+    }
+
+    #[test]
+    fn a_production_base_url_still_routes_onboarding_to_the_daily_host() {
+        // An operator who pins `base_url` at production keeps inference there,
+        // but production does not serve `onboardUser` — only a genuinely
+        // non-production, non-daily base_url (necessarily loopback, per the
+        // AntigravityOauth validation guard in src/config.rs) collapses
+        // daily_api_endpoint onto api_endpoint.
         let store = AntigravityAuthStore::new(
             temp_auth_file("production_default_daily_host"),
             reqwest::Client::new(),
@@ -1389,6 +1430,37 @@ mod tests {
             assert!(
                 !addresses_production_backend(spelling),
                 "{spelling} is not the plain production backend"
+            );
+        }
+    }
+
+    #[test]
+    fn every_config_valid_spelling_of_the_default_host_is_recognised_as_the_default() {
+        // `login_base_url` uses this to tell a slot left at the built-in
+        // default from one the operator declared, so the same spellings the
+        // validator admits for the default must all read as the default — a
+        // byte compare would make that pick depend on capitalization.
+        for spelling in [
+            DEFAULT_API_ENDPOINT,
+            "https://Daily-CloudCode-PA.googleapis.com",
+            "https://daily-cloudcode-pa.googleapis.com/",
+        ] {
+            assert!(
+                addresses_default_backend(spelling),
+                "{spelling} is the default backend"
+            );
+        }
+        for spelling in [
+            API_ENDPOINT,
+            "https://daily-cloudcode-pa.googleapis.com:8443",
+            "https://daily-cloudcode-pa.googleapis.com/debug-proxy",
+            "http://daily-cloudcode-pa.googleapis.com",
+            "http://127.0.0.1:8080",
+            "not a url",
+        ] {
+            assert!(
+                !addresses_default_backend(spelling),
+                "{spelling} is not the plain default backend"
             );
         }
     }

--- a/src/auth/antigravity/mod.rs
+++ b/src/auth/antigravity/mod.rs
@@ -126,7 +126,7 @@ pub fn routed_antigravity_credential_error(config: &Config) -> Option<String> {
 
 /// The Code Assist host `shunt login antigravity` runs project discovery
 /// against: the `base_url` of the Antigravity upstream the config routes to,
-/// else of the only one it declares, else the production default.
+/// else of the only one it declares, else [`auth::DEFAULT_API_ENDPOINT`].
 ///
 /// Looking a slot up by name alone is not enough, and that distinction is
 /// load-bearing rather than defensive. `[providers.antigravity]` is only a
@@ -145,12 +145,13 @@ pub fn routed_antigravity_credential_error(config: &Config) -> Option<String> {
 /// `resolve_credential`.
 pub fn login_base_url(config: Option<&Config>) -> String {
     let Some(config) = config else {
-        return auth::API_ENDPOINT.to_string();
+        return auth::DEFAULT_API_ENDPOINT.to_string();
     };
 
     // Prefer the upstreams the config can actually send a request to. A
     // non-ordered `[providers.*]` config keeps every built-in table merged in,
-    // so the seeded `antigravity` slot exists — pointing at production — even
+    // so the seeded `antigravity` slot exists — pointing at the default
+    // backend — even
     // when the operator declared their own Antigravity provider under another
     // name and routed to that one. Picking by name alone would then discover
     // against production while the request path used the configured host,
@@ -173,7 +174,7 @@ pub fn login_base_url(config: Option<&Config>) -> String {
     let candidates = if routed_vetted.is_empty() {
         // Nothing Antigravity-shaped is routed, so there is no intent to read
         // off the routes — but the seeded `antigravity` table is still in the
-        // map, and left at the production default it is not a declaration
+        // map, and left at the built-in default it is not a declaration
         // either. Dropping it here cannot widen where the token can go: the
         // host it names is exactly the fallback this function returns when it
         // finds no signal at all. Keeping it would instead outvote the one
@@ -182,7 +183,7 @@ pub fn login_base_url(config: Option<&Config>) -> String {
         vetted
             .into_iter()
             .filter(|(name, provider)| {
-                *name != "antigravity" || !auth::addresses_production_backend(&provider.base_url)
+                *name != "antigravity" || !auth::addresses_default_backend(&provider.base_url)
             })
             .collect()
     } else {
@@ -196,7 +197,7 @@ pub fn login_base_url(config: Option<&Config>) -> String {
     // reach another host the operator themself pinned — never an arbitrary
     // one.
     match candidates.as_slice() {
-        [] => auth::API_ENDPOINT.to_string(),
+        [] => auth::DEFAULT_API_ENDPOINT.to_string(),
         [(_, provider)] => provider.base_url.clone(),
         // Several qualify. The built-in name still disambiguates when it is
         // one of them: an operator who configured that slot named the upstream
@@ -209,7 +210,7 @@ pub fn login_base_url(config: Option<&Config>) -> String {
             // Otherwise there is no operator-intended pick to infer — a
             // failover chain can hold both a debug proxy and the real backend.
             // Guessing would provision a project against a backend the
-            // operator never chose, so say so and use the production default,
+            // operator never chose, so say so and use the built-in default,
             // which is what login targeted before it read config at all.
             tracing::warn!(
                 candidates = ?several.iter().map(|(name, _)| *name).collect::<Vec<_>>(),
@@ -217,7 +218,7 @@ pub fn login_base_url(config: Option<&Config>) -> String {
                  `antigravity`; signing in against the default Code Assist endpoint. Name the \
                  one to log in to `antigravity` to discover the project against it."
             );
-            auth::API_ENDPOINT.to_string()
+            auth::DEFAULT_API_ENDPOINT.to_string()
         }
     }
 }
@@ -405,7 +406,7 @@ mod tests {
 
             assert_eq!(
                 login_base_url(Some(&config)),
-                super::auth::API_ENDPOINT,
+                super::auth::DEFAULT_API_ENDPOINT,
                 "kind {kind:?} with auth {auth:?} must not redirect discovery"
             );
         }
@@ -437,8 +438,8 @@ mod tests {
         // A failover chain can hold both a debug proxy and the real backend.
         // With no built-in name to disambiguate there is no operator-intended
         // pick to infer, and guessing would provision a project against a
-        // backend they never chose — so fall back to production rather than
-        // take the first one.
+        // backend they never chose — so fall back to the built-in default
+        // rather than take the first one.
         let mut config = base();
         let provider = config
             .providers
@@ -455,7 +456,10 @@ mod tests {
             config.providers.insert(name.to_string(), candidate);
         }
 
-        assert_eq!(login_base_url(Some(&config)), super::auth::API_ENDPOINT);
+        assert_eq!(
+            login_base_url(Some(&config)),
+            super::auth::DEFAULT_API_ENDPOINT
+        );
     }
 
     #[test]
@@ -508,19 +512,18 @@ mod tests {
     }
 
     #[test]
-    fn login_treats_every_production_spelling_of_the_built_in_slot_as_no_signal() {
+    fn login_treats_every_default_spelling_of_the_built_in_slot_as_no_signal() {
         // Whether the seeded `antigravity` table was left alone or spelled out
-        // by hand, a slot that addresses production names exactly the host
-        // login falls back to — so it never outvotes a declared upstream. The
-        // check parses the URL rather than comparing bytes, which is why the
-        // cased, trailing-slash, and explicit-port spellings behave the same;
+        // by hand, a slot that addresses the built-in default names exactly
+        // the host login falls back to — so it never outvotes a declared
+        // upstream. The check parses the URL rather than comparing bytes,
+        // which is why the cased and trailing-slash spellings behave the same;
         // a byte compare would make the pick depend on capitalization, the
-        // defect `addresses_production_backend` exists to prevent.
+        // defect `addresses_default_backend` exists to prevent.
         for spelling in [
-            "https://cloudcode-pa.googleapis.com",
-            "https://cloudcode-pa.googleapis.com/",
-            "https://CloudCode-PA.googleapis.com",
-            "https://cloudcode-pa.googleapis.com:443",
+            "https://daily-cloudcode-pa.googleapis.com",
+            "https://daily-cloudcode-pa.googleapis.com/",
+            "https://Daily-CloudCode-PA.googleapis.com",
         ] {
             let mut config = base();
             let mut provider = config
@@ -545,10 +548,10 @@ mod tests {
     }
 
     #[test]
-    fn login_falls_back_to_production_without_a_config() {
+    fn login_falls_back_to_the_default_backend_without_a_config() {
         // `shunt login antigravity` must still work when no config loads at
         // all — that is the whole reason main.rs treats the load as optional.
-        assert_eq!(login_base_url(None), super::auth::API_ENDPOINT);
+        assert_eq!(login_base_url(None), super::auth::DEFAULT_API_ENDPOINT);
     }
 
     /// A legacy `[providers.*]` config with the operator's own Antigravity
@@ -666,7 +669,10 @@ mod tests {
         });
         config.providers.remove("antigravity");
 
-        assert_eq!(login_base_url(Some(&config)), super::auth::API_ENDPOINT);
+        assert_eq!(
+            login_base_url(Some(&config)),
+            super::auth::DEFAULT_API_ENDPOINT
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1917,6 +1917,26 @@ pub fn host_is_google_codeassist(host: &str) -> bool {
     host == "cloudcode-pa.googleapis.com"
 }
 
+/// Whether `host` is the `daily-` Code Assist control plane
+/// (`daily-cloudcode-pa.googleapis.com`). This is the backend the Antigravity
+/// client itself addresses for both discovery and inference, and is shunt's
+/// default for `kind = "antigravity"`.
+pub fn host_is_antigravity_daily(host: &str) -> bool {
+    host == "daily-cloudcode-pa.googleapis.com"
+}
+
+/// Whether `host` is a backend an `antigravity_oauth` provider may address.
+///
+/// Deliberately wider than [`host_is_google_codeassist`] and deliberately not
+/// "any googleapis.com host": the Antigravity backend answers on the `daily-`
+/// control plane as well as on production, and the two are the only hosts that
+/// answer for Antigravity. Every other `googleapis.com` name — the `sandbox`
+/// spellings included — is a different product, so a subscription bearer must
+/// not reach it.
+pub fn host_is_antigravity_backend(host: &str) -> bool {
+    host_is_google_codeassist(host) || host_is_antigravity_daily(host)
+}
+
 /// Whether `host` belongs to Kimi (`kimi.com` or any subdomain, which covers
 /// the measured `api.kimi.com` API host). Used to reject a `kimi_oauth`
 /// provider pointed at a non-Kimi host, so shunt never leaks a Kimi Code
@@ -2065,7 +2085,7 @@ pub enum ConfigError {
     GoogleOauthNotHttps { provider: String },
     #[error("providers.{provider} uses auth = \"antigravity_oauth\" but kind is not \"antigravity\"; another adapter would forward the client's own credential instead of the Antigravity token")]
     AntigravityOauthWrongKind { provider: String },
-    #[error("providers.{provider} uses auth = \"antigravity_oauth\" but base_url host {host} is not a googleapis.com host; refusing to send a subscription token off-origin")]
+    #[error("providers.{provider} uses auth = \"antigravity_oauth\" but base_url host {host} is neither daily-cloudcode-pa.googleapis.com nor cloudcode-pa.googleapis.com; refusing to send a subscription token off-origin")]
     AntigravityOauthNonGoogleHost { provider: String, host: String },
     #[error("providers.{provider} uses auth = \"antigravity_oauth\" but base_url is not https; refusing to send a subscription token over plaintext")]
     AntigravityOauthNotHttps { provider: String },
@@ -2509,9 +2529,11 @@ impl Default for Config {
             (
                 // Antigravity over its native HTTP backend, authenticated with
                 // `shunt login antigravity`. Same service the `agy` CLI reaches,
-                // without the subprocess.
+                // without the subprocess — including the `daily-` control
+                // plane that client addresses for both discovery and
+                // inference.
                 "antigravity".to_string(),
-                ProviderConfig::antigravity("https://cloudcode-pa.googleapis.com"),
+                ProviderConfig::antigravity("https://daily-cloudcode-pa.googleapis.com"),
             ),
             (
                 // Local Antigravity CLI binary (`agy`) execution for Gemini
@@ -3398,9 +3420,9 @@ impl Config {
             }
             // Mirrors the `google_oauth` guards above: the Antigravity token is
             // a subscription bearer on the same Google host family, so it must
-            // stay on a googleapis.com host over https and be carried by the
-            // adapter that injects it rather than one that forwards the
-            // client's own credential.
+            // stay on one of the two Antigravity backends over https and be
+            // carried by the adapter that injects it rather than one that
+            // forwards the client's own credential.
             if provider.auth == AuthMode::AntigravityOauth {
                 if provider.kind != ProviderKind::Antigravity {
                     return Err(ConfigError::AntigravityOauthWrongKind {
@@ -3414,7 +3436,7 @@ impl Config {
                             provider: name.clone(),
                         });
                     }
-                    if !host_is_google_codeassist(host) {
+                    if !host_is_antigravity_backend(host) {
                         return Err(ConfigError::AntigravityOauthNonGoogleHost {
                             provider: name.clone(),
                             host: host.to_string(),
@@ -6952,7 +6974,7 @@ id = "claude-sonnet-5"
         let native = config.provider("antigravity").unwrap();
         assert_eq!(native.kind, ProviderKind::Antigravity);
         assert_eq!(native.auth, AuthMode::AntigravityOauth);
-        assert_eq!(native.base_url, "https://cloudcode-pa.googleapis.com");
+        assert_eq!(native.base_url, "https://daily-cloudcode-pa.googleapis.com");
 
         // The `agy` subprocess transport kept its behaviour under a new name.
         let cli = config.provider("antigravity-cli").unwrap();
@@ -7201,6 +7223,62 @@ id = "claude-sonnet-5"
             ConfigError::AntigravityOauthNotHttps { .. }
         ));
         assert!(error.to_string().contains("plaintext"));
+    }
+
+    #[test]
+    fn antigravity_oauth_accepts_both_antigravity_backends() {
+        // The `daily-` control plane is the default and the only host that
+        // serves the Antigravity catalog; production stays valid for operators
+        // who still point at it.
+        for base_url in [
+            "https://daily-cloudcode-pa.googleapis.com",
+            "https://cloudcode-pa.googleapis.com",
+        ] {
+            let mut config = Config::default();
+            config.providers.get_mut("antigravity").unwrap().base_url = base_url.to_string();
+            config
+                .validate()
+                .unwrap_or_else(|error| panic!("{base_url} must validate: {error}"));
+        }
+    }
+
+    #[test]
+    fn antigravity_oauth_rejects_other_googleapis_hosts() {
+        // Widening the guard to the `daily-` host must not widen it to the
+        // whole domain: the sandbox spelling and every other googleapis.com
+        // product are different backends the subscription bearer must not
+        // reach.
+        for host in [
+            "daily-cloudcode-pa.sandbox.googleapis.com",
+            "generativelanguage.googleapis.com",
+            "storage.googleapis.com",
+        ] {
+            let mut config = Config::default();
+            config.providers.get_mut("antigravity").unwrap().base_url = format!("https://{host}");
+            let error = config.validate().unwrap_err();
+            assert!(matches!(
+                error,
+                ConfigError::AntigravityOauthNonGoogleHost { .. }
+            ));
+            assert!(error.to_string().contains(host));
+        }
+    }
+
+    #[test]
+    fn google_oauth_still_rejects_the_antigravity_daily_host() {
+        // The wider host predicate belongs to `antigravity_oauth` alone. Code
+        // Assist's own guard stays pinned to the production host.
+        let mut config = Config::default();
+        config.providers.get_mut("gemini").unwrap().base_url =
+            "https://daily-cloudcode-pa.googleapis.com".to_string();
+        let error = config.validate().unwrap_err();
+        assert!(matches!(
+            error,
+            ConfigError::GoogleOauthNonGoogleHost { .. }
+        ));
+        assert!(error
+            .to_string()
+            .contains("daily-cloudcode-pa.googleapis.com"));
     }
 
     #[test]

--- a/src/model/antigravity_request.rs
+++ b/src/model/antigravity_request.rs
@@ -1,0 +1,540 @@
+//! Antigravity request shaping: the agent envelope and catalog model ids.
+//!
+//! Antigravity speaks the same Code Assist protocol the `gemini` provider
+//! does — [`crate::model::gemini_request`] still builds the inner
+//! `generateContent` body — but it is addressed as the Antigravity client
+//! rather than as the Gemini CLI, and its catalog names models differently.
+//! Both differences live here so the Code Assist path stays untouched.
+
+use serde_json::{json, Value};
+
+/// Client identity the Antigravity client sends on every request.
+const ANTIGRAVITY_USER_AGENT: &str = "antigravity";
+const ANTIGRAVITY_REQUEST_TYPE: &str = "agent";
+/// Only Gemini ids carry an effort suffix in the Antigravity catalog.
+const ANTIGRAVITY_GEMINI_PREFIX: &str = "gemini-";
+const ANTIGRAVITY_EFFORT_TIERS: [&str; 3] = ["low", "medium", "high"];
+const ANTIGRAVITY_DEFAULT_TIER: &str = "medium";
+const THINKING_LOW_BUDGET: u64 = 2048;
+const THINKING_MEDIUM_BUDGET: u64 = 8192;
+/// Bound on a rendered `sessionId`, matching the reference client's
+/// `generateSessionID` (`rand.Int63n(9_000_000_000_000_000_000)` in
+/// router-for-me/CLIProxyAPI, whose stable variant masks to
+/// `0x7FFF_FFFF_FFFF_FFFF`). Deliberately below `i64::MAX` rather than the
+/// 19-digit ceiling of `10^19`: that ceiling admits values no Antigravity
+/// client ever emits, and a backend parsing the field as a signed 64-bit
+/// integer would reject them.
+const SESSION_ID_MODULUS: u64 = 9_000_000_000_000_000_000;
+
+/// Wrap a Gemini `generateContent` request in the Antigravity *agent*
+/// envelope.
+///
+/// The Antigravity client sends the Code Assist protocol plus its own
+/// identity: `userAgent`, `requestType`, a per-request `requestId`, and a
+/// `sessionId` inside the inner request. The field set mirrors
+/// `geminiToAntigravity` in router-for-me/CLIProxyAPI
+/// (`internal/runtime/executor/antigravity_executor_request.go`), which is the
+/// only public description of the shape that client sends.
+///
+/// A live probe reached `200` on the daily host with this envelope and a
+/// suffixed model id. It did not isolate the envelope from the host, so this
+/// mirrors the client rather than asserting the backend rejects the plain
+/// Code Assist envelope of [`crate::model::gemini_request::wrap_code_assist_envelope`].
+pub fn wrap_antigravity_envelope(
+    model: &str,
+    project: &str,
+    request: Value,
+    request_id: &str,
+    session_id: &str,
+) -> Value {
+    let mut request = request;
+    if let Some(object) = request.as_object_mut() {
+        object.insert("sessionId".to_string(), json!(session_id));
+    }
+    json!({
+        "model": model,
+        "project": project,
+        "userAgent": ANTIGRAVITY_USER_AGENT,
+        "requestType": ANTIGRAVITY_REQUEST_TYPE,
+        "requestId": request_id,
+        "request": request
+    })
+}
+
+/// A fresh `requestId` for one Antigravity request, in the `agent-<uuid v4>`
+/// shape the reference client uses.
+pub fn antigravity_request_id() -> String {
+    format!("agent-{}", uuid::Uuid::new_v4())
+}
+
+/// The `sessionId` for a *translated* Gemini request.
+///
+/// The backend correlates turns by this value, so it is derived from the first
+/// user turn's first text part rather than drawn at random: a follow-up turn
+/// in the same conversation repeats that opening text and lands on the same
+/// session, mirroring `generateStableSessionID` in CLIProxyAPI. A request with
+/// no user text at all (an empty or tool-only history) has nothing stable to
+/// key on and gets a random id instead of colliding with every other such
+/// request.
+pub fn antigravity_session_id(request: &Value) -> String {
+    let seed = request
+        .get("contents")
+        .and_then(Value::as_array)
+        .and_then(|contents| {
+            contents
+                .iter()
+                .find(|content| content.get("role").and_then(Value::as_str) == Some("user"))
+        })
+        .and_then(|content| content.get("parts"))
+        .and_then(Value::as_array)
+        .and_then(|parts| {
+            parts
+                .iter()
+                .find_map(|part| part.get("text").and_then(Value::as_str))
+        });
+
+    let digits = match seed {
+        Some(text) => stable_session_digits(text),
+        None => rand::random::<u64>() % SESSION_ID_MODULUS,
+    };
+    format!("-{digits}")
+}
+
+/// FNV-1a, spelled out rather than reached for through `DefaultHasher`: this
+/// value is a session identity the backend correlates across requests, so it
+/// must not change when the standard library's default hasher does. The
+/// modulus keeps the rendering inside the 19 decimal digits the reference
+/// client emits.
+fn stable_session_digits(text: &str) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in text.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash % SESSION_ID_MODULUS
+}
+
+/// Resolve the Antigravity catalog id for `upstream_model`.
+///
+/// The Antigravity backend publishes its Gemini models with the effort tier in
+/// the id (`gemini-3.8-flash-medium`, `gemini-3.1-pro-high`) and serves no bare
+/// slug — a bare id is a 404 on the daily host and a misleading
+/// `429 RESOURCE_EXHAUSTED` on production. Rather than make every operator
+/// hand-write the suffix, the tier is resolved from the strongest signal
+/// available, in order: an explicit `effort` on the route or provider, the
+/// inbound request's `output_config.effort`, an enabled `thinking` budget, and
+/// finally `medium`. Whichever source wins, its value is normalized by
+/// [`fold_effort`] onto a tier the catalog publishes.
+///
+/// Ids that are not Gemini (`claude-sonnet-4-6`, `gpt-oss-120b-medium`) and ids
+/// that already carry a tier are returned untouched.
+pub fn antigravity_upstream_model(
+    upstream_model: &str,
+    route_effort: Option<&str>,
+    request: &Value,
+) -> String {
+    let Some((tier, source)) = antigravity_effort_tier(upstream_model, route_effort, request)
+    else {
+        return upstream_model.to_string();
+    };
+    let resolved = format!("{upstream_model}-{tier}");
+    tracing::debug!(
+        upstream_model,
+        resolved = %resolved,
+        source,
+        "resolved antigravity effort tier"
+    );
+    resolved
+}
+
+/// The tier to append, plus the signal that decided it, or `None` when
+/// `upstream_model` must be sent as written.
+fn antigravity_effort_tier(
+    upstream_model: &str,
+    route_effort: Option<&str>,
+    request: &Value,
+) -> Option<(String, &'static str)> {
+    if !upstream_model.starts_with(ANTIGRAVITY_GEMINI_PREFIX)
+        || ANTIGRAVITY_EFFORT_TIERS
+            .iter()
+            .any(|tier| ends_with_tier(upstream_model, tier))
+    {
+        return None;
+    }
+
+    let (tier, source) = if let Some(effort) = route_effort {
+        // Operator intent wins over every request signal, but the *value* is
+        // normalized the same way a request's is: `xhigh` and `max` name
+        // levels the Antigravity catalog has never published, and appending
+        // one verbatim only produces an id the backend cannot serve.
+        let tier = fold_effort(effort)
+            .map(str::to_string)
+            // No allowlist for the operator: the backend catalog is the
+            // authority on which tiers exist, so a tier shunt has not heard of
+            // must be reachable without a release.
+            .unwrap_or_else(|| effort.to_string());
+        (tier, "config")
+    } else if let Some(effort) = request
+        .pointer("/output_config/effort")
+        .and_then(Value::as_str)
+    {
+        // Unlike the operator's own `effort`, this value comes from the
+        // inbound request, so an unrecognised one falls back to the default
+        // rather than being pasted into the upstream model id.
+        let tier = fold_effort(effort).unwrap_or(ANTIGRAVITY_DEFAULT_TIER);
+        (tier.to_string(), "output_config")
+    } else if request.pointer("/thinking/type").and_then(Value::as_str) == Some("enabled") {
+        // An enabled block that names no budget resolves to the same default
+        // the translated request carries in `thinkingConfig.thinkingBudget`,
+        // so the tier and the budget describe one request rather than two.
+        let budget = request
+            .pointer("/thinking/budget_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(crate::model::gemini_request::DEFAULT_THINKING_BUDGET);
+        (thinking_budget_tier(budget).to_string(), "thinking")
+    } else {
+        (ANTIGRAVITY_DEFAULT_TIER.to_string(), "default")
+    };
+
+    Some((clamp_tier_to_family(upstream_model, tier), source))
+}
+
+fn ends_with_tier(model: &str, tier: &str) -> bool {
+    model
+        .strip_suffix(tier)
+        .is_some_and(|head| head.ends_with('-'))
+}
+
+/// Normalize one effort level — from a route/provider `effort` or from a
+/// request's `output_config.effort` — onto the tiers Antigravity publishes.
+///
+/// Claude Code sends `low|medium|high|xhigh|max`; the catalog stops at `high`,
+/// so the two levels above it fold onto it. `None` means the level is outside
+/// that vocabulary; each caller decides what to do with it, since an operator
+/// naming a tier shunt has not heard of and a client sending noise deserve
+/// different answers.
+fn fold_effort(effort: &str) -> Option<&'static str> {
+    match effort {
+        "low" => Some("low"),
+        "medium" => Some("medium"),
+        "high" | "xhigh" | "max" => Some("high"),
+        _ => None,
+    }
+}
+
+/// `thinking.budget_tokens` is the only quantitative signal a client that does
+/// not send `output_config` gives about how much reasoning it wants. The
+/// thresholds are the same ones Claude Code's own tiers land on.
+fn thinking_budget_tier(budget: u64) -> &'static str {
+    if budget <= THINKING_LOW_BUDGET {
+        "low"
+    } else if budget <= THINKING_MEDIUM_BUDGET {
+        "medium"
+    } else {
+        "high"
+    }
+}
+
+/// The Pro family is published as `-low` and `-high` only, so a derived (or
+/// pinned) `medium` would 404. Flash keeps all three.
+fn clamp_tier_to_family(upstream_model: &str, tier: String) -> String {
+    if tier == "medium" && upstream_model.contains("-pro") {
+        return "high".to_string();
+    }
+    tier
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn the_antigravity_envelope_carries_the_agent_identity() {
+        let wrapped = wrap_antigravity_envelope(
+            "gemini-3.8-flash-medium",
+            "test-proj-789",
+            json!({ "contents": [] }),
+            "agent-6f0c9d4e-0000-4000-8000-000000000000",
+            "-1234567890123456789",
+        );
+
+        assert_eq!(wrapped["model"], "gemini-3.8-flash-medium");
+        assert_eq!(wrapped["project"], "test-proj-789");
+        assert_eq!(wrapped["userAgent"], "antigravity");
+        assert_eq!(wrapped["requestType"], "agent");
+        assert_eq!(
+            wrapped["requestId"],
+            "agent-6f0c9d4e-0000-4000-8000-000000000000"
+        );
+        // The session id rides *inside* the inner request, not beside it.
+        assert_eq!(wrapped["request"]["sessionId"], "-1234567890123456789");
+        assert!(wrapped["request"].get("contents").is_some());
+    }
+
+    #[test]
+    fn a_request_id_is_a_fresh_agent_prefixed_uuid() {
+        let first = antigravity_request_id();
+        let second = antigravity_request_id();
+
+        assert!(first.starts_with("agent-"), "{first}");
+        assert_ne!(first, second, "requestId is per request");
+        uuid::Uuid::parse_str(first.trim_start_matches("agent-")).expect("uuid v4 suffix");
+    }
+
+    #[test]
+    fn a_session_id_is_stable_for_the_same_opening_user_text() {
+        // The backend correlates a conversation by this value, so the same
+        // opening turn must reach the same session on every follow-up request.
+        let request = json!({
+            "contents": [
+                {"role": "user", "parts": [{"text": "refactor the parser"}]},
+                {"role": "model", "parts": [{"text": "on it"}]},
+            ]
+        });
+        let other = json!({
+            "contents": [{"role": "user", "parts": [{"text": "refactor the lexer"}]}]
+        });
+
+        let session_id = antigravity_session_id(&request);
+        assert_eq!(session_id, antigravity_session_id(&request));
+        assert_ne!(session_id, antigravity_session_id(&other));
+
+        let digits = session_id
+            .strip_prefix('-')
+            .expect("a session id is a leading dash then decimal digits");
+        assert!(digits.chars().all(|character| character.is_ascii_digit()));
+        assert!(digits.len() <= 19, "{digits} is longer than 19 digits");
+    }
+
+    #[test]
+    fn a_session_id_always_fits_in_a_signed_64_bit_integer() {
+        // The reference client draws from `Int63n`, so every session id it
+        // emits is a positive i64. A 10^19 modulus would have kept the string
+        // inside 19 digits while still producing values above `i64::MAX`,
+        // which a backend parsing this field as a signed integer rejects.
+        let mut seeds: Vec<String> = (0..256).map(|index| format!("turn {index}")).collect();
+        seeds.extend([
+            String::new(),
+            "\u{ac00}\u{b098}\u{b2e4}".to_string(),
+            "x".repeat(4096),
+        ]);
+
+        for seed in &seeds {
+            let request = json!({
+                "contents": [{"role": "user", "parts": [{"text": seed}]}]
+            });
+            let session_id = antigravity_session_id(&request);
+            let digits = session_id
+                .strip_prefix('-')
+                .unwrap_or_else(|| panic!("{session_id} must start with a dash"));
+            assert!(digits.len() <= 19, "{session_id} is longer than 19 digits");
+            digits
+                .parse::<i64>()
+                .unwrap_or_else(|error| panic!("{session_id} must parse as i64: {error}"));
+        }
+
+        // The random fallback is bounded by the same modulus.
+        for _ in 0..256 {
+            let session_id = antigravity_session_id(&json!({ "contents": [] }));
+            let digits = session_id.strip_prefix('-').expect("leading dash");
+            assert!(digits.len() <= 19, "{session_id} is longer than 19 digits");
+            digits.parse::<i64>().expect("random ids parse as i64");
+        }
+    }
+
+    #[test]
+    fn a_session_id_skips_leading_non_user_turns() {
+        // Only the first *user* turn seeds the id; a model turn ahead of it
+        // (a replayed history) must not.
+        let with_model_first = json!({
+            "contents": [
+                {"role": "model", "parts": [{"text": "hello"}]},
+                {"role": "user", "parts": [{"text": "refactor the parser"}]},
+            ]
+        });
+        let user_only = json!({
+            "contents": [{"role": "user", "parts": [{"text": "refactor the parser"}]}]
+        });
+
+        assert_eq!(
+            antigravity_session_id(&with_model_first),
+            antigravity_session_id(&user_only)
+        );
+    }
+
+    #[test]
+    fn a_session_id_without_user_text_is_random_rather_than_shared() {
+        // Nothing stable to key on, so every such request gets its own session
+        // instead of all of them colliding on one.
+        let request = json!({ "contents": [] });
+
+        let first = antigravity_session_id(&request);
+        assert_ne!(first, antigravity_session_id(&request));
+        let digits = first.strip_prefix('-').expect("leading dash");
+        assert!(digits.chars().all(|character| character.is_ascii_digit()));
+        assert!(digits.len() <= 19, "{digits} is longer than 19 digits");
+    }
+
+    #[test]
+    fn ids_that_need_no_effort_suffix_are_sent_as_written() {
+        // Rule 1: non-Gemini catalog ids carry their tier in the published
+        // name (or have none), and a hand-written suffix is the operator's.
+        let no_signals = json!({});
+        for model in [
+            "claude-sonnet-4-6",
+            "claude-opus-4-6-thinking",
+            "gpt-oss-120b-medium",
+            "gemini-3.8-flash-medium",
+            "gemini-3.1-pro-high",
+            "gemini-3.6-flash-low",
+        ] {
+            assert_eq!(
+                antigravity_upstream_model(model, None, &no_signals),
+                model,
+                "{model} must be sent as written"
+            );
+            assert_eq!(
+                antigravity_upstream_model(model, Some("high"), &no_signals),
+                model,
+                "{model} must be sent as written even with a configured effort"
+            );
+        }
+    }
+
+    #[test]
+    fn a_configured_effort_pins_the_suffix() {
+        // Rule 2: explicit operator intent wins over every request signal —
+        // here over an `output_config.effort` that says something else.
+        let request = json!({"output_config": {"effort": "low"}});
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.6-flash", Some("high"), &request),
+            "gemini-3.6-flash-high"
+        );
+
+        // Winning does not mean escaping normalization: `xhigh` and `max` are
+        // levels the catalog has never published, so they fold onto `high`
+        // exactly as a request's would. A level shunt does not know is passed
+        // through untouched, so an operator can name a future tier without
+        // waiting for a release.
+        for (effort, expected) in [
+            ("low", "gemini-3.6-flash-low"),
+            ("medium", "gemini-3.6-flash-medium"),
+            ("high", "gemini-3.6-flash-high"),
+            ("xhigh", "gemini-3.6-flash-high"),
+            ("max", "gemini-3.6-flash-high"),
+            ("extra-low", "gemini-3.6-flash-extra-low"),
+        ] {
+            assert_eq!(
+                antigravity_upstream_model("gemini-3.6-flash", Some(effort), &json!({})),
+                expected,
+                "configured effort {effort}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_request_effort_decides_when_nothing_is_configured() {
+        // Rule 3: Claude Code sends low|medium|high|xhigh|max; the catalog
+        // stops at high, so the two levels above it fold onto it. A level from
+        // outside that vocabulary is *not* passed through here — this value
+        // comes from the inbound request, so it falls back to the default
+        // rather than reaching the upstream model id.
+        for (effort, expected) in [
+            ("low", "gemini-3.6-flash-low"),
+            ("medium", "gemini-3.6-flash-medium"),
+            ("high", "gemini-3.6-flash-high"),
+            ("xhigh", "gemini-3.6-flash-high"),
+            ("max", "gemini-3.6-flash-high"),
+            ("extra-low", "gemini-3.6-flash-medium"),
+        ] {
+            let request = json!({"output_config": {"effort": effort}});
+            assert_eq!(
+                antigravity_upstream_model("gemini-3.6-flash", None, &request),
+                expected,
+                "output_config.effort {effort}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_thinking_budget_decides_when_no_effort_is_sent() {
+        // Rule 4, at both threshold boundaries. An enabled block with no
+        // budget is not "as much as possible": the translated request sends
+        // the 1024 default in `thinkingConfig.thinkingBudget`, so the tier has
+        // to describe that same budget, which lands in `low`.
+        for (budget, expected) in [
+            (Some(2048), "gemini-3.6-flash-low"),
+            (Some(2049), "gemini-3.6-flash-medium"),
+            (Some(8192), "gemini-3.6-flash-medium"),
+            (Some(8193), "gemini-3.6-flash-high"),
+            (None, "gemini-3.6-flash-low"),
+        ] {
+            let thinking = match budget {
+                Some(budget) => json!({"type": "enabled", "budget_tokens": budget}),
+                None => json!({"type": "enabled"}),
+            };
+            let request = json!({"thinking": thinking});
+            assert_eq!(
+                antigravity_upstream_model("gemini-3.6-flash", None, &request),
+                expected,
+                "thinking budget {budget:?}"
+            );
+        }
+
+        // A disabled thinking block is not a signal.
+        let disabled = json!({"thinking": {"type": "disabled", "budget_tokens": 100}});
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.6-flash", None, &disabled),
+            "gemini-3.6-flash-medium"
+        );
+    }
+
+    #[test]
+    fn a_bare_gemini_id_with_no_signals_at_all_resolves_to_medium() {
+        // Rule 5. The bare id itself is never served — a 404 on the daily host
+        // and a misleading 429 on production — so there is no "leave it alone"
+        // option here.
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.6-flash", None, &json!({})),
+            "gemini-3.6-flash-medium"
+        );
+    }
+
+    #[test]
+    fn the_pro_family_has_no_medium_tier() {
+        // Rule 6: Pro is published as `-low` / `-high` only, so a medium from
+        // any source clamps up rather than 404ing.
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.1-pro", None, &json!({})),
+            "gemini-3.1-pro-high"
+        );
+        let request = json!({"output_config": {"effort": "medium"}});
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.1-pro", None, &request),
+            "gemini-3.1-pro-high"
+        );
+        assert_eq!(
+            antigravity_upstream_model(
+                "gemini-3.1-pro",
+                None,
+                &json!({"thinking": {"type": "enabled", "budget_tokens": 4096}})
+            ),
+            "gemini-3.1-pro-high"
+        );
+        // Low still reaches Pro, and Flash keeps its medium.
+        assert_eq!(
+            antigravity_upstream_model(
+                "gemini-3.1-pro",
+                None,
+                &json!({"output_config": {"effort": "low"}})
+            ),
+            "gemini-3.1-pro-low"
+        );
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.8-flash", None, &json!({})),
+            "gemini-3.8-flash-medium"
+        );
+    }
+}

--- a/src/model/antigravity_request.rs
+++ b/src/model/antigravity_request.rs
@@ -71,29 +71,26 @@ pub fn antigravity_request_id() -> String {
 
 /// The `sessionId` for a *translated* Gemini request.
 ///
-/// The backend correlates turns by this value, so it is derived from the first
-/// user turn's first text part rather than drawn at random: a follow-up turn
-/// in the same conversation repeats that opening text and lands on the same
-/// session, mirroring `generateStableSessionID` in CLIProxyAPI. A request with
-/// no user text at all (an empty or tool-only history) has nothing stable to
-/// key on and gets a random id instead of colliding with every other such
-/// request.
+/// The backend correlates turns by this value, so it is derived from the
+/// earliest user text in the history rather than drawn at random: a follow-up
+/// turn in the same conversation repeats that opening text and lands on the
+/// same session, mirroring `generateStableSessionID` in CLIProxyAPI. The scan
+/// covers every user turn, not only the first — an opening turn that is an
+/// image or a tool result alone would otherwise push every follow-up onto a
+/// fresh random id. A request with no user text at all (an empty or tool-only
+/// history) has nothing stable to key on and gets a random id instead of
+/// colliding with every other such request.
 pub fn antigravity_session_id(request: &Value) -> String {
     let seed = request
         .get("contents")
         .and_then(Value::as_array)
-        .and_then(|contents| {
-            contents
-                .iter()
-                .find(|content| content.get("role").and_then(Value::as_str) == Some("user"))
-        })
-        .and_then(|content| content.get("parts"))
-        .and_then(Value::as_array)
-        .and_then(|parts| {
-            parts
-                .iter()
-                .find_map(|part| part.get("text").and_then(Value::as_str))
-        });
+        .into_iter()
+        .flatten()
+        .filter(|content| content.get("role").and_then(Value::as_str) == Some("user"))
+        .filter_map(|content| content.get("parts").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .find(|text| !text.is_empty());
 
     let digits = match seed {
         Some(text) => stable_session_digits(text),
@@ -176,8 +173,10 @@ fn antigravity_effort_tier(
             .map(str::to_string)
             // No allowlist for the operator: the backend catalog is the
             // authority on which tiers exist, so a tier shunt has not heard of
-            // must be reachable without a release.
-            .unwrap_or_else(|| effort.to_string());
+            // must be reachable without a release. It still goes out in the
+            // catalog's own spelling — trimmed and lower-cased — so `High`
+            // names the published tier rather than a `-High` id.
+            .unwrap_or_else(|| normalize_effort(effort));
         (tier, "config")
     } else if let Some(effort) = request
         .pointer("/output_config/effort")
@@ -214,17 +213,24 @@ fn ends_with_tier(model: &str, tier: &str) -> bool {
 /// request's `output_config.effort` — onto the tiers Antigravity publishes.
 ///
 /// Claude Code sends `low|medium|high|xhigh|max`; the catalog stops at `high`,
-/// so the two levels above it fold onto it. `None` means the level is outside
-/// that vocabulary; each caller decides what to do with it, since an operator
-/// naming a tier shunt has not heard of and a client sending noise deserve
-/// different answers.
+/// so the two levels above it fold onto it. Matching is case-insensitive and
+/// ignores surrounding whitespace, so a hand-written `High` is the published
+/// tier rather than a level shunt has never seen. `None` means the level is
+/// outside that vocabulary; each caller decides what to do with it, since an
+/// operator naming a tier shunt has not heard of and a client sending noise
+/// deserve different answers.
 fn fold_effort(effort: &str) -> Option<&'static str> {
-    match effort {
+    match normalize_effort(effort).as_str() {
         "low" => Some("low"),
         "medium" => Some("medium"),
         "high" | "xhigh" | "max" => Some("high"),
         _ => None,
     }
+}
+
+/// The catalog spells its tiers in lower case with no padding.
+fn normalize_effort(effort: &str) -> String {
+    effort.trim().to_ascii_lowercase()
 }
 
 /// `thinking.budget_tokens` is the only quantitative signal a client that does
@@ -242,8 +248,16 @@ fn thinking_budget_tier(budget: u64) -> &'static str {
 
 /// The Pro family is published as `-low` and `-high` only, so a derived (or
 /// pinned) `medium` would 404. Flash keeps all three.
+///
+/// The family is read from the id's `-`-separated segments, so a
+/// `gemini-3-pro-preview`-style variant is still Pro while an id that merely
+/// contains the letters (`-prod`, `-prompt`) is not. It is deliberately not a
+/// suffix check: `high` is published in every family and `medium` is not in
+/// Pro, so mis-reading a Pro variant as Flash costs a `404` where the reverse
+/// only costs a tier.
 fn clamp_tier_to_family(upstream_model: &str, tier: String) -> String {
-    if tier == "medium" && upstream_model.contains("-pro") {
+    let is_pro = upstream_model.split('-').any(|segment| segment == "pro");
+    if tier == "medium" && is_pro {
         return "high".to_string();
     }
     tier
@@ -375,6 +389,44 @@ mod tests {
     }
 
     #[test]
+    fn a_session_id_survives_an_image_only_opening_turn() {
+        // An opening turn that is an image (or a tool result) alone carries no
+        // text; the first user *text* in the history seeds the id instead, so
+        // follow-ups still correlate rather than each drawing a random id.
+        let image_first = json!({
+            "contents": [
+                {"role": "user", "parts": [{"inlineData": {"mimeType": "image/png", "data": "AAAA"}}]},
+                {"role": "model", "parts": [{"text": "I see a chart"}]},
+                {"role": "user", "parts": [{"text": "refactor the parser"}]},
+            ]
+        });
+        // An empty text part is not a seed either: the scan continues past
+        // it rather than stopping and falling back to a random id.
+        let empty_text_first = json!({
+            "contents": [
+                {"role": "user", "parts": [{"text": ""}, {"inlineData": {"mimeType": "image/png", "data": "AAAA"}}]},
+                {"role": "user", "parts": [{"text": "refactor the parser"}]},
+            ]
+        });
+        let user_only = json!({
+            "contents": [{"role": "user", "parts": [{"text": "refactor the parser"}]}]
+        });
+
+        assert_eq!(
+            antigravity_session_id(&image_first),
+            antigravity_session_id(&image_first)
+        );
+        assert_eq!(
+            antigravity_session_id(&image_first),
+            antigravity_session_id(&user_only)
+        );
+        assert_eq!(
+            antigravity_session_id(&empty_text_first),
+            antigravity_session_id(&user_only)
+        );
+    }
+
+    #[test]
     fn a_session_id_without_user_text_is_random_rather_than_shared() {
         // Nothing stable to key on, so every such request gets its own session
         // instead of all of them colliding on one.
@@ -435,6 +487,12 @@ mod tests {
             ("xhigh", "gemini-3.6-flash-high"),
             ("max", "gemini-3.6-flash-high"),
             ("extra-low", "gemini-3.6-flash-extra-low"),
+            // Spelling is normalized before either branch: a hand-written
+            // `High` is the published tier, not a `-High` id the backend
+            // cannot serve, and an unknown level goes out in catalog case.
+            ("High", "gemini-3.6-flash-high"),
+            (" MAX ", "gemini-3.6-flash-high"),
+            ("Extra-Low", "gemini-3.6-flash-extra-low"),
         ] {
             assert_eq!(
                 antigravity_upstream_model("gemini-3.6-flash", Some(effort), &json!({})),
@@ -532,6 +590,16 @@ mod tests {
                 &json!({"thinking": {"type": "enabled", "budget_tokens": 4096}})
             ),
             "gemini-3.1-pro-high"
+        );
+        // The family is a segment of the id, not a suffix: a Pro variant
+        // still clamps, and an id that only contains the letters does not.
+        assert_eq!(
+            antigravity_upstream_model("gemini-3-pro-preview", None, &json!({})),
+            "gemini-3-pro-preview-high"
+        );
+        assert_eq!(
+            antigravity_upstream_model("gemini-3.8-flash-prod", None, &json!({})),
+            "gemini-3.8-flash-prod-medium"
         );
         // Low still reaches Pro, and Flash keeps its medium.
         assert_eq!(

--- a/src/model/antigravity_request.rs
+++ b/src/model/antigravity_request.rs
@@ -24,6 +24,8 @@ const THINKING_MEDIUM_BUDGET: u64 = 8192;
 /// 19-digit ceiling of `10^19`: that ceiling admits values no Antigravity
 /// client ever emits, and a backend parsing the field as a signed 64-bit
 /// integer would reject them.
+/// Bytes of the opening user text that seed the stable session id.
+const SESSION_SEED_LIMIT: usize = 4096;
 const SESSION_ID_MODULUS: u64 = 9_000_000_000_000_000_000;
 
 /// Wrap a Gemini `generateContent` request in the Antigravity *agent*
@@ -104,11 +106,14 @@ pub fn antigravity_session_id(request: &Value) -> String {
 /// value is a session identity the backend correlates across requests, so it
 /// must not change when the standard library's default hasher does. The
 /// modulus keeps the rendering inside the 19 decimal digits the reference
-/// client emits.
+/// client emits. Only the first [`SESSION_SEED_LIMIT`] bytes feed the hash:
+/// an opening turn can carry a whole pasted file, and a bounded prefix is
+/// already enough to tell sessions apart without scanning every byte on the
+/// request path.
 fn stable_session_digits(text: &str) -> u64 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in text.as_bytes() {
-        hash ^= u64::from(*byte);
+    for byte in text.bytes().take(SESSION_SEED_LIMIT) {
+        hash ^= u64::from(byte);
         hash = hash.wrapping_mul(0x100_0000_01b3);
     }
     hash % SESSION_ID_MODULUS
@@ -326,20 +331,25 @@ mod tests {
                 "contents": [{"role": "user", "parts": [{"text": seed}]}]
             });
             let session_id = antigravity_session_id(&request);
+            // The id itself stays out of these messages: CodeQL reads a
+            // formatted `session_id` as sensitive data reaching a log sink.
             let digits = session_id
                 .strip_prefix('-')
-                .unwrap_or_else(|| panic!("{session_id} must start with a dash"));
-            assert!(digits.len() <= 19, "{session_id} is longer than 19 digits");
+                .expect("a session id must start with a dash");
+            assert!(digits.len() <= 19, "a session id is at most 19 digits");
             digits
                 .parse::<i64>()
-                .unwrap_or_else(|error| panic!("{session_id} must parse as i64: {error}"));
+                .unwrap_or_else(|error| panic!("a session id must parse as i64: {error}"));
         }
 
         // The random fallback is bounded by the same modulus.
         for _ in 0..256 {
             let session_id = antigravity_session_id(&json!({ "contents": [] }));
             let digits = session_id.strip_prefix('-').expect("leading dash");
-            assert!(digits.len() <= 19, "{session_id} is longer than 19 digits");
+            assert!(
+                digits.len() <= 19,
+                "a random session id is at most 19 digits"
+            );
             digits.parse::<i64>().expect("random ids parse as i64");
         }
     }

--- a/src/model/gemini_request.rs
+++ b/src/model/gemini_request.rs
@@ -12,6 +12,11 @@ const GEMINI_3_MODEL_PREFIX: &str = "gemini-3";
 const GEMINI_TOOL_USE_ID_PREFIX: &str = "call_gemini_v1_";
 // Google documents this exact value for imported/custom Gemini 3 function-call history.
 const GEMINI_THOUGHT_SIGNATURE_PLACEHOLDER: &str = "context_engineering_is_the_way to_go";
+/// Budget an enabled `thinking` block asks for when it names none. Shared with
+/// `crate::model::antigravity_request`, which reads the same block to pick an
+/// effort tier — the two must not drift apart on what "enabled, no budget"
+/// means.
+pub(crate) const DEFAULT_THINKING_BUDGET: u64 = 1024;
 
 fn bad_request(message: impl Into<String>) -> AdapterError {
     AdapterError {
@@ -440,7 +445,7 @@ fn translate_thinking_config(request: &Value) -> Option<Value> {
             let budget = thinking
                 .get("budget_tokens")
                 .and_then(Value::as_u64)
-                .unwrap_or(1024);
+                .unwrap_or(DEFAULT_THINKING_BUDGET);
             Some(json!({ "thinkingBudget": budget }))
         }
         Some("disabled") => Some(json!({ "thinkingBudget": 0 })),

--- a/src/model/gemini_request/tests.rs
+++ b/src/model/gemini_request/tests.rs
@@ -287,3 +287,20 @@ fn wrap_envelope_creates_code_assist_shape() {
     assert_eq!(wrapped["project"], "test-proj-789");
     assert!(wrapped.get("request").is_some());
 }
+
+#[test]
+fn the_code_assist_envelope_carries_none_of_the_agent_fields() {
+    // The `gemini` provider talks to production Code Assist as the Gemini
+    // CLI. Sending Antigravity's client identity there would misidentify
+    // it, so these fields must never leak onto that path.
+    let wrapped = wrap_code_assist_envelope(
+        "gemini-3-flash-preview",
+        "test-proj-789",
+        json!({ "contents": [] }),
+    );
+
+    for field in ["userAgent", "requestType", "requestId"] {
+        assert!(wrapped.get(field).is_none(), "{field} must not be sent");
+    }
+    assert!(wrapped["request"].get("sessionId").is_none());
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,4 @@
+pub mod antigravity_request;
 pub mod gemini;
 pub mod gemini_request;
 pub mod responses;


### PR DESCRIPTION
## Summary

The built-in `antigravity` provider (native HTTP) failed on every request. The first call came back
`429 RESOURCE_EXHAUSTED "Resource has been exhausted (e.g. check quota)."` — not a real quota state,
but the backend's response to a request that did not look like an Antigravity agent request.

A live probe matrix with a real Antigravity token isolated the working combination:

| Host | Model id | Envelope | Result |
| --- | --- | --- | --- |
| production `cloudcode-pa` | `gemini-3.8-flash` | none | 429 RESOURCE_EXHAUSTED |
| production `cloudcode-pa` | `gemini-3.8-flash-medium` | none | 503 |
| daily `daily-cloudcode-pa` | `gemini-3.8-flash-medium` | agent | 200 |
| daily `daily-cloudcode-pa` | `gemini-3.8-flash` | agent | 404 NOT_FOUND |

The backend catalog (`agy models`) only publishes effort-suffixed ids, so a bare `gemini-*` id has to
be resolved to a tier before the request goes out. The reference implementation is
router-for-me/CLIProxyAPI, `internal/runtime/executor/antigravity_executor_request.go`.

## Milestone / spec

No milestone doc. The investigation and the probe matrix are recorded in the new note
`docs/notes/antigravity-daily-host.md`.

## Changes

- **Daily host by default.** The provider's default `base_url` becomes
  `https://daily-cloudcode-pa.googleapis.com`. The `antigravity_oauth` host guard now accepts
  `daily-cloudcode-pa.googleapis.com` and `cloudcode-pa.googleapis.com` only; the `google_oauth`
  guard is unchanged.
- **Agent envelope.** Antigravity requests carry `userAgent: "antigravity"`,
  `requestType: "agent"`, `requestId: "agent-<uuid>"`, and `request.sessionId` (FNV-1a of the first
  user text).
- **Effort tier resolution** for bare `gemini-*` ids, in order: `[[routes]]` / provider `effort` →
  request `output_config.effort` → `thinking.budget_tokens` (≤2048 low, ≤8192 medium, else high) →
  default `medium`. `xhigh` and `max` fold to `high`; `-pro` ids clamp `medium` up to `high`.
  Already-suffixed ids and non-Gemini ids are left untouched. New module
  `src/model/antigravity_request.rs`.
- **Docs.** README ×4 locales, the site provider page / providers guide / config reference ×4
  locales, the blueprint, and the new note. `wiki/` untouched.

## Notes for reviewers

For operators: bare ids such as `gemini-3.6-flash` keep working through automatic tier resolution.
A hand-written suffix or an explicit `effort` pins the tier. Operators who need the production host
can set `base_url = "https://cloudcode-pa.googleapis.com"`.

The daily host and the agent envelope were changed together, mirroring the reference
implementation, so it is **not** isolated whether either one alone is sufficient.

## Verification

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` — 2271 passed, 0 failed, 2 ignored
- [ ] `site/` `npm run build` / `lint:docs` — not run locally (`node_modules` absent)
- [ ] Live end-to-end request through shunt with the new binary — the probes were raw curl against
      the backend, not through the gateway

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The built-in `antigravity` provider previously sent plain Code Assist requests to `cloudcode-pa.googleapis.com` and failed with misleading quota errors. It now targets `daily-cloudcode-pa.googleapis.com` by default, sends the required agent envelope, and resolves bare Gemini model IDs to effort-suffixed catalog IDs.

**Details**

- Explicit production-host configurations remain valid, while other Google API hosts stay rejected; login without a config now provisions against the daily host.
- Effort resolution uses configured effort, request effort, thinking budget, then `medium`; existing suffixes and non-Gemini IDs remain unchanged.
- Pro models clamp unsupported `medium` tiers to `high`, and Pro family detection uses the id's `-`-separated segments.
- Each request gets a unique request ID, with the session ID seeded from the earliest non-empty user text and bounded to 4096 bytes.
- The `gemini` provider keeps its existing production endpoint and envelope.
- User documentation and the Antigravity blueprint now describe the daily host and model resolution.

<sup>Written for commit de85d11a740065caf57e8c9a35a51d4812952637. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

