### PR TITLE
feat(config): add Zhipu and MiniMax China Anthropic presets

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 
 この名前が仕組みそのものを表しています。電気回路や鉄道の *shunt*（分岐器）が、選んだ一部の流れを並行した経路へ振り分けるのと同じように、ここではマッピングされたモデルの推論を別のプロバイダーへ振り分けつつ、Claude Code のツールやスキルはそのまま保たれます。
 
-**OpenAI**、**ChatGPT/Codex**（`codex login` でサブスクリプションを再利用）、**xAI**（API キー）、**Grok**（`shunt login xai` で SuperGrok / X Premium+ サブスクリプションを再利用）、**Cursor**（`shunt login cursor` でサブスクリプションを再利用）、**Kimi Code**（`shunt login kimi` でサブスクリプションを再利用）、**Gemini / Google Code Assist**（`~/.gemini/oauth_creds.json` でサブスクリプションを再利用。shunt は有効なアクセストークンをそのまま使用し、自前でのリフレッシュには `SHUNT_GOOGLE_CLIENT_ID` と `SHUNT_GOOGLE_CLIENT_SECRET` が必要です）、そして **Anthropic** パススルーが標準搭載されており、さらに Anthropic Messages 互換のバックエンド（Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway、…）は TOML テーブルまたは YAML マッピングを 1 つ書くだけで、コード変更なしに追加できます。
+**OpenAI**、**ChatGPT/Codex**（`codex login` でサブスクリプションを再利用）、**xAI**（API キー）、**Grok**（`shunt login xai` で SuperGrok / X Premium+ サブスクリプションを再利用）、**Cursor**（`shunt login cursor` でサブスクリプションを再利用）、**Kimi Code**（`shunt login kimi` でサブスクリプションを再利用）、**Zhipu** と **MiniMax 中国版**（API キー）、**Gemini / Google Code Assist**（`~/.gemini/oauth_creds.json` でサブスクリプションを再利用。shunt は有効なアクセストークンをそのまま使用し、自前でのリフレッシュには `SHUNT_GOOGLE_CLIENT_ID` と `SHUNT_GOOGLE_CLIENT_SECRET` が必要です）、そして **Anthropic** パススルーが標準搭載されており、さらに Anthropic Messages 互換のバックエンド（Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway、…）は TOML テーブルまたは YAML マッピングを 1 つ書くだけで、コード変更なしに追加できます。
 
 > [!NOTE]
 > `shunt` は活発に開発中の 1.0 未満（pre-1.0）ソフトウェアです。[SemVer](https://semver.org/lang/ja/#spec) の慣例に従い、`0.x` リリースには設定キー・CLI・動作に対する破壊的変更（breaking change）が含まれる場合があります。アップグレード前に[リリースノート](https://github.com/pleaseai/shunt/releases)を確認してください。
@@ -209,7 +209,9 @@ provider = "cursor"
 | Kimi Code（サブスクリプション、OAuth） | `https://api.kimi.com/coding` | サブスクリプションが提供する ID を使用 |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| Zhipu（GLM 中国版） | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) を参照 |
+| MiniMax 中国版 | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@
 
 이름 자체가 동작 방식을 나타냅니다. 전기/철도의 *shunt*는 흐름의 일부를 선택해 병렬 경로로 우회시킵니다. 여기서는 매핑된 모델의 추론이 다른 프로바이더로 우회되는 동안 Claude Code의 도구와 스킬은 그대로 유지됩니다.
 
-**OpenAI**, **ChatGPT/Codex**(`codex login`으로 구독을 재사용), **xAI**(API 키), **Grok**(`shunt login xai`로 SuperGrok / X Premium+ 구독을 재사용), **Cursor**(`shunt login cursor`로 구독을 재사용), **Kimi Code**(`shunt login kimi`로 구독을 재사용), **Gemini / Google Code Assist**(`~/.gemini/oauth_creds.json`으로 구독을 재사용. shunt는 유효한 액세스 토큰을 그대로 사용하며, 자체 갱신에는 `SHUNT_GOOGLE_CLIENT_ID`와 `SHUNT_GOOGLE_CLIENT_SECRET`가 필요합니다), **Anthropic** 패스스루가 기본 내장되어 있으며, Anthropic Messages 호환 백엔드(Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway 등)라면 무엇이든 TOML 테이블 하나 또는 YAML 매핑 하나만 추가하면 됩니다. 코드 변경은 필요 없습니다.
+**OpenAI**, **ChatGPT/Codex**(`codex login`으로 구독을 재사용), **xAI**(API 키), **Grok**(`shunt login xai`로 SuperGrok / X Premium+ 구독을 재사용), **Cursor**(`shunt login cursor`로 구독을 재사용), **Kimi Code**(`shunt login kimi`로 구독을 재사용), **Zhipu**와 **MiniMax 중국**(API 키), **Gemini / Google Code Assist**(`~/.gemini/oauth_creds.json`으로 구독을 재사용. shunt는 유효한 액세스 토큰을 그대로 사용하며, 자체 갱신에는 `SHUNT_GOOGLE_CLIENT_ID`와 `SHUNT_GOOGLE_CLIENT_SECRET`가 필요합니다), **Anthropic** 패스스루가 기본 내장되어 있으며, Anthropic Messages 호환 백엔드(Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway 등)라면 무엇이든 TOML 테이블 하나 또는 YAML 매핑 하나만 추가하면 됩니다. 코드 변경은 필요 없습니다.
 
 > [!NOTE]
 > `shunt`는 활발히 개발 중인 1.0 미만(pre-1.0) 소프트웨어입니다. [SemVer](https://semver.org/lang/ko/#spec) 관례에 따라 `0.x` 릴리스에는 설정 키, CLI, 동작에 대한 호환성이 깨지는 변경(breaking change)이 포함될 수 있으니, 업그레이드 전에 [릴리스 노트](https://github.com/pleaseai/shunt/releases)를 확인하세요.
@@ -206,7 +206,9 @@ provider = "cursor"
 | Kimi Code (구독, OAuth) | `https://api.kimi.com/coding` | 구독에서 제공하는 ID 사용 |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| Zhipu (GLM 중국) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | [MiniMax 문서](https://platform.minimax.io/docs/token-plan/claude-code) 참고 |
+| MiniMax 중국 | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 The name is the mechanism: an electrical/railway *shunt* diverts a selected part of the flow onto a parallel path. Here, a mapped model's inference is diverted to another provider while Claude Code's tools and skills stay intact.
 
-It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), **xAI** (API key), **Grok** (reuse your SuperGrok / X Premium+ subscription via `shunt login xai`), **Cursor** (reuse your subscription via `shunt login cursor`), **Kimi Code** (reuse your subscription via `shunt login kimi`), **Gemini / Google Code Assist** (reuse your subscription via `~/.gemini/oauth_creds.json`; shunt uses a valid access token directly, while self-refresh requires `SHUNT_GOOGLE_CLIENT_ID` and `SHUNT_GOOGLE_CLIENT_SECRET`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table or YAML mapping away, no code changes.
+It ships with **OpenAI**, **ChatGPT/Codex** (reuse your subscription via `codex login`), **xAI** (API key), **Grok** (reuse your SuperGrok / X Premium+ subscription via `shunt login xai`), **Cursor** (reuse your subscription via `shunt login cursor`), **Kimi Code** (reuse your subscription via `shunt login kimi`), **Zhipu** and **MiniMax China** (API keys), **Gemini / Google Code Assist** (reuse your subscription via `~/.gemini/oauth_creds.json`; shunt uses a valid access token directly, while self-refresh requires `SHUNT_GOOGLE_CLIENT_ID` and `SHUNT_GOOGLE_CLIENT_SECRET`), and **Anthropic** passthrough built in — and any Anthropic-Messages-compatible backend (Kimi, DeepSeek, GLM, MiniMax, OpenRouter, Vercel AI Gateway, …) is one TOML table or YAML mapping away, no code changes.
 
 > [!NOTE]
 > `shunt` is pre-1.0 software under active development. Per [SemVer](https://semver.org/#spec), `0.x` releases may include breaking changes to configuration keys, the CLI, and behavior — check the [release notes](https://github.com/pleaseai/shunt/releases) before upgrading.
@@ -209,7 +209,9 @@ The `cursor:` / `cursor-agent:` / `cursor-plan:` / `cursor-ask:` prefixes pick C
 | Kimi Code (subscription, OAuth) | `https://api.kimi.com/coding` | use the ids your subscription exposes |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| Zhipu (GLM China) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | see [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) |
+| MiniMax China | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
 
 名字即机制:电气/铁路中的 *shunt(分流)* 将流量中被选中的部分导向一条并行路径。在这里,被映射模型的推理被分流到另一个提供方,而 Claude Code 的工具和技能保持完好。
 
-它内置了 **OpenAI**、**ChatGPT/Codex**(通过 `codex login` 复用你的订阅)、**xAI**(API 密钥)、**Grok**(通过 `shunt login xai` 复用你的 SuperGrok / X Premium+ 订阅)、**Cursor**(通过 `shunt login cursor` 复用你的订阅)、**Kimi Code**(通过 `shunt login kimi` 复用你的订阅)、**Gemini / Google Code Assist**(通过 `~/.gemini/oauth_creds.json` 复用你的订阅;shunt 会直接使用有效的访问令牌,而自行刷新需要 `SHUNT_GOOGLE_CLIENT_ID` 和 `SHUNT_GOOGLE_CLIENT_SECRET`)以及 **Anthropic** 透传 —— 而任何兼容 Anthropic-Messages 的后端(Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway……)只需一个 TOML 表或 YAML 映射即可接入,无需改动代码。
+它内置了 **OpenAI**、**ChatGPT/Codex**(通过 `codex login` 复用你的订阅)、**xAI**(API 密钥)、**Grok**(通过 `shunt login xai` 复用你的 SuperGrok / X Premium+ 订阅)、**Cursor**(通过 `shunt login cursor` 复用你的订阅)、**Kimi Code**(通过 `shunt login kimi` 复用你的订阅)、**智谱**和 **MiniMax 国内版**(API 密钥)、**Gemini / Google Code Assist**(通过 `~/.gemini/oauth_creds.json` 复用你的订阅;shunt 会直接使用有效的访问令牌,而自行刷新需要 `SHUNT_GOOGLE_CLIENT_ID` 和 `SHUNT_GOOGLE_CLIENT_SECRET`)以及 **Anthropic** 透传 —— 而任何兼容 Anthropic-Messages 的后端(Kimi、DeepSeek、GLM、MiniMax、OpenRouter、Vercel AI Gateway……)只需一个 TOML 表或 YAML 映射即可接入,无需改动代码。
 
 > [!NOTE]
 > `shunt` 是仍在活跃开发中的 1.0 之前(pre-1.0)软件。按照 [SemVer](https://semver.org/lang/zh-CN/#spec) 惯例,`0.x` 版本可能包含对配置键、CLI 和行为的破坏性变更(breaking change) —— 升级前请查看[发布说明](https://github.com/pleaseai/shunt/releases)。
@@ -204,7 +204,9 @@ provider = "cursor"
 | Kimi Code(订阅制,OAuth) | `https://api.kimi.com/coding` | 使用你订阅提供的 ID |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`、`deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`、`glm-4.7` |
+| 智谱（GLM 国内版） | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`、`glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | 见 [MiniMax 文档](https://platform.minimax.io/docs/token-plan/claude-code) |
+| MiniMax 国内版 | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` |
 

--- a/blueprints/upstream/minimax-cn.md
+++ b/blueprints/upstream/minimax-cn.md
@@ -1,0 +1,57 @@
+# shunt blueprint: MiniMax China
+
+You are a coding agent adding MiniMax's China Anthropic-compatible endpoint to an operator's shunt gateway. Follow these steps; verify each before moving on.
+
+## Prerequisites
+
+- Confirm `shunt` is installed and `shunt --help` runs.
+- Confirm the operator has a MiniMax API key from the China open platform.
+
+## Locate the config
+
+Honor an explicit `--config` path first. Otherwise, edit the active `shunt.toml`, `shunt.yaml`, or `shunt.yml`; if none exists, create `./shunt.toml`. Do not replace or weaken existing entries.
+
+## Add the upstream
+
+The `minimax-cn` preset supplies `kind = "anthropic"`, `base_url = "https://api.minimax.cn/anthropic"`, and API-key auth from `MINIMAX_API_KEY`:
+
+```toml
+[[upstreams]]
+name = "minimax-cn"
+provider = "minimax-cn"
+```
+
+When replacing the built-in provider set with `[[upstreams]]`, keep an `anthropic` passthrough upstream unless the operator intentionally changes `server.default_provider`.
+
+## Credentials
+
+Export the key in the environment that launches shunt:
+
+```bash
+export MINIMAX_API_KEY='...'
+```
+
+Never write, print, log, or commit the key. Do not reuse an international MiniMax key for the China endpoint.
+
+## Optional model routing
+
+```toml
+[[models]]
+id = "claude-minimax-cn"
+display_name = "MiniMax (China)"
+
+[models.upstream_model]
+minimax-cn = "MiniMax-M3"
+```
+
+Remove Claude Code's `[1m]` context hint from `upstream_model`; shunt strips it from inbound requests before matching.
+
+## Validate
+
+Run `shunt check` in the same environment as the key and continue only after it prints `config ok`. Start `shunt run`, send one minimal `/v1/messages` request for a routed model, and confirm `x-gateway-upstream` is `minimax-cn`.
+
+## Safety rules
+
+- Keep credentials in the process environment or a secret manager.
+- Preserve unrelated configuration and security controls.
+- Make the smallest reversible edit and report exactly what changed.

--- a/blueprints/upstream/minimax-cn.md
+++ b/blueprints/upstream/minimax-cn.md
@@ -44,7 +44,7 @@ display_name = "MiniMax (China)"
 minimax-cn = "MiniMax-M3"
 ```
 
-Remove Claude Code's `[1m]` context hint from `upstream_model`; shunt strips it from inbound requests before matching.
+Verify the model ID against the operator's MiniMax China plan. Remove Claude Code's `[1m]` context hint from `upstream_model`; shunt strips it from inbound requests before matching.
 
 ## Validate
 

--- a/blueprints/upstream/zhipu.md
+++ b/blueprints/upstream/zhipu.md
@@ -1,0 +1,57 @@
+# shunt blueprint: Zhipu (GLM China)
+
+You are a coding agent adding Zhipu's China BigModel GLM endpoint to an operator's shunt gateway. Follow these steps; verify each before moving on.
+
+## Prerequisites
+
+- Confirm `shunt` is installed and `shunt --help` runs.
+- Confirm the operator has a Zhipu GLM Coding Plan API key from BigModel.
+
+## Locate the config
+
+Honor an explicit `--config` path first. Otherwise, edit the active `shunt.toml`, `shunt.yaml`, or `shunt.yml`; if none exists, create `./shunt.toml`. Do not replace or weaken existing entries.
+
+## Add the upstream
+
+The `zhipu` preset supplies `kind = "anthropic"`, `base_url = "https://open.bigmodel.cn/api/anthropic"`, and API-key auth from `ZHIPUAI_API_KEY`:
+
+```toml
+[[upstreams]]
+name = "zhipu"
+provider = "zhipu"
+```
+
+When replacing the built-in provider set with `[[upstreams]]`, keep an `anthropic` passthrough upstream unless the operator intentionally changes `server.default_provider`.
+
+## Credentials
+
+Export the key in the environment that launches shunt:
+
+```bash
+export ZHIPUAI_API_KEY='...'
+```
+
+Never write, print, log, or commit the key.
+
+## Optional model routing
+
+```toml
+[[models]]
+id = "claude-glm-via-zhipu"
+display_name = "GLM (via Zhipu)"
+
+[models.upstream_model]
+zhipu = "glm-5.3-flash"
+```
+
+Verify the model ID against the operator's Zhipu plan. Remove Claude Code's `[1m]` hint from `upstream_model`; shunt strips it from inbound requests before matching.
+
+## Validate
+
+Run `shunt check` in the same environment as the key and continue only after it prints `config ok`. Start `shunt run`, send one minimal `/v1/messages` request for a routed model, and confirm `x-gateway-upstream` is `zhipu`.
+
+## Safety rules
+
+- Keep credentials in the process environment or a secret manager.
+- Preserve unrelated configuration and security controls.
+- Make the smallest reversible edit and report exactly what changed.

--- a/docs/init-command.md
+++ b/docs/init-command.md
@@ -6,7 +6,7 @@
 
 The starter begins with validation and run instructions. With no `--upstream`, the rest is commented guidance, so loading the file preserves shunt's default passthrough behavior. Repeating `--upstream <preset>` emits ordered `[[upstreams]]` entries and credential comments derived from the config preset registry, followed by a commented `models.upstream_model` example for the first requested preset. Because declaring `[[upstreams]]` replaces the built-in provider set, a trailing `anthropic` passthrough upstream is appended automatically (unless you request `anthropic` yourself) so the generated file passes `shunt check` and unmapped models keep their Anthropic fallback. It never sets `server.default_provider`, so unmapped traffic is not silently diverted.
 
-The accepted preset names are `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, and `kimi-code`. Unknown and duplicate values fail before the file is opened.
+The accepted preset names are `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, `kimi-code`, `zhipu`, and `minimax-cn`. Unknown and duplicate values fail before the file is opened.
 
 ## Command semantics
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -238,12 +238,16 @@ fields. Ready-to-use entries (uncomment in
 | Kimi Code (subscription, OAuth) | `https://api.kimi.com/coding` | use the ids your subscription exposes |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
-| Zhipu (GLM China) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
+| Zhipu (GLM China) — built-in preset | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | see [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) |
-| MiniMax China | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
+| MiniMax China — built-in preset | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | Mimo (Xiaomi) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — see [Mimo docs](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8`, `~anthropic/claude-sonnet-latest` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` (accepts `x_api_key`) |
+
+`zhipu` and `minimax-cn` are also built-in presets, so they do not need a `[providers.*]` table
+from `shunt.toml.example`. Use the ordered `[[upstreams]]` form instead — for example,
+`provider = "zhipu"` or `provider = "minimax-cn"` — and keep the `anthropic` passthrough default.
 
 Every row above but one takes `auth = "api_key"`. **Kimi Code** is the exception: a separate,
 subscription-billed Kimi service from the metered Moonshot API in the row above it — different

--- a/docs/running.md
+++ b/docs/running.md
@@ -238,7 +238,9 @@ fields. Ready-to-use entries (uncomment in
 | Kimi Code (subscription, OAuth) | `https://api.kimi.com/coding` | use the ids your subscription exposes |
 | DeepSeek | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | Z.ai (GLM) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| Zhipu (GLM China) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | MiniMax | `https://api.minimax.io/anthropic` | see [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) |
+| MiniMax China | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | Mimo (Xiaomi) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — see [Mimo docs](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) |
 | OpenRouter | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8`, `~anthropic/claude-sonnet-latest` |
 | Vercel AI Gateway | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` (accepts `x_api_key`) |

--- a/docs/upstreams-failover.md
+++ b/docs/upstreams-failover.md
@@ -43,6 +43,8 @@ branching). Unknown preset name → config error listing available presets.
 | `kimi` | anthropic | `https://api.moonshot.ai/anthropic` | `api_key`, env `MOONSHOT_API_KEY` |
 | `cursor` | cursor | Cursor backend (current documented URL) | `cursor_oauth` |
 | `kimi-code` | anthropic | `https://api.kimi.com/coding` | `kimi_oauth` |
+| `zhipu` | anthropic | `https://open.bigmodel.cn/api/anthropic` | `api_key`, env `ZHIPUAI_API_KEY` |
+| `minimax-cn` | anthropic | `https://api.minimax.cn/anthropic` | `api_key`, env `MINIMAX_API_KEY` |
 
 `kimi` and `kimi-code` are distinct presets for distinct services: `kimi` is the metered Moonshot
 API (`auth = "api_key"`, env `MOONSHOT_API_KEY`), while `kimi-code` is the subscription-billed Kimi
@@ -54,9 +56,9 @@ time, not from this table if they drift.
 
 No preset overrides `count_tokens`: every upstream keeps the field's normal
 serde default (`tiktoken`), which is only meaningful for `responses` and
-`cursor` kinds — `anthropic`-kind upstreams (including `kimi` and `kimi-code`) always forward
-`count_tokens` requests upstream regardless of the setting. Operators override
-per upstream with the explicit `count_tokens` field as today.
+`cursor` kinds — `anthropic`-kind upstreams (including `kimi`, `kimi-code`, `zhipu`, and
+`minimax-cn`) always forward `count_tokens` requests upstream regardless of the setting.
+Operators override per upstream with the explicit `count_tokens` field as today.
 
 ### 1.3 `auth` — string or map
 

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -230,7 +230,9 @@ Most third-party "use Claude Code with X" gateways are Anthropic-Messages-compat
 | [Kimi Code (subscription, OAuth)](/providers/kimi/#kimi-code-oauth-subscription) | `https://api.kimi.com/coding` | use the ids your subscription exposes |
 | [DeepSeek](/providers/deepseek/) | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | [Z.ai (GLM)](/providers/zai/) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| [Zhipu (GLM China)](/providers/zhipu/) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | [MiniMax](/providers/minimax/) | `https://api.minimax.io/anthropic` | see [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) |
+| [MiniMax China](/providers/minimax-cn/) | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | [Mimo (Xiaomi)](/providers/mimo/) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — see [Mimo docs](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) |
 | [OpenRouter](/providers/openrouter/) | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | [Vercel AI Gateway](/providers/vercel-ai-gateway/) | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8` (accepts `x_api_key`) |

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -169,7 +169,9 @@ OAuth 経由であなたの **SuperGrok / X Premium+** サブスクリプショ�
 | [Kimi Code（サブスクリプション、OAuth）](/ja/providers/kimi/#kimi-codeoauth-サブスクリプション) | `https://api.kimi.com/coding` | サブスクリプションが公開しているモデル ID を使用 |
 | [DeepSeek](/ja/providers/deepseek/) | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | [Z.ai (GLM)](/ja/providers/zai/) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| [Zhipu（GLM 中国版）](/ja/providers/zhipu/) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | [MiniMax](/ja/providers/minimax/) | `https://api.minimax.io/anthropic` | [MiniMax docs](https://platform.minimax.io/docs/token-plan/claude-code) を参照 |
+| [MiniMax 中国版](/ja/providers/minimax-cn/) | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | [Mimo (Xiaomi)](/ja/providers/mimo/) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — [Mimo docs](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) を参照 |
 | [OpenRouter](/ja/providers/openrouter/) | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | [Vercel AI Gateway](/ja/providers/vercel-ai-gateway/) | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8`（`x_api_key` を受け入れる） |

--- a/site/src/content/docs/ja/providers/minimax-cn.md
+++ b/site/src/content/docs/ja/providers/minimax-cn.md
@@ -1,0 +1,63 @@
+---
+title: MiniMax China
+description: MINIMAX_API_KEY で MiniMax-M3 を MiniMax 中国の Anthropic 互換エンドポイントへルーティングする。
+---
+
+**MiniMax China** は **MiniMax-M3** を **Anthropic 互換**エンドポイントで提供します。組み込みの
+`minimax-cn` preset は `kind = "anthropic"`、
+`base_url = "https://api.minimax.cn/anthropic"`、および `MINIMAX_API_KEY`
+からの API キー認証を提供します。
+
+国際版エンドポイントは [MiniMax](/ja/providers/minimax/) を参照してください。ホストと認証情報は別です。
+
+## アップストリームの設定
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # ルート未指定のモデル（例: claude-*）の既定として Anthropic を維持
+
+[[upstreams]]
+name = "minimax-cn"
+provider = "minimax-cn"
+
+[[routes]]
+model = "MiniMax-M3"
+provider = "minimax-cn"
+```
+
+順序付き `[[upstreams]]` は shunt の組み込み provider を置き換えるため、設定はフォールバック先の
+`anthropic` 既定も宣言する必要があります（`server.default_provider` の既定は `anthropic`）。
+
+## 認証情報
+
+```bash
+export MINIMAX_API_KEY='...'
+```
+
+中国の MiniMax open platform のキーを使用してください。キーを設定ファイルに書き込まないでください。
+`shunt check` は設定構造のみを検証し、キーの値は読み取りません。`MINIMAX_API_KEY` が未設定の場合、
+`minimax-cn` へルーティングされた最初のリクエストは認証エラーを返します。
+
+## モデル
+
+| モデル ID | 備考 |
+| :-- | :-- |
+| `MiniMax-M3` | 1M トークンコンテキスト。クライアントは Claude Code の `[1m]` マーカーを付けられますが、shunt はマッチ前に除去するため、接尾辞なしの ID をルーティングしてください |
+
+Claude Code では `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION`、またはサブエージェントの
+`model:` frontmatter でルーティングされた ID を選択します。
+
+## 検証
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"MiniMax-M3[1m]","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+レスポンスの `x-gateway-upstream` ヘッダーが `minimax-cn` であることを確認し、
+[Claude Code を shunt へ向けてください](/ja/guides/connect-claude-code/)。

--- a/site/src/content/docs/ja/providers/minimax-cn.md
+++ b/site/src/content/docs/ja/providers/minimax-cn.md
@@ -46,7 +46,9 @@ export MINIMAX_API_KEY='...'
 | `MiniMax-M3` | 1M トークンコンテキスト。クライアントは Claude Code の `[1m]` マーカーを付けられますが、shunt はマッチ前に除去するため、接尾辞なしの ID をルーティングしてください |
 
 Claude Code では `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION`、またはサブエージェントの
-`model:` frontmatter でルーティングされた ID を選択します。
+`model:` frontmatter でルーティングされた ID を選択します。代わりに `/model` ピッカーへ表示するには、
+`[models.upstream_model]` マップとともに `claude` プレフィックス付きのエイリアスを広告してください —
+[Model Discovery](/ja/guides/model-discovery/) を参照。マッピングする ID は `[1m]` で終わっては**いけません**。
 
 ## 検証
 

--- a/site/src/content/docs/ja/providers/zhipu.md
+++ b/site/src/content/docs/ja/providers/zhipu.md
@@ -1,0 +1,67 @@
+---
+title: Zhipu (GLM China)
+description: ZHIPUAI_API_KEY で GLM Coding Plan モデルを Zhipu の Anthropic 互換 BigModel エンドポイントへルーティングする。
+---
+
+**Zhipu** は中国の BigModel プラットフォームで **GLM** モデルを **Anthropic 互換**
+エンドポイントとして提供します。組み込みの `zhipu` preset は `kind = "anthropic"`、
+`base_url = "https://open.bigmodel.cn/api/anthropic"`、および `ZHIPUAI_API_KEY`
+からの API キー認証を提供します。
+
+国際版 Z.ai エンドポイントは [Z.ai (GLM)](/ja/providers/zai/) を参照してください。ホストと認証情報は別です。
+
+## アップストリームの設定
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # ルート未指定のモデル（例: claude-*）の既定として Anthropic を維持
+
+[[upstreams]]
+name = "zhipu"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3-flash"
+provider = "zhipu"
+```
+
+順序付き `[[upstreams]]` は shunt の組み込み provider を置き換えるため、設定はフォールバック先の
+`anthropic` 既定も宣言する必要があります（`server.default_provider` の既定は `anthropic`）。
+
+## 認証情報
+
+```bash
+export ZHIPUAI_API_KEY='...'
+```
+
+キーを設定ファイルに書き込まないでください。`shunt check` は設定構造のみを検証し、キーの値は読み取りません。
+`ZHIPUAI_API_KEY` が未設定の場合、`zhipu` へルーティングされた最初のリクエストは認証エラーを返します。
+
+## モデル
+
+| モデル ID | 備考 |
+| :-- | :-- |
+| `glm-5.3` | GLM Coding Plan のフラッグシップテキストモデル |
+| `glm-5.3-flash` | より高速なマルチモーダルティア。クライアントは `[1m]` を付けられますが、shunt はルートマッチ前に除去します |
+
+Claude Code では `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION`、またはサブエージェントの
+`model:` frontmatter でルーティングされた ID を選択します。
+
+## 検証
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"glm-5.3-flash","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+レスポンスの `x-gateway-upstream` ヘッダーが `zhipu` であることを確認し、
+[Claude Code を shunt へ向けてください](/ja/guides/connect-claude-code/)。

--- a/site/src/content/docs/ja/providers/zhipu.md
+++ b/site/src/content/docs/ja/providers/zhipu.md
@@ -50,7 +50,9 @@ export ZHIPUAI_API_KEY='...'
 | `glm-5.3-flash` | より高速なマルチモーダルティア。クライアントは `[1m]` を付けられますが、shunt はルートマッチ前に除去します |
 
 Claude Code では `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION`、またはサブエージェントの
-`model:` frontmatter でルーティングされた ID を選択します。
+`model:` frontmatter でルーティングされた ID を選択します。代わりに `/model` ピッカーへ表示するには、
+`[models.upstream_model]` マップとともに `claude` プレフィックス付きのエイリアスを広告してください —
+[Model Discovery](/ja/guides/model-discovery/) を参照。
 
 ## 検証
 

--- a/site/src/content/docs/ja/reference/cli.mdx
+++ b/site/src/content/docs/ja/reference/cli.mdx
@@ -42,7 +42,7 @@ shunt init --root /path/to/project
 shunt init --force
 ```
 
-Upstream を指定しない場合、starter はすべてコメントで構成され、shunt のデフォルト passthrough 設定として読み込まれます。`--upstream` を繰り返すと、failover 順に preset エントリを追加できます。指定できる名前は `anthropic`、`codex`、`openai`、`xai`、`grok`、`kimi`、`cursor`、`kimi-code` です。Starter は `server.default_provider` を設定しないため、マッピングされていないトラフィックはデフォルトの Anthropic passthrough のままです。preset を指定すると、生成されたファイルが `shunt check` を通過しつつこの fallback を維持できるよう、末尾に `anthropic` passthrough upstream が自動的に追加されます（自分で `anthropic` を指定した場合を除く）。
+Upstream を指定しない場合、starter はすべてコメントで構成され、shunt のデフォルト passthrough 設定として読み込まれます。`--upstream` を繰り返すと、failover 順に preset エントリを追加できます。指定できる名前は `anthropic`、`codex`、`openai`、`xai`、`grok`、`kimi`、`cursor`、`kimi-code`、`zhipu`、`minimax-cn` です。Starter は `server.default_provider` を設定しないため、マッピングされていないトラフィックはデフォルトの Anthropic passthrough のままです。preset を指定すると、生成されたファイルが `shunt check` を通過しつつこの fallback を維持できるよう、末尾に `anthropic` passthrough upstream が自動的に追加されます（自分で `anthropic` を指定した場合を除く）。
 
 Root のデフォルトは現在のディレクトリで、あらかじめ存在している必要があります。そこに `shunt.toml`、`shunt.yaml`、`shunt.yml` のいずれかがある場合、`--force` なしでは何も書き込まず停止します。強制 init が上書きするのは `shunt.toml` だけです。YAML variant はそのまま残り、config discovery では新しい TOML ファイルが優先されます。
 

--- a/site/src/content/docs/ja/reference/configuration.md
+++ b/site/src/content/docs/ja/reference/configuration.md
@@ -270,6 +270,9 @@ codex-fallback = "gpt-5.2"
 | `grok` | `responses` | `https://cli-chat-proxy.grok.com/v1` | `xai_oauth` |
 | `kimi` | `anthropic` | `https://api.moonshot.ai/anthropic` | `api_key`, env `MOONSHOT_API_KEY` |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | `cursor_oauth` |
+| `kimi-code` | `anthropic` | `https://api.kimi.com/coding` | `kimi_oauth` |
+| `zhipu` | `anthropic` | `https://open.bigmodel.cn/api/anthropic` | `api_key`, env `ZHIPUAI_API_KEY` |
+| `minimax-cn` | `anthropic` | `https://api.minimax.cn/anthropic` | `api_key`, env `MINIMAX_API_KEY` |
 
 `auth = "claude_oauth"` のような文字列は `auth = { mode = "claude_oauth" }` の省略形です。`api_key` マップは `env`（preset が提供しない場合は必須）と `header`（デフォルトは `bearer`、または `x_api_key`）を受け取ります。`claude_oauth` と `chatgpt_oauth` のマップは `account = "name"` または `accounts = [...]` で範囲を絞れますが、両方は指定できません。`accounts` にはストアエントリ名の文字列と完全なアカウントテーブルを指定できます。明示的な `accounts = []` は拒否され、両方のスコープフィールドを省略するとストア全体を走査します。ChatGPT ストアが空の場合、`chatgpt_oauth` は従来どおり `~/.codex/auth.json` にフォールバックします。`passthrough`、`xai_oauth`、`cursor_oauth`、`antigravity_oauth` のマップは `mode` のみを受け付け、mode 固有の未知のキーはエラーです。
 

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -171,7 +171,9 @@ OAuth를 통해 사용자의 **SuperGrok / X Premium+** 구독을 사용하고(`
 | [Kimi Code(구독, OAuth)](/ko/providers/kimi/#kimi-code-oauth-구독) | `https://api.kimi.com/coding` | 구독이 노출하는 모델 ID 사용 |
 | [DeepSeek](/ko/providers/deepseek/) | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`, `deepseek-v4-flash` |
 | [Z.ai (GLM)](/ko/providers/zai/) | `https://api.z.ai/api/anthropic` | `glm-5.2`, `glm-4.7` |
+| [Zhipu (GLM 중국)](/ko/providers/zhipu/) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`, `glm-5.3-flash` |
 | [MiniMax](/ko/providers/minimax/) | `https://api.minimax.io/anthropic` | [MiniMax 문서](https://platform.minimax.io/docs/token-plan/claude-code) 참고 |
+| [MiniMax 중국](/ko/providers/minimax-cn/) | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | [Mimo (Xiaomi)](/ko/providers/mimo/) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — [Mimo 문서](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) 참고 |
 | [OpenRouter](/ko/providers/openrouter/) | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | [Vercel AI Gateway](/ko/providers/vercel-ai-gateway/) | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8`(`x_api_key`를 받아들임) |

--- a/site/src/content/docs/ko/providers/minimax-cn.md
+++ b/site/src/content/docs/ko/providers/minimax-cn.md
@@ -1,0 +1,64 @@
+---
+title: MiniMax China
+description: MINIMAX_API_KEY로 MiniMax-M3를 MiniMax 중국 Anthropic 호환 엔드포인트로 라우팅하기.
+---
+
+**MiniMax China**는 **MiniMax-M3**를 **Anthropic 호환** 엔드포인트로 제공합니다. 내장된
+`minimax-cn` preset은 `kind = "anthropic"`,
+`base_url = "https://api.minimax.cn/anthropic"` 및 `MINIMAX_API_KEY`의 API 키 인증을
+제공합니다.
+
+국제 엔드포인트는 [MiniMax](/ko/providers/minimax/)를 참고하세요. 두 호스트와 자격 증명은
+별개입니다.
+
+## 업스트림 구성
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # 라우트가 없는 모델(예: claude-*)의 기본값으로 Anthropic을 유지
+
+[[upstreams]]
+name = "minimax-cn"
+provider = "minimax-cn"
+
+[[routes]]
+model = "MiniMax-M3"
+provider = "minimax-cn"
+```
+
+순서가 있는 `[[upstreams]]`는 shunt의 내장 provider를 대체하므로, 구성이 여전히 폴백하는
+`anthropic` 기본값을 선언해야 합니다(`server.default_provider`의 기본값은 `anthropic`).
+
+## 자격 증명
+
+```bash
+export MINIMAX_API_KEY='...'
+```
+
+중국 MiniMax open platform의 키를 사용하세요. 키를 구성 파일에 쓰지 마세요. `shunt check`는
+구성 구조를 검증할 뿐 키 값을 읽지 않습니다. `MINIMAX_API_KEY`가 설정되지 않았다면
+`minimax-cn`으로 라우팅된 첫 요청은 인증 오류를 반환합니다.
+
+## 모델
+
+| 모델 ID | 참고 |
+| :-- | :-- |
+| `MiniMax-M3` | 1M 토큰 컨텍스트. 클라이언트가 Claude Code의 `[1m]` 표시를 붙일 수 있으며 shunt는 매칭 전에 제거하므로 접미사 없는 ID로 라우팅하세요 |
+
+Claude Code에서 `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, 또는 서브에이전트의
+`model:` frontmatter로 라우팅된 ID를 선택하세요.
+
+## 검증
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"MiniMax-M3[1m]","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+응답의 `x-gateway-upstream` 헤더가 `minimax-cn`을 가리키는지 확인한 뒤
+[Claude Code를 shunt에 연결](/ko/guides/connect-claude-code/)하세요.

--- a/site/src/content/docs/ko/providers/minimax-cn.md
+++ b/site/src/content/docs/ko/providers/minimax-cn.md
@@ -47,7 +47,9 @@ export MINIMAX_API_KEY='...'
 | `MiniMax-M3` | 1M 토큰 컨텍스트. 클라이언트가 Claude Code의 `[1m]` 표시를 붙일 수 있으며 shunt는 매칭 전에 제거하므로 접미사 없는 ID로 라우팅하세요 |
 
 Claude Code에서 `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, 또는 서브에이전트의
-`model:` frontmatter로 라우팅된 ID를 선택하세요.
+`model:` frontmatter로 라우팅된 ID를 선택하세요. 대신 `/model` 선택기에 노출하려면
+`[models.upstream_model]` 맵과 함께 `claude` 프리픽스가 붙은 별칭을 선언하세요 —
+[모델 디스커버리](/ko/guides/model-discovery/)를 참고하세요. 매핑된 ID는 `[1m]`으로 끝나면 **안 됩니다**.
 
 ## 검증
 

--- a/site/src/content/docs/ko/providers/zhipu.md
+++ b/site/src/content/docs/ko/providers/zhipu.md
@@ -1,0 +1,68 @@
+---
+title: Zhipu (GLM China)
+description: ZHIPUAI_API_KEY로 GLM Coding Plan 모델을 Zhipu의 Anthropic 호환 BigModel 엔드포인트로 라우팅하기.
+---
+
+**Zhipu**는 중국 BigModel 플랫폼에서 **GLM** 모델을 **Anthropic 호환** 엔드포인트로 제공합니다.
+내장된 `zhipu` preset은 `kind = "anthropic"`,
+`base_url = "https://open.bigmodel.cn/api/anthropic"` 및 `ZHIPUAI_API_KEY`의 API 키 인증을
+제공합니다.
+
+국제 Z.ai 엔드포인트는 [Z.ai (GLM)](/ko/providers/zai/)를 참고하세요. 두 호스트와 자격 증명은
+별개입니다.
+
+## 업스트림 구성
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # 라우트가 없는 모델(예: claude-*)의 기본값으로 Anthropic을 유지
+
+[[upstreams]]
+name = "zhipu"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3-flash"
+provider = "zhipu"
+```
+
+순서가 있는 `[[upstreams]]`는 shunt의 내장 provider를 대체하므로, 구성이 여전히 폴백하는
+`anthropic` 기본값을 선언해야 합니다(`server.default_provider`의 기본값은 `anthropic`).
+
+## 자격 증명
+
+```bash
+export ZHIPUAI_API_KEY='...'
+```
+
+키를 구성 파일에 쓰지 마세요. `shunt check`는 구성 구조를 검증할 뿐 키 값을 읽지 않습니다.
+`ZHIPUAI_API_KEY`가 설정되지 않았다면 `zhipu`로 라우팅된 첫 요청은 인증 오류를 반환합니다.
+
+## 모델
+
+| 모델 ID | 참고 |
+| :-- | :-- |
+| `glm-5.3` | GLM Coding Plan 플래그십 텍스트 모델 |
+| `glm-5.3-flash` | 더 빠른 멀티모달 티어. 클라이언트가 `[1m]`을 붙일 수 있으며 shunt는 라우트 매칭 전에 제거합니다 |
+
+Claude Code에서 `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, 또는 서브에이전트의
+`model:` frontmatter로 라우팅된 ID를 선택하세요.
+
+## 검증
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"glm-5.3-flash","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+응답의 `x-gateway-upstream` 헤더가 `zhipu`를 가리키는지 확인한 뒤
+[Claude Code를 shunt에 연결](/ko/guides/connect-claude-code/)하세요.

--- a/site/src/content/docs/ko/providers/zhipu.md
+++ b/site/src/content/docs/ko/providers/zhipu.md
@@ -51,7 +51,9 @@ export ZHIPUAI_API_KEY='...'
 | `glm-5.3-flash` | 더 빠른 멀티모달 티어. 클라이언트가 `[1m]`을 붙일 수 있으며 shunt는 라우트 매칭 전에 제거합니다 |
 
 Claude Code에서 `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, 또는 서브에이전트의
-`model:` frontmatter로 라우팅된 ID를 선택하세요.
+`model:` frontmatter로 라우팅된 ID를 선택하세요. 대신 `/model` 선택기에 노출하려면
+`[models.upstream_model]` 맵과 함께 `claude` 프리픽스가 붙은 별칭을 선언하세요 —
+[모델 디스커버리](/ko/guides/model-discovery/)를 참고하세요.
 
 ## 검증
 

--- a/site/src/content/docs/ko/reference/cli.mdx
+++ b/site/src/content/docs/ko/reference/cli.mdx
@@ -42,7 +42,7 @@ shunt init --root /path/to/project
 shunt init --force
 ```
 
-Upstream을 지정하지 않으면 starter 전체가 주석으로 구성되어 shunt의 기본 passthrough 설정으로 로드됩니다. `--upstream`을 반복하면 failover 순서대로 preset 항목을 추가합니다. 사용할 수 있는 이름은 `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, `kimi-code`입니다. Starter는 `server.default_provider`를 설정하지 않으므로 매핑되지 않은 트래픽은 기본 Anthropic passthrough를 유지합니다. Preset을 지정하면 생성된 파일이 `shunt check`를 통과하면서도 이 fallback을 유지하도록 마지막에 `anthropic` passthrough upstream이 자동으로 추가됩니다(직접 `anthropic`을 지정한 경우는 제외).
+Upstream을 지정하지 않으면 starter 전체가 주석으로 구성되어 shunt의 기본 passthrough 설정으로 로드됩니다. `--upstream`을 반복하면 failover 순서대로 preset 항목을 추가합니다. 사용할 수 있는 이름은 `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, `kimi-code`, `zhipu`, `minimax-cn`입니다. Starter는 `server.default_provider`를 설정하지 않으므로 매핑되지 않은 트래픽은 기본 Anthropic passthrough를 유지합니다. Preset을 지정하면 생성된 파일이 `shunt check`를 통과하면서도 이 fallback을 유지하도록 마지막에 `anthropic` passthrough upstream이 자동으로 추가됩니다(직접 `anthropic`을 지정한 경우는 제외).
 
 Root의 기본값은 현재 디렉터리이며 이미 존재해야 합니다. 그 안에 `shunt.toml`, `shunt.yaml`, `shunt.yml` 중 하나가 있으면 `--force` 없이는 아무것도 쓰지 않고 중단합니다. 강제 init은 `shunt.toml`만 덮어씁니다. YAML variant는 그대로 남고, config discovery에서는 새 TOML 파일이 우선합니다.
 

--- a/site/src/content/docs/ko/reference/configuration.md
+++ b/site/src/content/docs/ko/reference/configuration.md
@@ -299,6 +299,9 @@ codex-fallback = "gpt-5.2"
 | `grok` | `responses` | `https://cli-chat-proxy.grok.com/v1` | `xai_oauth` |
 | `kimi` | `anthropic` | `https://api.moonshot.ai/anthropic` | `api_key`, env `MOONSHOT_API_KEY` |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | `cursor_oauth` |
+| `kimi-code` | `anthropic` | `https://api.kimi.com/coding` | `kimi_oauth` |
+| `zhipu` | `anthropic` | `https://open.bigmodel.cn/api/anthropic` | `api_key`, env `ZHIPUAI_API_KEY` |
+| `minimax-cn` | `anthropic` | `https://api.minimax.cn/anthropic` | `api_key`, env `MINIMAX_API_KEY` |
 
 `auth = "claude_oauth"` 같은 문자열은 `auth = { mode = "claude_oauth" }`의 축약형입니다. `api_key` 맵은 `env`(preset이 제공하지 않으면 필수)와 `header`(기본 `bearer`, 또는 `x_api_key`)를 받습니다. `claude_oauth`와 `chatgpt_oauth` 맵은 `account = "name"` 또는 `accounts = [...]`로 범위를 좁힐 수 있지만 둘을 함께 쓸 수는 없습니다. `accounts`에는 스토어 항목 이름 문자열과 전체 계정 테이블을 넣을 수 있습니다. 명시적인 `accounts = []`는 거부되며, 두 범위 필드를 모두 생략하면 전체 스토어를 스캔합니다. ChatGPT 스토어가 비어 있으면 `chatgpt_oauth`는 기존 `~/.codex/auth.json` fallback을 유지합니다. `passthrough`, `xai_oauth`, `cursor_oauth`, `antigravity_oauth` 맵에는 `mode`만 사용할 수 있으며, mode별로 알 수 없는 키는 오류입니다.
 

--- a/site/src/content/docs/providers/minimax-cn.md
+++ b/site/src/content/docs/providers/minimax-cn.md
@@ -1,0 +1,66 @@
+---
+title: MiniMax China
+description: Route MiniMax-M3 to MiniMax's China Anthropic-compatible endpoint with a MINIMAX_API_KEY.
+---
+
+**MiniMax China** serves **MiniMax-M3** over an **Anthropic-compatible** endpoint. The built-in
+`minimax-cn` preset supplies `kind = "anthropic"`,
+`base_url = "https://api.minimax.cn/anthropic"`, and API-key auth from `MINIMAX_API_KEY`.
+
+For the international endpoint, see [MiniMax](/providers/minimax/). The credentials and hosts are
+separate.
+
+## Configure the upstream
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # keep Anthropic as the default for unrouted models (e.g. claude-*)
+
+[[upstreams]]
+name = "minimax-cn"
+provider = "minimax-cn"
+
+[[routes]]
+model = "MiniMax-M3"
+provider = "minimax-cn"
+```
+
+Ordered `[[upstreams]]` replace shunt's built-in providers, so the config must declare the
+`anthropic` default it still falls back to (`server.default_provider` defaults to `anthropic`).
+
+## Credentials
+
+```bash
+export MINIMAX_API_KEY='...'
+```
+
+Use a key from the China MiniMax open platform. Never write the key into the config.
+`shunt check` validates the config's structure but does not read the key's value — if
+`MINIMAX_API_KEY` is unset, the first request routed to `minimax-cn` returns an authentication
+error.
+
+## Models
+
+| Model id | Notes |
+| :-- | :-- |
+| `MiniMax-M3` | 1M-token context; a client may append Claude Code's `[1m]` marker, which shunt strips before matching, so route the unsuffixed id |
+
+Select the routed id in Claude Code via `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, or a
+subagent's `model:` frontmatter. To surface an entry in the `/model` picker instead, advertise a
+`claude`-prefixed alias with a `[models.upstream_model]` map — see
+[Model Discovery](/guides/model-discovery/). A mapped id must **not** end in `[1m]`.
+
+## Verify
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"MiniMax-M3[1m]","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+Confirm the response's `x-gateway-upstream` header names `minimax-cn`, then
+[point Claude Code at shunt](/guides/connect-claude-code/).

--- a/site/src/content/docs/providers/zhipu.md
+++ b/site/src/content/docs/providers/zhipu.md
@@ -1,0 +1,71 @@
+---
+title: Zhipu (GLM China)
+description: Route GLM Coding Plan models to Zhipu's Anthropic-compatible BigModel endpoint with a ZHIPUAI_API_KEY.
+---
+
+**Zhipu** serves **GLM** models from its China BigModel platform over an
+**Anthropic-compatible** endpoint. The built-in `zhipu` preset supplies
+`kind = "anthropic"`, `base_url = "https://open.bigmodel.cn/api/anthropic"`, and API-key auth
+from `ZHIPUAI_API_KEY`.
+
+For the international Z.ai endpoint, see [Z.ai (GLM)](/providers/zai/). The credentials and
+hosts are separate.
+
+## Configure the upstream
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # keep Anthropic as the default for unrouted models (e.g. claude-*)
+
+[[upstreams]]
+name = "zhipu"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3-flash"
+provider = "zhipu"
+```
+
+Ordered `[[upstreams]]` replace shunt's built-in providers, so the config must declare the
+`anthropic` default it still falls back to (`server.default_provider` defaults to `anthropic`).
+
+## Credentials
+
+```bash
+export ZHIPUAI_API_KEY='...'
+```
+
+Never write the key into the config. `shunt check` validates the config's structure but does not
+read the key's value — if `ZHIPUAI_API_KEY` is unset, the first request routed to `zhipu` returns
+an authentication error.
+
+## Models
+
+| Model id | Notes |
+| :-- | :-- |
+| `glm-5.3` | GLM Coding Plan flagship text model |
+| `glm-5.3-flash` | faster multimodal tier; clients may append `[1m]`, which shunt strips before route matching |
+
+Select a routed id in Claude Code via `ANTHROPIC_MODEL`, `ANTHROPIC_CUSTOM_MODEL_OPTION`, or a
+subagent's `model:` frontmatter. To surface an entry in the `/model` picker instead, advertise a
+`claude`-prefixed alias with a `[models.upstream_model]` map — see
+[Model Discovery](/guides/model-discovery/).
+
+## Verify
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"glm-5.3-flash","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+Confirm the response's `x-gateway-upstream` header names `zhipu`, then
+[point Claude Code at shunt](/guides/connect-claude-code/).

--- a/site/src/content/docs/reference/cli.mdx
+++ b/site/src/content/docs/reference/cli.mdx
@@ -42,7 +42,7 @@ shunt init --root /path/to/project
 shunt init --force
 ```
 
-With no upstreams, the starter is fully commented and loads to shunt's passthrough defaults. Repeat `--upstream` to add preset entries in failover order; accepted names are `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, and `kimi-code`. Unmapped traffic remains on the default Anthropic passthrough because the starter does not set `server.default_provider`. When you request presets, a trailing `anthropic` passthrough upstream is appended automatically (unless you name `anthropic` yourself) so the generated file passes `shunt check` while keeping that fallback.
+With no upstreams, the starter is fully commented and loads to shunt's passthrough defaults. Repeat `--upstream` to add preset entries in failover order; accepted names are `anthropic`, `codex`, `openai`, `xai`, `grok`, `kimi`, `cursor`, `kimi-code`, `zhipu`, and `minimax-cn`. Unmapped traffic remains on the default Anthropic passthrough because the starter does not set `server.default_provider`. When you request presets, a trailing `anthropic` passthrough upstream is appended automatically (unless you name `anthropic` yourself) so the generated file passes `shunt check` while keeping that fallback.
 
 The root defaults to the current directory and must already exist. If `shunt.toml`, `shunt.yaml`, or `shunt.yml` exists there, init stops without writing unless `--force` is set. Forced init overwrites only `shunt.toml`; YAML variants stay untouched, and the new TOML file takes precedence during config discovery.
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -415,6 +415,8 @@ Available presets:
 | `kimi` | `anthropic` | `https://api.moonshot.ai/anthropic` | `api_key`, env `MOONSHOT_API_KEY` |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | `cursor_oauth` |
 | `kimi-code` | `anthropic` | `https://api.kimi.com/coding` | `kimi_oauth` |
+| `zhipu` | `anthropic` | `https://open.bigmodel.cn/api/anthropic` | `api_key`, env `ZHIPUAI_API_KEY` |
+| `minimax-cn` | `anthropic` | `https://api.minimax.cn/anthropic` | `api_key`, env `MINIMAX_API_KEY` |
 
 A bare string such as `auth = "claude_oauth"` is shorthand for `auth = { mode = "claude_oauth" }`. `api_key` maps accept `env` (required unless the preset supplies it) and `header` (`bearer` by default, or `x_api_key`). `claude_oauth`, `chatgpt_oauth`, and `kimi_oauth` maps may select `account = "name"` or `accounts = [...]`, but not both. `accounts` accepts bare store-entry names and full account tables; an explicitly empty `accounts = []` is rejected, while omitting both scope fields scans the whole store. If the ChatGPT store is empty, `chatgpt_oauth` retains its `~/.codex/auth.json` fallback. `passthrough`, `xai_oauth`, `cursor_oauth`, and `antigravity_oauth` maps take only `mode`; unknown mode-specific keys are errors.
 

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -168,7 +168,9 @@ ChatGPT 账户的 Codex 后端**拒绝** `gpt-*-codex` slug —— 它只接受�
 | [Kimi Code(订阅制,OAuth)](/zh-cn/providers/kimi/#kimi-codeoauth-订阅) | `https://api.kimi.com/coding` | 使用你的订阅暴露的模型 ID |
 | [DeepSeek](/zh-cn/providers/deepseek/) | `https://api.deepseek.com/anthropic` | `deepseek-v4-pro`、`deepseek-v4-flash` |
 | [Z.ai (GLM)](/zh-cn/providers/zai/) | `https://api.z.ai/api/anthropic` | `glm-5.2`、`glm-4.7` |
+| [智谱（GLM 国内版）](/zh-cn/providers/zhipu/) | `https://open.bigmodel.cn/api/anthropic` | `glm-5.3`、`glm-5.3-flash` |
 | [MiniMax](/zh-cn/providers/minimax/) | `https://api.minimax.io/anthropic` | 见 [MiniMax 文档](https://platform.minimax.io/docs/token-plan/claude-code) |
+| [MiniMax 国内版](/zh-cn/providers/minimax-cn/) | `https://api.minimax.cn/anthropic` | `MiniMax-M3` |
 | [Mimo (Xiaomi)](/zh-cn/providers/mimo/) | `https://api.xiaomimimo.com/anthropic` | `mimo-v2.5-pro` — 见 [Mimo 文档](https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode) |
 | [OpenRouter](/zh-cn/providers/openrouter/) | `https://openrouter.ai/api` | `anthropic/claude-opus-4.8` |
 | [Vercel AI Gateway](/zh-cn/providers/vercel-ai-gateway/) | `https://ai-gateway.vercel.sh` | `anthropic/claude-opus-4.8`(接受 `x_api_key`) |

--- a/site/src/content/docs/zh-cn/providers/minimax-cn.md
+++ b/site/src/content/docs/zh-cn/providers/minimax-cn.md
@@ -1,0 +1,61 @@
+---
+title: MiniMax China
+description: 用 MINIMAX_API_KEY 将 MiniMax-M3 路由到 MiniMax 国内兼容 Anthropic 的端点。
+---
+
+**MiniMax 中国版**通过**兼容 Anthropic** 的端点提供 **MiniMax-M3**。内置的 `minimax-cn`
+预设提供 `kind = "anthropic"`、`base_url = "https://api.minimax.cn/anthropic"`，以及来自
+`MINIMAX_API_KEY` 的 API 密钥认证。
+
+国际版端点见 [MiniMax](/zh-cn/providers/minimax/)。两者的主机和凭据互不相同。
+
+## 配置上游
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # 让 Anthropic 作为无路由匹配模型(例如 claude-*)的默认项
+
+[[upstreams]]
+name = "minimax-cn"
+provider = "minimax-cn"
+
+[[routes]]
+model = "MiniMax-M3"
+provider = "minimax-cn"
+```
+
+有序的 `[[upstreams]]` 会替换 shunt 的内置提供方，因此该配置必须声明它仍然回退到的
+`anthropic` 默认项(`server.default_provider` 默认为 `anthropic`)。
+
+## 凭据
+
+```bash
+export MINIMAX_API_KEY='...'
+```
+
+请使用中国 MiniMax 开放平台的密钥。绝不要把密钥写进配置。`shunt check` 校验配置的结构，但不会
+读取密钥的值 —— 如果 `MINIMAX_API_KEY` 未设置，第一个被路由到 `minimax-cn` 的请求会返回认证错误。
+
+## 模型
+
+| 模型 ID | 说明 |
+| :-- | :-- |
+| `MiniMax-M3` | 1M token 上下文；客户端可以添加 Claude Code 的 `[1m]` 标记，shunt 会在匹配前移除它，因此请路由不带后缀的 ID |
+
+在 Claude Code 中通过 `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION` 或子 agent 的
+`model:` frontmatter 选择一个已路由的 ID。
+
+## 校验
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"MiniMax-M3[1m]","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+确认响应的 `x-gateway-upstream` 头写的是 `minimax-cn`，然后
+[将 Claude Code 指向 shunt](/zh-cn/guides/connect-claude-code/)。

--- a/site/src/content/docs/zh-cn/providers/minimax-cn.md
+++ b/site/src/content/docs/zh-cn/providers/minimax-cn.md
@@ -44,7 +44,9 @@ export MINIMAX_API_KEY='...'
 | `MiniMax-M3` | 1M token 上下文；客户端可以添加 Claude Code 的 `[1m]` 标记，shunt 会在匹配前移除它，因此请路由不带后缀的 ID |
 
 在 Claude Code 中通过 `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION` 或子 agent 的
-`model:` frontmatter 选择一个已路由的 ID。
+`model:` frontmatter 选择一个已路由的 ID。要在 `/model` 选择器中展示条目,请用
+`[models.upstream_model]` 映射声明一个以 `claude` 为前缀的别名 —— 见
+[模型发现](/zh-cn/guides/model-discovery/)。被映射的 ID **不得**以 `[1m]` 结尾。
 
 ## 校验
 

--- a/site/src/content/docs/zh-cn/providers/zhipu.md
+++ b/site/src/content/docs/zh-cn/providers/zhipu.md
@@ -1,0 +1,67 @@
+---
+title: Zhipu (GLM China)
+description: 用 ZHIPUAI_API_KEY 将 GLM Coding Plan 模型路由到智谱兼容 Anthropic 的 BigModel 端点。
+---
+
+**智谱**在中国 BigModel 平台上通过**兼容 Anthropic** 的端点提供 **GLM** 模型。内置的
+`zhipu` 预设提供 `kind = "anthropic"`、
+`base_url = "https://open.bigmodel.cn/api/anthropic"`，以及来自 `ZHIPUAI_API_KEY` 的
+API 密钥认证。
+
+国际版 Z.ai 端点见 [Z.ai (GLM)](/zh-cn/providers/zai/)。两者的主机和凭据互不相同。
+
+## 配置上游
+
+```toml
+[[upstreams]]
+name = "anthropic"
+provider = "anthropic"   # 让 Anthropic 作为无路由匹配模型(例如 claude-*)的默认项
+
+[[upstreams]]
+name = "zhipu"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3"
+provider = "zhipu"
+
+[[routes]]
+model = "glm-5.3-flash"
+provider = "zhipu"
+```
+
+有序的 `[[upstreams]]` 会替换 shunt 的内置提供方，因此该配置必须声明它仍然回退到的
+`anthropic` 默认项(`server.default_provider` 默认为 `anthropic`)。
+
+## 凭据
+
+```bash
+export ZHIPUAI_API_KEY='...'
+```
+
+绝不要把密钥写进配置。`shunt check` 校验配置的结构，但不会读取密钥的值 —— 如果
+`ZHIPUAI_API_KEY` 未设置，第一个被路由到 `zhipu` 的请求会返回认证错误。
+
+## 模型
+
+| 模型 ID | 说明 |
+| :-- | :-- |
+| `glm-5.3` | GLM Coding Plan 旗舰文本模型 |
+| `glm-5.3-flash` | 更快的多模态档位；客户端可以添加 `[1m]`，shunt 会在路由匹配前移除它 |
+
+在 Claude Code 中通过 `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION` 或子 agent 的
+`model:` frontmatter 选择一个已路由的 ID。
+
+## 校验
+
+```bash
+shunt check    # -> config ok
+shunt run
+curl -sS http://127.0.0.1:3001/v1/messages \
+  -H 'anthropic-version: 2023-06-01' \
+  -H 'content-type: application/json' \
+  -d '{"model":"glm-5.3-flash","max_tokens":16,"messages":[{"role":"user","content":"Reply with OK."}]}'
+```
+
+确认响应的 `x-gateway-upstream` 头写的是 `zhipu`，然后
+[将 Claude Code 指向 shunt](/zh-cn/guides/connect-claude-code/)。

--- a/site/src/content/docs/zh-cn/providers/zhipu.md
+++ b/site/src/content/docs/zh-cn/providers/zhipu.md
@@ -50,7 +50,9 @@ export ZHIPUAI_API_KEY='...'
 | `glm-5.3-flash` | 更快的多模态档位；客户端可以添加 `[1m]`，shunt 会在路由匹配前移除它 |
 
 在 Claude Code 中通过 `ANTHROPIC_MODEL`、`ANTHROPIC_CUSTOM_MODEL_OPTION` 或子 agent 的
-`model:` frontmatter 选择一个已路由的 ID。
+`model:` frontmatter 选择一个已路由的 ID。要在 `/model` 选择器中展示条目,请用
+`[models.upstream_model]` 映射声明一个以 `claude` 为前缀的别名 —— 见
+[模型发现](/zh-cn/guides/model-discovery/)。
 
 ## 校验
 

--- a/site/src/content/docs/zh-cn/reference/cli.mdx
+++ b/site/src/content/docs/zh-cn/reference/cli.mdx
@@ -42,7 +42,7 @@ shunt init --root /path/to/project
 shunt init --force
 ```
 
-不指定 upstream 时，starter 完全由注释组成，加载后使用 shunt 的默认 passthrough 配置。重复使用 `--upstream` 可按 failover 顺序添加 preset 条目；可用名称为 `anthropic`、`codex`、`openai`、`xai`、`grok`、`kimi`、`cursor` 和 `kimi-code`。Starter 不设置 `server.default_provider`，因此未映射流量仍使用默认 Anthropic passthrough。指定 preset 时，会在末尾自动追加一个 `anthropic` passthrough upstream（除非你自己指定了 `anthropic`），使生成的文件既能通过 `shunt check`，又能保留该 fallback。
+不指定 upstream 时，starter 完全由注释组成，加载后使用 shunt 的默认 passthrough 配置。重复使用 `--upstream` 可按 failover 顺序添加 preset 条目；可用名称为 `anthropic`、`codex`、`openai`、`xai`、`grok`、`kimi`、`cursor`、`kimi-code`、`zhipu` 和 `minimax-cn`。Starter 不设置 `server.default_provider`，因此未映射流量仍使用默认 Anthropic passthrough。指定 preset 时，会在末尾自动追加一个 `anthropic` passthrough upstream（除非你自己指定了 `anthropic`），使生成的文件既能通过 `shunt check`，又能保留该 fallback。
 
 Root 默认为当前目录，并且必须已经存在。如果其中已有 `shunt.toml`、`shunt.yaml` 或 `shunt.yml`，则不带 `--force` 时会停止且不写入任何内容。强制 init 只覆盖 `shunt.toml`；YAML variant 保持不变，config discovery 会优先使用新的 TOML 文件。
 

--- a/site/src/content/docs/zh-cn/reference/configuration.md
+++ b/site/src/content/docs/zh-cn/reference/configuration.md
@@ -270,6 +270,9 @@ codex-fallback = "gpt-5.2"
 | `grok` | `responses` | `https://cli-chat-proxy.grok.com/v1` | `xai_oauth` |
 | `kimi` | `anthropic` | `https://api.moonshot.ai/anthropic` | `api_key`, env `MOONSHOT_API_KEY` |
 | `cursor` | `cursor` | `https://api2.cursor.sh` | `cursor_oauth` |
+| `kimi-code` | `anthropic` | `https://api.kimi.com/coding` | `kimi_oauth` |
+| `zhipu` | `anthropic` | `https://open.bigmodel.cn/api/anthropic` | `api_key`, env `ZHIPUAI_API_KEY` |
+| `minimax-cn` | `anthropic` | `https://api.minimax.cn/anthropic` | `api_key`, env `MINIMAX_API_KEY` |
 
 `auth = "claude_oauth"` 这样的字符串是 `auth = { mode = "claude_oauth" }` 的简写。`api_key` 映射接受 `env`（除非 preset 已提供，否则必需）和 `header`（默认为 `bearer`，也可设为 `x_api_key`）。`claude_oauth` 与 `chatgpt_oauth` 映射可用 `account = "name"` 或 `accounts = [...]` 缩小范围，但不能同时设置两者。`accounts` 接受存储条目名称字符串和完整账户表；显式的 `accounts = []` 会被拒绝，而省略两个范围字段则扫描整个存储。若 ChatGPT 存储为空，`chatgpt_oauth` 仍会回退到 `~/.codex/auth.json`。`passthrough`、`xai_oauth`、`cursor_oauth`、`antigravity_oauth` 映射只接受 `mode`；特定 mode 下的未知键会报错。
 

--- a/site/src/lib/i18n.ts
+++ b/site/src/lib/i18n.ts
@@ -47,12 +47,12 @@ export const NAVIGATION: NavigationGroup[] = [
       { label: "Kimi (Moonshot)", slug: "providers/kimi" },
       { label: "DeepSeek", slug: "providers/deepseek" },
       { label: "Z.ai (GLM)", slug: "providers/zai" },
-      { label: "MiniMax", slug: "providers/minimax" },
       {
         label: "Zhipu (GLM China)",
         translations: { ko: "Zhipu (GLM 중국)", ja: "Zhipu（GLM 中国版）", "zh-cn": "智谱（GLM 国内版）" },
         slug: "providers/zhipu",
       },
+      { label: "MiniMax", slug: "providers/minimax" },
       {
         label: "MiniMax China",
         translations: { ko: "MiniMax 중국", ja: "MiniMax 中国版", "zh-cn": "MiniMax 国内版" },

--- a/site/src/lib/i18n.ts
+++ b/site/src/lib/i18n.ts
@@ -48,6 +48,16 @@ export const NAVIGATION: NavigationGroup[] = [
       { label: "DeepSeek", slug: "providers/deepseek" },
       { label: "Z.ai (GLM)", slug: "providers/zai" },
       { label: "MiniMax", slug: "providers/minimax" },
+      {
+        label: "Zhipu (GLM China)",
+        translations: { ko: "Zhipu (GLM 중국)", ja: "Zhipu（GLM 中国版）", "zh-cn": "智谱（GLM 国内版）" },
+        slug: "providers/zhipu",
+      },
+      {
+        label: "MiniMax China",
+        translations: { ko: "MiniMax 중국", ja: "MiniMax 中国版", "zh-cn": "MiniMax 国内版" },
+        slug: "providers/minimax-cn",
+      },
       { label: "Mimo (Xiaomi)", slug: "providers/mimo" },
       { label: "OpenRouter", slug: "providers/openrouter" },
       { label: "Vercel AI Gateway", slug: "providers/vercel-ai-gateway" },

--- a/src/blueprints.rs
+++ b/src/blueprints.rs
@@ -83,6 +83,16 @@ const BLUEPRINTS: &[Blueprint] = &[
         &[],
         "Kimi Code subscription via kimi_oauth login"
     ),
+    upstream_blueprint!(
+        "zhipu",
+        &["bigmodel"],
+        "Zhipu GLM China via ZHIPUAI_API_KEY"
+    ),
+    upstream_blueprint!(
+        "minimax-cn",
+        &["minimax-china"],
+        "MiniMax China via MINIMAX_API_KEY"
+    ),
 ];
 
 const GENERIC_UPSTREAM: &str = include_str!("../blueprints/upstream/_generic.md");
@@ -271,6 +281,8 @@ mod tests {
             "cursor",
             "antigravity",
             "kimi-code",
+            "zhipu",
+            "minimax-cn",
         ] {
             assert!(error.contains(slug), "missing {slug:?} in {error:?}");
         }

--- a/src/config/presets.rs
+++ b/src/config/presets.rs
@@ -73,6 +73,20 @@ pub(super) const PRESETS: &[ProviderPreset] = &[
         auth: AuthMode::KimiOauth,
         api_key_env: None,
     },
+    ProviderPreset {
+        name: "zhipu",
+        kind: ProviderKind::Anthropic,
+        base_url: "https://open.bigmodel.cn/api/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("ZHIPUAI_API_KEY"),
+    },
+    ProviderPreset {
+        name: "minimax-cn",
+        kind: ProviderKind::Anthropic,
+        base_url: "https://api.minimax.cn/anthropic",
+        auth: AuthMode::ApiKey,
+        api_key_env: Some("MINIMAX_API_KEY"),
+    },
 ];
 
 pub(super) fn find(name: &str) -> Option<&'static ProviderPreset> {
@@ -112,12 +126,14 @@ mod tests {
                 "grok",
                 "kimi",
                 "cursor",
-                "kimi-code"
+                "kimi-code",
+                "zhipu",
+                "minimax-cn"
             ]
         );
         assert_eq!(
             available_names(),
-            "anthropic, codex, openai, xai, grok, kimi, cursor, kimi-code"
+            "anthropic, codex, openai, xai, grok, kimi, cursor, kimi-code, zhipu, minimax-cn"
         );
     }
 
@@ -155,5 +171,23 @@ mod tests {
         let kimi = find("kimi").unwrap();
         assert_eq!(kimi.base_url, "https://api.moonshot.ai/anthropic");
         assert_eq!(kimi.auth, AuthMode::ApiKey);
+    }
+
+    #[test]
+    fn zhipu_preset_uses_the_bigmodel_anthropic_surface() {
+        let zhipu = find("zhipu").unwrap();
+        assert_eq!(zhipu.kind, ProviderKind::Anthropic);
+        assert_eq!(zhipu.base_url, "https://open.bigmodel.cn/api/anthropic");
+        assert_eq!(zhipu.auth, AuthMode::ApiKey);
+        assert_eq!(zhipu.api_key_env, Some("ZHIPUAI_API_KEY"));
+    }
+
+    #[test]
+    fn minimax_cn_preset_uses_the_china_anthropic_surface() {
+        let minimax_cn = find("minimax-cn").unwrap();
+        assert_eq!(minimax_cn.kind, ProviderKind::Anthropic);
+        assert_eq!(minimax_cn.base_url, "https://api.minimax.cn/anthropic");
+        assert_eq!(minimax_cn.auth, AuthMode::ApiKey);
+        assert_eq!(minimax_cn.api_key_env, Some("MINIMAX_API_KEY"));
     }
 }


### PR DESCRIPTION
## Summary

- Add built-in Anthropic-compatible presets for Zhipu's China BigModel endpoint and MiniMax's China endpoint.
- Register matching upstream blueprints and focused preset coverage.
- Update the README surfaces, engineering docs, site navigation, provider guides, configuration/CLI references, and maintained `ko`/`ja`/`zh-cn` translations.

## Details

| Preset | Base URL | Auth |
| :-- | :-- | :-- |
| `zhipu` | `https://open.bigmodel.cn/api/anthropic` | `ZHIPUAI_API_KEY` |
| `minimax-cn` | `https://api.minimax.cn/anthropic` | `MINIMAX_API_KEY` |

The presets use the existing Anthropic provider kind, so no protocol behavior changes are required. Ordered upstream configurations still explicitly preserve the Anthropic passthrough/default.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

I also validated the China endpoints end to end with real provider traffic from two newly connected clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds built-in `zhipu` and `minimax-cn` provider presets so users can route to Zhipu's China BigModel and MiniMax's China Anthropic-compatible endpoints. Both reuse the existing Anthropic provider kind, so no protocol behavior changes.

- `zhipu` targets `https://open.bigmodel.cn/api/anthropic` and reads `ZHIPUAI_API_KEY`.
- `minimax-cn` targets `https://api.minimax.cn/anthropic` and reads `MINIMAX_API_KEY`.
- Registers both as accepted `shunt init --upstream` names and ships matching upstream blueprints.
- Adds provider pages, navigation entries, and reference updates across `en`, `ko`, `ja`, and `zh-cn` docs plus the init and upstreams-failover specs.
- Adds preset unit tests covering kind, base URL, auth mode, and API key env.

<sup>Written for commit e451c9ab360b48fb10a3a492a4b31c61b9043a4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

