### PR TITLE
chore(agent-memory): record the PR #451 review lessons

### DIFF
--- a/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [cubic empty review on clean tree](cubic-empty-review-clean-tree.md) — `-j` without `-b` on a clean tree = silent false-clean `{"issues":[]}`; always add `-b <base>` for committed-branch reviews.
 - [Sentry error Display URL leak (#310)](shunt-sentry-error-display-url-leak.md) — `error_chain` in stream_metrics.rs forwards reqwest URL text past `sanitize_tag`, contradicting docs/running.md's "host name never sent" guarantee.
+- [catalog cache sibling map eviction](shunt-catalog-cache-sibling-map-eviction.md) — antigravity catalog.rs `CATALOG_CACHE`/`CATALOG_FETCH_SLOTS` share a key space; an eviction fix to one map misses the other.

--- a/.claude/agent-memory/review-review-cubic-reviewer/shunt-catalog-cache-sibling-map-eviction.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/shunt-catalog-cache-sibling-map-eviction.md
@@ -1,0 +1,29 @@
+---
+name: shunt-catalog-cache-sibling-map-eviction
+description: shunt antigravity catalog module keeps two maps (CATALOG_CACHE, CATALOG_FETCH_SLOTS) keyed identically — an eviction fix applied to one silently misses the other
+metadata:
+  type: project
+---
+
+In `src/auth/antigravity/catalog.rs`, `CATALOG_CACHE` and `CATALOG_FETCH_SLOTS` are two
+separate `HashMap`s keyed by the same string (`cache_key(base_url, access_token, project_id)`
+— backend plus Code Assist project id, with a token fingerprint only for a project-less
+credential, as merged in PR #451). While that PR was in review, an intermediate working-tree
+state added `evict_expired()` to fix `CATALOG_CACHE`'s unbounded growth from per-credential
+keys but not the equivalent for `CATALOG_FETCH_SLOTS` — same growth pattern, no cleanup at
+all. Both cubic and manual review independently converged on this as the single real finding
+in that diff (P2/minor — slow, small leak). It was fixed before the commit landed: the merged
+`evict_expired()` sweeps both maps (a slot goes when its cache entry is gone and the map holds
+the last `Arc` reference).
+
+**Why:** the two maps look independent (different locks: `std::sync::Mutex` for the cache,
+also `std::sync::Mutex` for slots but holding a `tokio::sync::Mutex` inside) so a fix to one
+doesn't visually demand a matching fix to the other, but they share a key space by
+construction — any change to what the key encodes (e.g. adding the token fingerprint) affects
+both maps' growth rate identically.
+
+**How to apply:** when reviewing a change to `cache_key` / the keying scheme in this file,
+check `CATALOG_FETCH_SLOTS` too, not just `CATALOG_CACHE` — grep for every
+`static ... LazyLock<Mutex<HashMap<String, ...>>>` in the file and confirm each has an
+eviction path if its key can grow unboundedly. See [[new-credential-kind-slot-audit]] for the
+general pattern of a sibling data structure silently missing a fix applied to its counterpart.

--- a/.claude/agent-memory/review-review-cubic-reviewer/shunt-catalog-cache-sibling-map-eviction.md
+++ b/.claude/agent-memory/review-review-cubic-reviewer/shunt-catalog-cache-sibling-map-eviction.md
@@ -1,6 +1,6 @@
 ---
 name: shunt-catalog-cache-sibling-map-eviction
-description: shunt antigravity catalog module keeps two maps (CATALOG_CACHE, CATALOG_FETCH_SLOTS) keyed identically — an eviction fix applied to one silently misses the other
+description: shunt antigravity catalog module keeps two maps (CATALOG_CACHE, CATALOG_FETCH_SLOTS) keyed identically — an eviction fix applied to one silently misses the other (caught in PR #451 review, fixed before merge)
 metadata:
   type: project
 ---
@@ -25,5 +25,6 @@ both maps' growth rate identically.
 **How to apply:** when reviewing a change to `cache_key` / the keying scheme in this file,
 check `CATALOG_FETCH_SLOTS` too, not just `CATALOG_CACHE` — grep for every
 `static ... LazyLock<Mutex<HashMap<String, ...>>>` in the file and confirm each has an
-eviction path if its key can grow unboundedly. See [[new-credential-kind-slot-audit]] for the
-general pattern of a sibling data structure silently missing a fix applied to its counterpart.
+eviction path if its key can grow unboundedly. This is one instance of a general pattern: a
+sibling data structure silently missing a fix applied to its counterpart, so enumerate the
+siblings before calling the fix complete.

--- a/.claude/agent-memory/review-review-ocr-reviewer/MEMORY.md
+++ b/.claude/agent-memory/review-review-ocr-reviewer/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory index
+
+- [catalog fetch-slots sibling-map eviction](catalog-fetch-slots-sibling-map-eviction.md) — widened cache keys need eviction on every sibling map sharing the key space, not just the primary cache.
+- [workspace mutates during review](workspace-mutates-during-review.md) — a clean `git status` at session start doesn't guarantee it stays clean; re-check before finalizing scope in a shared worktree.

--- a/.claude/agent-memory/review-review-ocr-reviewer/catalog-fetch-slots-sibling-map-eviction.md
+++ b/.claude/agent-memory/review-review-ocr-reviewer/catalog-fetch-slots-sibling-map-eviction.md
@@ -17,9 +17,11 @@ still only grew (`slots.entry(key).or_default()`), never shrank: one
 process.
 
 The finding was fixed before the commit landed: the merged `evict_expired()`
-sweeps both maps, and the key is now backend + Code Assist `project_id`
-(token fingerprint only for a project-less credential), so a routine token
-refresh no longer rotates the key at all.
+sweeps both maps, and the key is now backend + Code Assist `project_id`, so a
+routine token refresh no longer rotates the key for a credential that has a
+project. The project-less fallback still keys on a token fingerprint and still
+rotates on every refresh — that path is why the eviction has to cover both
+maps, and a review of the keying scheme should check it explicitly.
 
 **How to apply:** when reviewing a cache-keying change here (or any paired
 cache + lock-slot map keyed by the same identity), check that eviction covers

--- a/.claude/agent-memory/review-review-ocr-reviewer/catalog-fetch-slots-sibling-map-eviction.md
+++ b/.claude/agent-memory/review-review-ocr-reviewer/catalog-fetch-slots-sibling-map-eviction.md
@@ -1,0 +1,26 @@
+---
+name: catalog-fetch-slots-sibling-map-eviction
+description: shunt Antigravity catalog cache — CATALOG_FETCH_SLOTS lacked eviction after cache keys were widened to per-credential keys (caught in PR #451 review, fixed before merge)
+metadata:
+  type: project
+---
+
+`src/auth/antigravity/catalog.rs` has two process-wide static maps keyed by the
+same `cache_key`: `CATALOG_CACHE` (catalog entries) and `CATALOG_FETCH_SLOTS`
+(single-flight locks). During the PR #451 review-feedback round, an
+intermediate working-tree state widened the key from `base_url` alone (low,
+stable cardinality) to a per-credential key and added `evict_expired()` —
+pruning entries older than `2×CATALOG_TTL` — but wired it only into the two
+`cache().insert(...)` call sites for `CATALOG_CACHE`. `CATALOG_FETCH_SLOTS`
+still only grew (`slots.entry(key).or_default()`), never shrank: one
+`Arc<tokio::sync::Mutex<()>>` entry per key rotation for the life of the
+process.
+
+The finding was fixed before the commit landed: the merged `evict_expired()`
+sweeps both maps, and the key is now backend + Code Assist `project_id`
+(token fingerprint only for a project-less credential), so a routine token
+refresh no longer rotates the key at all.
+
+**How to apply:** when reviewing a cache-keying change here (or any paired
+cache + lock-slot map keyed by the same identity), check that eviction covers
+every sibling map sharing the widened key space, not just the primary one.

--- a/.claude/agent-memory/review-review-ocr-reviewer/workspace-mutates-during-review.md
+++ b/.claude/agent-memory/review-review-ocr-reviewer/workspace-mutates-during-review.md
@@ -1,0 +1,31 @@
+---
+name: workspace-mutates-during-review
+description: ocr preview can flip from range to workspace mid-session when the lead session (or another agent) writes to the same worktree concurrently
+metadata:
+  type: feedback
+---
+
+During an agy-429 review, `git status --porcelain` was clean at session start
+(matching the stored gitStatus snapshot), so the review proceeded in range
+mode (`--from origin/main --to HEAD`). Partway through, the lead session that
+dispatched this review kept applying review fixes to the same three files in
+the working tree (the sibling `review-cubic-reviewer` ran finder-only and
+edited nothing), producing a genuine uncommitted diff against HEAD that
+exactly matched the task's literal "review the current uncommitted workspace
+changes" wording.
+
+**Why:** `Read`/`git diff` always reflect live disk state, not a frozen
+snapshot, and the shared worktree means the lead — or any agent running in
+parallel (ensemble-review dispatches several finders at once) — can land
+edits mid-run.
+The initial clean `git status` is not a guarantee of a clean status ten tool
+calls later.
+
+**How to apply:** when the task's phrasing insists on "current uncommitted
+changes" but the initial `git status` looked clean, re-check `git status
+--porcelain` and `ocr delegate preview` (no `--from/--to`) again before
+finalizing scope — don't trust only the first snapshot. If a real workspace
+diff appears, prefer it over the range mode chosen at session start, since it
+is what the caller actually meant. See
+[[catalog-fetch-slots-sibling-map-eviction]] for the concrete finding this
+surfaced.


### PR DESCRIPTION
## Summary

Commits the memories the `review-cubic-reviewer` and `review-ocr-reviewer` subagents wrote while reviewing #451, corrected to match what actually merged:

- **Sibling-map eviction** (both reviewers): `CATALOG_CACHE` and `CATALOG_FETCH_SLOTS` in `src/auth/antigravity/catalog.rs` share a key space, so an eviction fix to one map must cover the other. The intermediate state they reviewed missed the slot map; the merged `evict_expired()` sweeps both, and the key is backend + Code Assist `project_id` (token fingerprint only for a project-less credential), not a per-token fingerprint as the original notes said.
- **Worktree changes mid-review** (ocr): re-check `git status` before finalizing scope in a shared worktree. Attribution corrected — the edits came from the lead session applying review fixes; the cubic reviewer ran finder-only and edited nothing.

No code changes.

## Milestone / spec

n/a — agent memory only.

## Checklist

- [x] `cargo build` passes (unchanged)
- [x] `cargo test` passes (unchanged)
- [x] `cargo clippy --all-targets -- -D warnings` clean (unchanged)
- [x] `cargo fmt --all --check` clean (unchanged)
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it (n/a)
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes (n/a)
- [x] Any new GitHub Action is pinned to a full commit SHA (n/a)

## Notes for reviewers

The two "sibling map" notes overlap by design — each subagent keeps its own memory directory. The factual corrections are the only edits to the subagents' text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records review lessons from PR #451 in the `review-cubic-reviewer` and `review-ocr-reviewer` agent memories, corrected to match what merged. No production code changes.

- `CATALOG_CACHE` and `CATALOG_FETCH_SLOTS` share backend plus Code Assist `project_id` keys; `evict_expired()` sweeps both, using a token fingerprint only for project-less credentials.
- Documents that reviewers must re-check scope when a shared worktree changes; the lead applied the fixes, while the cubic reviewer made no edits.

<sup>Written for commit bc8106a67e0b750f99f52b9582d3c7f7490d8e47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

