### PR TITLE
docs(antigravity): warn that Antigravity's terms prohibit third-party clients

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -186,6 +186,8 @@ OpenAI の Thibault Sottiaux は、他のコーディングハーネスを通じ
 
 とはいえ、非公式なクライアントから ChatGPT/Codex や SuperGrok のサブスクリプション（あるいは Kimi、Cursor などの他のバックエンド）を再利用するかどうかは、あなた自身の判断です。公の歓迎は、将来のポリシーやアカウントに対する措置がないことを保証するものではありません。ご利用は自己責任でお願いします。
 
+**Antigravity は、規約がこれを明記している例外です。** Google の [Antigravity 利用規約](https://antigravity.google/terms)は、「サードパーティのソフトウェア、ツール、サービスを使ってサービスにアクセスすること（例：OpenClaw を Antigravity OAuth と組み合わせて使うこと）は本契約の違反」であり、そのような違反は「Antigravity および／または Gemini CLI アカウントの停止または解約の根拠となり得る」と述べています。shunt の `antigravity` プロバイダーはまさにそれ — Antigravity OAuth を使うサードパーティのソフトウェア — なので、このプロバイダーへのルーティングはその条項にそのまま該当します。`shunt login antigravity` を実行する前に、この点を踏まえて判断してください。
+
 **Cursor** も同じ仕組みです。一度ログインすれば、`cursor:*` のモデル id をルーティングできます。
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -183,6 +183,8 @@ OpenAI의 Thibault Sottiaux는 다른 코딩 하네스를 통해 Codex를 실행
 
 다만, 비공식 클라이언트에서 ChatGPT/Codex나 SuperGrok 구독(또는 Kimi, Cursor 등 다른 백엔드)을 재사용하는 것은 본인의 판단입니다. 공개적인 환영이 향후 정책이나 계정 제재가 없음을 보장하지는 않습니다. 사용에 따른 책임은 본인에게 있습니다.
 
+**Antigravity는 약관이 이를 명시한 예외입니다.** Google의 [Antigravity 약관](https://antigravity.google/terms)은 "서드파티 소프트웨어, 도구, 서비스로 서비스에 접근하는 것(예: OpenClaw를 Antigravity OAuth와 함께 사용)은 본 계약 위반"이며, 그러한 위반은 "Antigravity 및/또는 Gemini CLI 계정의 정지 또는 해지 사유가 될 수 있다"고 명시합니다. shunt의 `antigravity` 프로바이더가 바로 그것 — Antigravity OAuth를 사용하는 서드파티 소프트웨어 — 이므로, 이 프로바이더로 라우팅하는 것은 그 조항에 그대로 해당합니다. `shunt login antigravity`를 실행하기 전에 이를 감안해 결정하세요.
+
 **Cursor**도 같은 방식으로 동작합니다. 한 번 로그인한 뒤 `cursor:*` 모델 id를 라우팅하세요:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ He [followed up](https://x.com/thsottiaux/status/2076119366647894371) by walking
 
 That said, reusing your ChatGPT/Codex or SuperGrok subscription (or Kimi, Cursor, or other backends) from an unofficial client is your own call — a public welcome doesn't guarantee future policy or account enforcement. Use at your own risk.
 
+**Antigravity is the exception where the terms are explicit.** Google's [Antigravity terms](https://antigravity.google/terms) state that "using third party software, tools, or services to access the Service (e.g. using OpenClaw with Antigravity OAuth) is a breach of this Agreement" and that such a breach "may be grounds for suspension or termination of your Antigravity and/or Gemini CLI accounts". shunt's `antigravity` provider is exactly that — third-party software using Antigravity OAuth — so routing through it falls squarely under that clause. Decide with that in mind before running `shunt login antigravity`.
+
 **Cursor** works the same way — log in once and route a `cursor:*` model id:
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,6 +181,8 @@ OpenAI 的 Thibault Sottiaux 已公开欢迎通过其他编码 harness 运行 Co
 
 话虽如此，是否从非官方客户端复用你的 ChatGPT/Codex 或 SuperGrok 订阅（或 Kimi、Cursor 等其他后端），由你自己决定 —— 公开的欢迎并不保证未来的政策或账号层面的处置。使用风险自负。
 
+**Antigravity 是条款对此有明文规定的例外。** Google 的 [Antigravity 条款](https://antigravity.google/terms)写明：“使用第三方软件、工具或服务访问本服务（例如将 OpenClaw 与 Antigravity OAuth 配合使用）即违反本协议”，且此类违约“可能成为暂停或终止你的 Antigravity 和/或 Gemini CLI 账号的理由”。shunt 的 `antigravity` 提供方正是如此 —— 使用 Antigravity OAuth 的第三方软件 —— 因此经由该提供方路由恰好落在该条款之内。运行 `shunt login antigravity` 之前，请据此做出决定。
+
 **Cursor** 的工作方式相同 —— 登录一次,然后路由一个 `cursor:*` 模型 id:
 
 ```bash

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -78,6 +78,17 @@ re-resolved rather than forwarded. Every spelling works.
 For the full setup — login and scopes, project discovery, model slugs, thinking, and what the
 adapter carries — see the dedicated [Antigravity provider page](/providers/antigravity/).
 
+<Aside type="caution" title="Antigravity's terms">
+
+Google's [Antigravity terms](https://antigravity.google/terms) name this use directly: "using third party software, tools,
+or services to access the Service (e.g. using OpenClaw with Antigravity OAuth) is a breach of this
+Agreement", and such a breach "may be grounds for suspension or termination of your Antigravity
+and/or Gemini CLI accounts". shunt is third-party software using Antigravity OAuth, so routing
+through this provider falls squarely under that clause. Whether the subscription is worth that risk
+is your own call — nothing here can shield the account.
+
+</Aside>
+
 <Aside type="caution" title="`antigravity` changed meaning">
 
 `kind = "antigravity"` used to run the local `agy` binary. It is now the HTTP upstream, and the subprocess transport moved to

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -63,6 +63,18 @@ Antigravity は Gemini モデルを effort が id に含まれる形で公開し
 ログインとスコープ、プロジェクトディスカバリー、モデルスラッグ、thinking、アダプターが伝えるものを含む完全なセットアップに
 ついては、専用の [Antigravity プロバイダーページ](/ja/providers/antigravity/)を参照してください。
 
+<Aside type="caution" title="Antigravity の利用規約">
+
+Google の [Antigravity 利用規約](https://antigravity.google/terms)は、この使い方を名指ししています。「サードパーティの
+ソフトウェア、ツール、サービスを使ってサービスにアクセスすること（例：OpenClaw を Antigravity OAuth と
+組み合わせて使うこと）は本契約の違反」であり、そのような違反は「Antigravity および／または Gemini CLI
+アカウントの停止または解約の根拠となり得る」とされています。shunt は Antigravity OAuth を使う
+サードパーティのソフトウェアなので、このプロバイダーへのルーティングはその条項にそのまま該当します。
+サブスクリプションがそのリスクに見合うかどうかはあなた自身の判断であり、ここにあるものは何も
+アカウントを守ってはくれません。
+
+</Aside>
+
 <Aside type="caution" title="`antigravity` の意味が変わりました">
 
 `kind = "antigravity"` はかつてローカルの `agy` バイナリを実行していました。現在は HTTP の上流であり、サブプロセス転送は

--- a/site/src/content/docs/ja/providers/antigravity.mdx
+++ b/site/src/content/docs/ja/providers/antigravity.mdx
@@ -15,6 +15,18 @@ Antigravity には、もう 1 つ古い転送があります。`kind = "antigrav
 [非推奨の `antigravity-cli` 転送](/ja/guides/providers/#非推奨の-antigravity_cli-転送)を参照してください。
 このページは HTTP プロバイダーを扱い、そうした仕組みは一切必要としません。
 
+<Aside type="caution" title="Antigravity の利用規約">
+
+Google の [Antigravity 利用規約](https://antigravity.google/terms)は、この使い方を名指ししています。「サードパーティの
+ソフトウェア、ツール、サービスを使ってサービスにアクセスすること（例：OpenClaw を Antigravity OAuth と
+組み合わせて使うこと）は本契約の違反」であり、そのような違反は「Antigravity および／または Gemini CLI
+アカウントの停止または解約の根拠となり得る」とされています。shunt は Antigravity OAuth を使う
+サードパーティのソフトウェアなので、このプロバイダーへのルーティングはその条項にそのまま該当します。
+サブスクリプションがそのリスクに見合うかどうかはあなた自身の判断であり、ここにあるものは何も
+アカウントを守ってはくれません。
+
+</Aside>
+
 ## クイックスタート
 
 コーディングエージェントにセットアップを任せることもできます — `shunt add` は組み込みのセットアップ

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -63,6 +63,17 @@ Antigravity는 Gemini 모델을 effort가 id에 담긴 형태로 게시하며, �
 전체 설정 — 로그인과 스코프, 프로젝트 디스커버리, 모델 슬러그, thinking, 어댑터가 전달하는 것 — 은 전용
 [Antigravity 프로바이더 페이지](/ko/providers/antigravity/)를 참고하세요.
 
+<Aside type="caution" title="Antigravity 약관">
+
+Google의 [Antigravity 약관](https://antigravity.google/terms)은 이 사용 방식을 직접 지목합니다. "서드파티 소프트웨어, 도구,
+서비스로 서비스에 접근하는 것(예: OpenClaw를 Antigravity OAuth와 함께 사용)은 본 계약 위반"이며,
+그러한 위반은 "Antigravity 및/또는 Gemini CLI 계정의 정지 또는 해지 사유가 될 수 있다"고 명시합니다.
+shunt는 Antigravity OAuth를 사용하는 서드파티 소프트웨어이므로, 이 프로바이더로 라우팅하는 것은 그
+조항에 그대로 해당합니다. 구독이 그 위험을 감수할 만한지는 본인의 판단이며, 여기 있는 어떤 것도 계정을
+보호해 주지 못합니다.
+
+</Aside>
+
 <Aside type="caution" title="`antigravity`의 의미가 바뀌었습니다">
 
 `kind = "antigravity"`는 예전에 로컬 `agy` 바이너리를 실행했습니다. 이제는 HTTP 업스트림이며, 서브프로세스 전송은

--- a/site/src/content/docs/ko/providers/antigravity.mdx
+++ b/site/src/content/docs/ko/providers/antigravity.mdx
@@ -15,6 +15,17 @@ Antigravity에는 두 번째의 더 오래된 전송이 있습니다. `kind = "a
 [더 이상 사용되지 않는 `antigravity-cli` 전송](/ko/guides/providers/#더-이상-사용되지-않는-antigravity_cli-전송)을
 참고하세요. 이 페이지는 그런 장치가 전혀 필요 없는 HTTP 프로바이더를 다룹니다.
 
+<Aside type="caution" title="Antigravity 약관">
+
+Google의 [Antigravity 약관](https://antigravity.google/terms)은 이 사용 방식을 직접 지목합니다. "서드파티 소프트웨어, 도구,
+서비스로 서비스에 접근하는 것(예: OpenClaw를 Antigravity OAuth와 함께 사용)은 본 계약 위반"이며,
+그러한 위반은 "Antigravity 및/또는 Gemini CLI 계정의 정지 또는 해지 사유가 될 수 있다"고 명시합니다.
+shunt는 Antigravity OAuth를 사용하는 서드파티 소프트웨어이므로, 이 프로바이더로 라우팅하는 것은 그
+조항에 그대로 해당합니다. 구독이 그 위험을 감수할 만한지는 본인의 판단이며, 여기 있는 어떤 것도 계정을
+보호해 주지 못합니다.
+
+</Aside>
+
 ## 빠른 시작
 
 코딩 에이전트가 대신 구성하도록 하세요 — `shunt add`는 내장된 설정 블루프린트를 출력합니다

--- a/site/src/content/docs/providers/antigravity.mdx
+++ b/site/src/content/docs/providers/antigravity.mdx
@@ -15,6 +15,17 @@ as a subprocess and is **deprecated** — see
 [the deprecated `antigravity-cli` transport](/guides/providers/#the-deprecated-antigravity-cli-transport).
 This page covers the HTTP provider, which needs none of that machinery.
 
+<Aside type="caution" title="Antigravity's terms">
+
+Google's [Antigravity terms](https://antigravity.google/terms) name this use directly: "using third party software, tools,
+or services to access the Service (e.g. using OpenClaw with Antigravity OAuth) is a breach of this
+Agreement", and such a breach "may be grounds for suspension or termination of your Antigravity
+and/or Gemini CLI accounts". shunt is third-party software using Antigravity OAuth, so routing
+through this provider falls squarely under that clause. Whether the subscription is worth that risk
+is your own call — nothing here can shield the account.
+
+</Aside>
+
 ## Quick start
 
 Let a coding agent wire it up for you — `shunt add` prints an embedded setup blueprint

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -63,6 +63,15 @@ Antigravity 把 Gemini 模型的 effort 写进 id 发布,并不提供不带后�
 完整设置 —— 登录与 scope、项目发现、模型 slug、thinking,以及适配器承载的内容 —— 见专门的
 [Antigravity 提供方页面](/zh-cn/providers/antigravity/)。
 
+<Aside type="caution" title="Antigravity 的条款">
+
+Google 的 [Antigravity 条款](https://antigravity.google/terms)直接点名了这种用法:"使用第三方软件、工具或服务访问本服务(例如将
+OpenClaw 与 Antigravity OAuth 配合使用)即违反本协议",且此类违约"可能成为暂停或终止你的 Antigravity
+和/或 Gemini CLI 账号的理由"。shunt 就是使用 Antigravity OAuth 的第三方软件,因此经由该提供方路由恰好落在
+该条款之内。这份订阅是否值得冒这个风险由你自己决定 —— 这里没有任何东西能保护你的账号。
+
+</Aside>
+
 <Aside type="caution" title="`antigravity` 的含义已改变">
 
 `kind = "antigravity"` 过去运行的是本地 `agy` 二进制。现在它是 HTTP 上游,而子进程传输迁移到了 `kind = "antigravity_cli"`

--- a/site/src/content/docs/zh-cn/providers/antigravity.mdx
+++ b/site/src/content/docs/zh-cn/providers/antigravity.mdx
@@ -13,6 +13,15 @@ Antigravity 还有第二种、更老的传输方式。`kind = "antigravity_cli"`
 [已废弃的 `antigravity-cli` 传输](/zh-cn/guides/providers/#已废弃的-antigravity_cli-传输)。
 本页讲的是 HTTP 提供方,它完全不需要那套机制。
 
+<Aside type="caution" title="Antigravity 的条款">
+
+Google 的 [Antigravity 条款](https://antigravity.google/terms)直接点名了这种用法:"使用第三方软件、工具或服务访问本服务(例如将
+OpenClaw 与 Antigravity OAuth 配合使用)即违反本协议",且此类违约"可能成为暂停或终止你的 Antigravity
+和/或 Gemini CLI 账号的理由"。shunt 就是使用 Antigravity OAuth 的第三方软件,因此经由该提供方路由恰好落在
+该条款之内。这份订阅是否值得冒这个风险由你自己决定 —— 这里没有任何东西能保护你的账号。
+
+</Aside>
+
 ## 快速开始
 
 让编码 agent 为你完成接入 —— `shunt add` 会打印一份内置的设置蓝图


### PR DESCRIPTION
## Summary

Google's [Antigravity terms](https://antigravity.google/terms) clause 6 states that "using third party software, tools, or services to access the Service (e.g. using OpenClaw with Antigravity OAuth) is a breach of this Agreement", and that such a breach "may be grounds for suspension or termination of your Antigravity and/or Gemini CLI accounts". shunt's `antigravity` provider is third-party software using Antigravity OAuth, so it falls squarely under that clause.

Until now the repo carried only the generic "your own call" disclaimer that covers Codex, Grok, Kimi, and Cursor. Antigravity is the one backend whose terms name this use explicitly, so it warrants a warning the reader sees **before** running `shunt login antigravity` — not a paragraph buried after setup.

The docs quote the clause as written rather than paraphrasing or overstating it. In particular, the clause names **Antigravity and/or Gemini CLI accounts**, not the whole Google account, and the wording added here keeps that scope.

### Changes

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` — a bold paragraph directly after the existing "your own call" disclaimer, quoting the clause verbatim and telling the reader to decide before running `shunt login antigravity`.
- `site/src/content/docs/{,ko/,ja/,zh-cn/}providers/antigravity.mdx` — an `<Aside type="caution" title="Antigravity's terms">` placed before "Quick start", so it is read before login.
- `site/src/content/docs/{,ko/,ja/,zh-cn/}guides/providers.mdx` — the same aside at the end of the Antigravity section, mirroring the Cursor section's existing "Your own call" caution.

12 files, 94 insertions, no code. All four locales are updated in the same PR per AGENTS.md; `wiki/` is generated and was not touched.

## Milestone / spec

None — documentation only; no implementation behavior changes.

## Checklist

- [ ] `cargo build` passes — N/A, no Rust changed
- [ ] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible) — N/A, no Rust changed
- [ ] `cargo clippy --all-targets -- -D warnings` clean — N/A, no Rust changed
- [ ] `cargo fmt --all --check` clean — N/A, no Rust changed
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style (plus the maintained ko/ja/zh-CN translations)
- [x] Frozen spec in `docs/` updated if this change deviates from it — no deviation; `docs/` untouched
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` (+3 locales) and `site/` (8 pages); `wiki/` left alone
- [x] Any new GitHub Action is pinned to a full commit SHA — none added

## Notes for reviewers

- **Verification.** `npm ci && npm run build` in `site/` succeeded: 153 pages built, and the terms link renders in the built HTML for every affected page. Worth stating explicitly because no workflow builds `site/` on a pull request — the docs site is only built on push to `main`, so CI will not produce this evidence for you.
- **Scope of the claim.** Please check the wording against the source clause. The intent is to reproduce it, not to editorialize: the risk named is suspension or termination of the Antigravity and/or Gemini CLI accounts, and the decision is left to the reader.
- **Placement.** On the provider page the aside sits before "Quick start" deliberately, so a reader cannot follow the login steps without passing it first. In the providers guide it sits at the end of the Antigravity section to match the Cursor section's existing caution.
- No code changed, so no cargo checks apply.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning that Google's Antigravity terms explicitly prohibit third-party clients like shunt's `antigravity` provider, with suspension or termination of Antigravity and/or Gemini CLI accounts as a possible consequence. Previously the docs carried only the generic "your own call" disclaimer.

- Quotes the clause verbatim in the README and docs site across all four locales.
- Places the warning before `shunt login antigravity` steps so readers see it before acting.
- No code changed; docs only.

<sup>Written for commit 1daa2cba1e010010efbb7657f9f380c0f18c5848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

