### PR TITLE
fix(codex): bump client identity to 0.153.3 for gpt-6-astra

### DIFF
--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -180,14 +180,14 @@ For a Codex request shunt sends the Codex-CLI identity so client-version gating 
 | `authorization` | `Bearer <access_token>` |
 | `chatgpt-account-id` | `<account_id>` |
 | `originator` | `codex_cli_rs` |
-| `user-agent` | `codex_cli_rs/0.148.0` (`CODEX_USER_AGENT`) |
-| `version` | `0.148.0` (`CODEX_CLIENT_VERSION`) |
+| `user-agent` | `codex_cli_rs/0.153.3` (`CODEX_USER_AGENT`) |
+| `version` | `0.153.3` (`CODEX_CLIENT_VERSION`) |
 | `x-codex-routing-hint` | `model=<upstream_model>`, or `model=<upstream_model>;tier=<service_tier>` when a tier is set — omitted when the model can't be safely put in a header (see below) |
 | `OpenAI-Beta` | `responses=experimental` |
 | `content-type` | `application/json` |
 | `content-encoding` | `zstd` — only when the request body was compressed (see §4.5) |
 
-The `user-agent` / `version` are **pinned to openai/codex rust-v0.148.0**. If a future slug
+The `user-agent` / `version` are **pinned to openai/codex rust-v0.153.3**. If a future slug
 demands a newer client, bump `CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION` in
 `src/adapters/responses/request.rs`.
 
@@ -482,7 +482,7 @@ Claude Code's effort level (`/effort`, the `/model` slider, `--effort`, or
 | `low` / `medium` / `high` / `xhigh` | passthrough |
 | `max` | passthrough on slugs that accept it (the **gpt-5.6** family), else folded to `xhigh` |
 
-`max` folds to `xhigh` unless the upstream slug contains `gpt-5.6` (`supports_max_effort`,
+`max` folds to `xhigh` unless the upstream slug contains `gpt-5.6` or `gpt-6` (`supports_max_effort`,
 `src/model/responses_request.rs`), because `models.json` `supported_reasoning_levels` caps
 `gpt-5.5`/`5.4`/`5.2` at `xhigh` while the gpt-5.6 family accepts `max`.
 
@@ -817,7 +817,7 @@ auto-discovered accounts, so imported store logins still get pooling.)
 - No model-based routing — every inbound request goes to the one configured provider, regardless
   of the `model` field in the body.
 - **Verbatim header passthrough.** The outbound path *synthesizes* the Codex identity headers of
-  §4.4 (pinned `originator`/`user-agent=codex_cli_rs/0.148.0`/`version=0.148.0`, `OpenAI-Beta`, session
+  §4.4 (pinned `originator`/`user-agent=codex_cli_rs/0.153.3`/`version=0.153.3`, `OpenAI-Beta`, session
   headers). The inbound endpoint does **not** — the client already *is* a Codex CLI, so its own
   request headers (`version`, `originator`, `OpenAI-Beta`, `x-codex-*`, …) are forwarded unchanged
   and shunt swaps in **only** the pool account's `Authorization` + `chatgpt-account-id` (and strips

--- a/docs/m11-inbound-codex-endpoint.md
+++ b/docs/m11-inbound-codex-endpoint.md
@@ -112,7 +112,7 @@ the Codex CLI speaks the same wire protocol to shunt that it would speak directl
 Because the inbound client **is** a real Codex CLI (unlike the `/v1/messages` path, where shunt
 *impersonates* one), the passthrough forwards the client's **own request headers verbatim** rather
 than synthesizing them. shunt's translating path builds a fresh request with a hardcoded Codex
-identity (`originator=codex_cli_rs`, `user-agent=codex_cli_rs/0.148.0`, `version=0.148.0`,
+identity (`originator=codex_cli_rs`, `user-agent=codex_cli_rs/0.153.3`, `version=0.153.3`,
 `OpenAI-Beta: responses=experimental`, and session/window headers derived from the session id); the
 inbound passthrough does **not** — it forwards whatever `version`, `originator`, `user-agent`,
 `OpenAI-Beta`, `session-id`, `thread-id`, `x-codex-window-id`, `x-codex-*`, `content-type`, and

--- a/docs/running.md
+++ b/docs/running.md
@@ -806,7 +806,7 @@ an accurate window, one model at a time. (Subagents are a separate path — see 
 > on the `originator` + `version` headers ([openai/codex#31967](https://github.com/openai/codex/issues/31967)).
 > shunt therefore sends the Codex CLI identity headers (`originator: codex_cli_rs`,
 > `version`, and a matching `user-agent`) on ChatGPT OAuth requests, **pinned to
-> openai/codex rust-v0.148.0**. If a future slug demands a newer client, bump the pinned
+> openai/codex rust-v0.153.3**. If a future slug demands a newer client, bump the pinned
 > version in `src/adapters/responses/request.rs` (`CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION`).
 
 Per-context selection also works via Claude Code's own knobs — divert one agent to a mapped model

--- a/site/src/content/docs/guides/codex.mdx
+++ b/site/src/content/docs/guides/codex.mdx
@@ -149,10 +149,10 @@ earlier ones (a free account has resolved to `gpt-5.5`). shunt surfaces the back
 
 <Aside type="note" title="`Model not found <slug>` is client-version gating, not entitlement">
 
-Some slugs carry a `minimal_client_version` (e.g. `gpt-5.6-luna` needs ≥ 0.144.0). When the
+Some slugs carry a `minimal_client_version` (e.g. `gpt-6-astra` needs ≥ 0.153.0). When the
 request's client identity is missing or too old the backend answers `Model not found <slug>`.
 shunt avoids this by sending the pinned Codex CLI identity headers (`originator: codex_cli_rs`,
-`user-agent`, `version`), pinned to **openai/codex rust-v0.148.0**. See
+`user-agent`, `version`), pinned to **openai/codex rust-v0.153.3**. See
 [openai/codex#31967](https://github.com/openai/codex/issues/31967).
 
 </Aside>

--- a/site/src/content/docs/guides/effort-and-context.mdx
+++ b/site/src/content/docs/guides/effort-and-context.mdx
@@ -10,7 +10,7 @@ Claude Code's effort level (`/effort`, the `/model` slider, `--effort`, or `CLAU
 | Claude Code effort | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | passthrough |
-| `max` | passthrough on models that accept it (the **gpt-5.6** family), else folded to `xhigh` |
+| `max` | passthrough on models that accept it (the **gpt-5.6** and **gpt-6** families), else folded to `xhigh` |
 
 Which reasoning levels a Codex slug accepts is listed per-model in openai/codex's [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) (`supported_reasoning_levels`).
 

--- a/src/adapters/responses/request.rs
+++ b/src/adapters/responses/request.rs
@@ -5,10 +5,10 @@ use axum::http::HeaderValue;
 
 use crate::{auth::Credential, routing::Route, server::AppState};
 
-/// Codex CLI client identity, mirrored from openai/codex rust-v0.148.0.
+/// Codex CLI client identity, mirrored from openai/codex rust-v0.153.3.
 ///
-/// The ChatGPT backend routes newer model slugs (e.g. gpt-5.6-luna, which has
-/// `minimal_client_version: 0.144.0`) by client identity and answers
+/// The ChatGPT backend routes newer model slugs (e.g. gpt-6-astra, which has
+/// `minimal_client_version: 0.153.0`) by client identity and answers
 /// "Model not found" — not an entitlement error — when the identity is
 /// missing or too old. Per openai/codex#31967 the gate keys on the
 /// `originator` + `version` header combination; the `user-agent` is sent for
@@ -20,8 +20,8 @@ use crate::{auth::Credential, routing::Route, server::AppState};
 /// `pub(crate)`: also reused by `crate::auth::codex::usage` (the wham/usage
 /// poller) so its CLI identity headers cannot drift from the Responses
 /// adapter's own.
-pub(crate) const CODEX_USER_AGENT: &str = "codex_cli_rs/0.148.0";
-pub(crate) const CODEX_CLIENT_VERSION: &str = "0.148.0";
+pub(crate) const CODEX_USER_AGENT: &str = "codex_cli_rs/0.153.3";
+pub(crate) const CODEX_CLIENT_VERSION: &str = "0.153.3";
 
 /// Grok CLI identity, mirrored from the official Grok CLI (via
 /// raine/claude-code-proxy `src/providers/grok/client.rs`). The subscription

--- a/src/model/responses_request.rs
+++ b/src/model/responses_request.rs
@@ -338,8 +338,8 @@ fn input_items(request: &Value, context: &ToolSearchContext) -> Vec<Value> {
 ///
 /// Which levels the ChatGPT/Codex backend accepts is per-model, listed in
 /// openai/codex `codex-rs/models-manager/models.json` (`supported_reasoning_levels`):
-/// the gpt-5.6 family accepts up to `max` (sol/terra even `ultra`), while the
-/// gpt-5.5/5.4/5.2 slugs cap at `xhigh`. So `max` passes through for a model that
+/// the gpt-5.6 and gpt-6 families accept up to `max` (sol/terra even `ultra`), while
+/// the gpt-5.5/5.4/5.2 slugs cap at `xhigh`. So `max` passes through for a model that
 /// supports it and folds to `xhigh` otherwise. (Claude Code never emits `ultra`.)
 fn map_effort(effort: &str, model: &str) -> String {
     if effort == "max" && !supports_max_effort(model) {
@@ -350,9 +350,9 @@ fn map_effort(effort: &str, model: &str) -> String {
 }
 
 /// Whether `model` accepts the `max` reasoning level, per codex models.json.
-/// The gpt-5.6 family does; earlier slugs cap at `xhigh`.
+/// The gpt-5.6 and gpt-6 families do; earlier slugs cap at `xhigh`.
 fn supports_max_effort(model: &str) -> bool {
-    model.contains("gpt-5.6")
+    model.contains("gpt-5.6") || model.contains("gpt-6")
 }
 
 /// Claude Code sends mid-conversation `system`-role messages (e.g. SessionStart
@@ -991,6 +991,14 @@ mod tests {
         let request = json!({"output_config": {"effort": "max"}});
         assert_eq!(effort(&request, &codex_route_model("gpt-5.6-sol")), "max");
         assert_eq!(effort(&request, &codex_route_model("gpt-5.6-luna")), "max");
+    }
+
+    #[test]
+    fn passes_max_effort_through_for_gpt_6() {
+        // gpt-6* accept `max` natively, so it must not fold to xhigh.
+        let request = json!({"output_config": {"effort": "max"}});
+        assert_eq!(effort(&request, &codex_route_model("gpt-6-astra")), "max");
+        assert_eq!(effort(&request, &codex_route_model("gpt-6-pro")), "max");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes pleaseai/shunt#458. Bumps the pinned Codex CLI client identity to **0.153.3** so `gpt-6-astra` passes the ChatGPT backend `minimal_client_version: 0.153.0` gate, and extends `supports_max_effort` to the **gpt-6** family so Claude Code's `output_config.effort=max` passes through instead of folding to `xhigh`.

## Changes

- `src/adapters/responses/request.rs`: bump `CODEX_USER_AGENT` / `CODEX_CLIENT_VERSION` to `0.153.3` (mirrors openai/codex rust-v0.153.3).
- `src/model/responses_request.rs`: extend `supports_max_effort` for `gpt-6*`; add `passes_max_effort_through_for_gpt_6` unit test.
- `site/src/content/docs/guides/effort-and-context.mdx`: note that `max` is supported on gpt-5.6 and gpt-6 families.

## Checklist

- [x] `cargo fmt --all --check` clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (CI)
- [ ] `cargo test --all-features --workspace` (CI)

Closes #458

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Codex CLI client identity to 0.153.3 so `gpt-6-astra` passes the ChatGPT backend's `minimal_client_version` gate, and lets `max` effort pass through on gpt-6 models.

- Fixes pleaseai/shunt#458.
- Updates `CODEX_USER_AGENT` and `CODEX_CLIENT_VERSION` to `0.153.3`.
- Extends `supports_max_effort` to the `gpt-6` family so `output_config.effort=max` passes through instead of folding to `xhigh`, with a new unit test covering `gpt-6-astra` and `gpt-6-pro`.
- Refreshes docs to reference the new pinned client identity and gpt-6 `max` support.

<sup>Written for commit 5f8c34b5b12fe33614a91b2f2ab98a678f9c9fa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

