### PR TITLE
docs(codex): sync gpt-6 max-effort and 0.153.3 identity across locales

### DIFF
--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -275,8 +275,8 @@ to**, and **rejects the `gpt-*-codex` slugs** (e.g. `gpt-5.2-codex`) with a `400
 - To see what your account can use, look at what the `codex` CLI itself sends, or the live
   `/models` fetch it performs at startup.
 
-> **Client-version gating.** Some slugs carry a `minimal_client_version` (e.g. `gpt-5.6-luna`
-> needs ≥ 0.144.0). When the request's client identity is missing or too old the backend answers
+> **Client-version gating.** Some slugs carry a `minimal_client_version` (e.g. `gpt-6-astra`
+> needs ≥ 0.153.0). When the request's client identity is missing or too old the backend answers
 > **`Model not found <slug>`** — *not* an entitlement error. shunt avoids this by sending the
 > pinned Codex CLI headers (§4.4). See [openai/codex#31967](https://github.com/openai/codex/issues/31967).
 
@@ -480,11 +480,11 @@ Claude Code's effort level (`/effort`, the `/model` slider, `--effort`, or
 | Claude Code effort | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | passthrough |
-| `max` | passthrough on slugs that accept it (the **gpt-5.6** family), else folded to `xhigh` |
+| `max` | passthrough on slugs that accept it (the **gpt-5.6** and **gpt-6** families), else folded to `xhigh` |
 
 `max` folds to `xhigh` unless the upstream slug contains `gpt-5.6` or `gpt-6` (`supports_max_effort`,
 `src/model/responses_request.rs`), because `models.json` `supported_reasoning_levels` caps
-`gpt-5.5`/`5.4`/`5.2` at `xhigh` while the gpt-5.6 family accepts `max`.
+`gpt-5.5`/`5.4`/`5.2` at `xhigh` while the gpt-5.6 and gpt-6 families accept `max`.
 
 > **Custom gateway ids carry effort on their own.** Verified on the wire against Claude Code v2.1.224: an id like `gpt-5.6-sol` already sends
 > `output_config.effort` with `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` unset, and setting it to `1`

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -268,10 +268,10 @@ to**, and **rejects the `gpt-*-codex` slugs** (e.g. `gpt-5.2-codex`) with a `400
 
 - The authoritative catalog of Codex slugs (and the reasoning levels each accepts) is openai/codex's
   [`codex-rs/models-manager/models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
-- Current listed slugs: **`gpt-5.6-sol`**, **`gpt-5.6-terra`**, **`gpt-5.6-luna`** (latest,
-  frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** / **`gpt-5.2`**. Older
-  accounts may only be entitled to the earlier ones; a **free** account has resolved to `gpt-5.5`
-  in testing.
+- Current listed slugs: **`gpt-6-astra`**, **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
+  **`gpt-5.6-luna`** (latest, frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
+  **`gpt-5.2`**. Older accounts may only be entitled to the earlier ones; a **free** account has
+  resolved to `gpt-5.5` in testing.
 - To see what your account can use, look at what the `codex` CLI itself sends, or the live
   `/models` fetch it performs at startup.
 

--- a/docs/codex-configuration.md
+++ b/docs/codex-configuration.md
@@ -268,8 +268,8 @@ to**, and **rejects the `gpt-*-codex` slugs** (e.g. `gpt-5.2-codex`) with a `400
 
 - The authoritative catalog of Codex slugs (and the reasoning levels each accepts) is openai/codex's
   [`codex-rs/models-manager/models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
-- Current listed slugs: **`gpt-6-astra`**, **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
-  **`gpt-5.6-luna`** (latest, frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
+- Current listed slugs: **`gpt-6-astra`** (latest), **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
+  **`gpt-5.6-luna`** (frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
   **`gpt-5.2`**. Older accounts may only be entitled to the earlier ones; a **free** account has
   resolved to `gpt-5.5` in testing.
 - To see what your account can use, look at what the `codex` CLI itself sends, or the live

--- a/docs/running.md
+++ b/docs/running.md
@@ -795,10 +795,10 @@ an accurate window, one model at a time. (Subagents are a separate path — see 
 > `gpt-5.2-codex`) — it only accepts the account's live-entitled slugs. The authoritative catalog
 > of Codex slugs (and the reasoning levels each accepts) is openai/codex's
 > [`codex-rs/models-manager/models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
-> The current listed slugs are **`gpt-5.6-sol`**, **`gpt-5.6-terra`**, **`gpt-5.6-luna`** (latest,
-> frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** / **`gpt-5.2`**; older accounts
-> may only be entitled to the earlier ones. Use `upstream_model` in a route, or pass an entitled
-> slug via `ANTHROPIC_CUSTOM_MODEL_OPTION`. See [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) §0.
+> The current listed slugs are **`gpt-6-astra`**, **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
+> **`gpt-5.6-luna`** (latest, frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
+> **`gpt-5.2`**; older accounts may only be entitled to the earlier ones. Use `upstream_model` in
+> a route, or pass an entitled slug via `ANTHROPIC_CUSTOM_MODEL_OPTION`. See [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) §0.
 
 > **Client-version gating:** some slugs additionally carry a `minimal_client_version` (e.g.
 > `gpt-6-astra` requires ≥ 0.153.0) and the backend answers **`Model not found <slug>`** — not
@@ -925,9 +925,9 @@ it to the Responses `reasoning.effort` for mapped models:
 Which reasoning levels a Codex slug accepts is listed per-model in openai/codex's
 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)
 (`supported_reasoning_levels`): `gpt-5.6-sol`/`-terra`/`-luna` and the gpt-6 slugs (e.g.
-`gpt-6-astra`) accept up to `max` (sol/terra even `ultra`, which Claude Code never sends), while
-`gpt-5.5`/`5.4`/`5.2` cap at `xhigh`. shunt folds `max → xhigh` only for slugs that don't
-support it.
+`gpt-6-astra`) accept up to `max` — `sol`/`terra`/`astra` even `ultra`, which Claude Code never
+sends and `gpt-5.6-luna` does not list — while `gpt-5.5`/`5.4`/`5.2` cap at `xhigh`. shunt folds
+`max → xhigh` only for slugs that don't support it.
 
 **A custom gateway id like `gpt-5.6-sol` carries effort on its own.** Verified on the wire against Claude Code v2.1.224: the request already
 includes `output_config.effort` with `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` unset, and setting it to `1`

--- a/docs/running.md
+++ b/docs/running.md
@@ -795,8 +795,8 @@ an accurate window, one model at a time. (Subagents are a separate path — see 
 > `gpt-5.2-codex`) — it only accepts the account's live-entitled slugs. The authoritative catalog
 > of Codex slugs (and the reasoning levels each accepts) is openai/codex's
 > [`codex-rs/models-manager/models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
-> The current listed slugs are **`gpt-6-astra`**, **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
-> **`gpt-5.6-luna`** (latest, frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
+> The current listed slugs are **`gpt-6-astra`** (latest), **`gpt-5.6-sol`**, **`gpt-5.6-terra`**,
+> **`gpt-5.6-luna`** (frontier), and **`gpt-5.5`** / **`gpt-5.4`** / **`gpt-5.4-mini`** /
 > **`gpt-5.2`**; older accounts may only be entitled to the earlier ones. Use `upstream_model` in
 > a route, or pass an entitled slug via `ANTHROPIC_CUSTOM_MODEL_OPTION`. See [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) §0.
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -104,7 +104,7 @@ auth = "chatgpt_oauth"         # reuses ~/.codex/auth.json
 model = "gpt-5.6-sol"
 provider = "codex"
 # upstream_model = "gpt-5.6-sol"
-# effort = "high"          # gpt-5.6 slugs also accept "max"
+# effort = "high"          # gpt-5.6 and gpt-6 slugs also accept "max"
 
 # Then prefix match.
 [[route_prefixes]]
@@ -801,7 +801,7 @@ an accurate window, one model at a time. (Subagents are a separate path — see 
 > slug via `ANTHROPIC_CUSTOM_MODEL_OPTION`. See [`m2-chatgpt-oauth.md`](m2-chatgpt-oauth.md) §0.
 
 > **Client-version gating:** some slugs additionally carry a `minimal_client_version` (e.g.
-> `gpt-5.6-luna` requires ≥ 0.144.0) and the backend answers **`Model not found <slug>`** — not
+> `gpt-6-astra` requires ≥ 0.153.0) and the backend answers **`Model not found <slug>`** — not
 > an entitlement error — when the request's client identity is missing or too old. The gate keys
 > on the `originator` + `version` headers ([openai/codex#31967](https://github.com/openai/codex/issues/31967)).
 > shunt therefore sends the Codex CLI identity headers (`originator: codex_cli_rs`,
@@ -920,13 +920,14 @@ it to the Responses `reasoning.effort` for mapped models:
 | Claude Code effort | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | passthrough |
-| `max` | passthrough on models that accept it (the **gpt-5.6** family), else folded to `xhigh` |
+| `max` | passthrough on models that accept it (the **gpt-5.6** and **gpt-6** families), else folded to `xhigh` |
 
 Which reasoning levels a Codex slug accepts is listed per-model in openai/codex's
 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)
-(`supported_reasoning_levels`): `gpt-5.6-sol`/`-terra`/`-luna` accept up to `max` (sol/terra even
-`ultra`, which Claude Code never sends), while `gpt-5.5`/`5.4`/`5.2` cap at `xhigh`. shunt folds
-`max → xhigh` only for slugs that don't support it.
+(`supported_reasoning_levels`): `gpt-5.6-sol`/`-terra`/`-luna` and the gpt-6 slugs (e.g.
+`gpt-6-astra`) accept up to `max` (sol/terra even `ultra`, which Claude Code never sends), while
+`gpt-5.5`/`5.4`/`5.2` cap at `xhigh`. shunt folds `max → xhigh` only for slugs that don't
+support it.
 
 **A custom gateway id like `gpt-5.6-sol` carries effort on its own.** Verified on the wire against Claude Code v2.1.224: the request already
 includes `output_config.effort` with `CLAUDE_CODE_ALWAYS_ENABLE_EFFORT` unset, and setting it to `1`

--- a/site/src/content/docs/guides/codex.mdx
+++ b/site/src/content/docs/guides/codex.mdx
@@ -283,7 +283,7 @@ runs `gpt-5.6-luna` — the resolved id is exactly what shunt routes on, so no
 
 Set the effort with Claude Code's usual controls (`/effort`, the `/model` slider, `--effort`).
 shunt maps it to the Responses `reasoning.effort`, folding `max → xhigh` for slugs that don't
-support `max` (only the **gpt-5.6** family does).
+support `max` (the **gpt-5.6** and **gpt-6** families do).
 
 
 

--- a/site/src/content/docs/guides/codex.mdx
+++ b/site/src/content/docs/guides/codex.mdx
@@ -136,7 +136,7 @@ The ChatGPT-account backend **rejects** `gpt-*-codex` slugs (e.g. `gpt-5.2-codex
 it only accepts your account's **live-entitled** slugs. The authoritative catalog (and the
 reasoning levels each accepts) is openai/codex's
 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json).
-Current slugs: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (frontier) and
+Current slugs: `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (frontier) and
 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`. Older accounts may only be entitled to the
 earlier ones (a free account has resolved to `gpt-5.5`). shunt surfaces the backend's own error
 `detail`, so a wrong slug returns the real reason.

--- a/site/src/content/docs/guides/codex.mdx
+++ b/site/src/content/docs/guides/codex.mdx
@@ -283,7 +283,7 @@ runs `gpt-5.6-luna` — the resolved id is exactly what shunt routes on, so no
 
 Set the effort with Claude Code's usual controls (`/effort`, the `/model` slider, `--effort`).
 shunt maps it to the Responses `reasoning.effort`, folding `max → xhigh` for slugs that don't
-support `max` (the **gpt-5.6** and **gpt-6** families do).
+support `max` (only the **gpt-5.6** and **gpt-6** families do).
 
 
 

--- a/site/src/content/docs/guides/providers.mdx
+++ b/site/src/content/docs/guides/providers.mdx
@@ -204,7 +204,7 @@ xAI may gate OAuth access by subscription tier — if `grok` returns 403, use th
 
 <Aside type="caution" title="Model slugs">
 
-The ChatGPT-account Codex backend **rejects** `gpt-*-codex` slugs — it only accepts the account's live-entitled slugs. The authoritative catalog is openai/codex's [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json). Current slugs are `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (frontier) and `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`; older accounts may only be entitled to the earlier ones. Use `upstream_model` in a route to map any alias onto an entitled slug.
+The ChatGPT-account Codex backend **rejects** `gpt-*-codex` slugs — it only accepts the account's live-entitled slugs. The authoritative catalog is openai/codex's [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json). Current slugs are `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (frontier) and `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`; older accounts may only be entitled to the earlier ones. Use `upstream_model` in a route to map any alias onto an entitled slug.
 
 </Aside>
 

--- a/site/src/content/docs/ja/guides/codex.mdx
+++ b/site/src/content/docs/ja/guides/codex.mdx
@@ -235,7 +235,7 @@ provider = "codex"
 
 ## 5. 推論エフォート
 
-エフォートは Claude Code の通常のコントロール（`/effort`、`/model` のスライダー、`--effort`）で設定します。shunt はそれを Responses の `reasoning.effort` へマッピングし、`max` をサポートしないスラッグでは `max → xhigh` に折りたたみます（サポートするのは **gpt-5.6** と **gpt-6** ファミリー）。
+エフォートは Claude Code の通常のコントロール（`/effort`、`/model` のスライダー、`--effort`）で設定します。shunt はそれを Responses の `reasoning.effort` へマッピングし、`max` をサポートしないスラッグでは `max → xhigh` に折りたたみます（サポートするのは **gpt-5.6** と **gpt-6** ファミリーのみ）。
 
 
 

--- a/site/src/content/docs/ja/guides/codex.mdx
+++ b/site/src/content/docs/ja/guides/codex.mdx
@@ -112,7 +112,7 @@ provider = "codex"
 <Aside type="caution" title="モデルスラッグ — `-codex` は不可">
 
 ChatGPT アカウントのバックエンドは `gpt-*-codex` スラッグ（例 `gpt-5.2-codex`）を `400` で**拒否**します。アカウントが**ライブで entitle されている**スラッグのみを受け入れます。信頼できるカタログ（および各スラッグが受け入れる reasoning レベル）は openai/codex の
-[`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) です。現在のスラッグ: `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`（フロンティア）と
+[`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) です。現在のスラッグ: `gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`（フロンティア）と
 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`。古いアカウントでは以前のものにしか entitle されていない場合があります（無料アカウントは `gpt-5.5` に解決されています）。shunt はバックエンド自身のエラー `detail` を表面化するため、間違ったスラッグは本当の理由を返します。
 
 </Aside>

--- a/site/src/content/docs/ja/guides/codex.mdx
+++ b/site/src/content/docs/ja/guides/codex.mdx
@@ -123,7 +123,7 @@ ChatGPT アカウントのバックエンドは `gpt-*-codex` スラッグ（例
 
 <Aside type="note" title="`Model not found <slug>` は entitlement ではなくクライアントバージョンのゲーティング">
 
-一部のスラッグは `minimal_client_version` を持ちます（例 `gpt-5.6-luna` は ≥ 0.144.0 が必要）。リクエストのクライアント identity が欠落しているか古すぎる場合、バックエンドは `Model not found <slug>` と応答します。shunt は固定された Codex CLI の identity ヘッダー（`originator: codex_cli_rs`、`user-agent`、`version`）を **openai/codex rust-v0.148.0** に固定して送ることで、これを回避します。[openai/codex#31967](https://github.com/openai/codex/issues/31967) を参照してください。
+一部のスラッグは `minimal_client_version` を持ちます（例 `gpt-6-astra` は ≥ 0.153.0 が必要）。リクエストのクライアント identity が欠落しているか古すぎる場合、バックエンドは `Model not found <slug>` と応答します。shunt は固定された Codex CLI の identity ヘッダー（`originator: codex_cli_rs`、`user-agent`、`version`）を **openai/codex rust-v0.153.3** に固定して送ることで、これを回避します。[openai/codex#31967](https://github.com/openai/codex/issues/31967) を参照してください。
 
 </Aside>
 
@@ -235,7 +235,7 @@ provider = "codex"
 
 ## 5. 推論エフォート
 
-エフォートは Claude Code の通常のコントロール（`/effort`、`/model` のスライダー、`--effort`）で設定します。shunt はそれを Responses の `reasoning.effort` へマッピングし、`max` をサポートしないスラッグでは `max → xhigh` に折りたたみます（サポートするのは **gpt-5.6** ファミリーのみ）。
+エフォートは Claude Code の通常のコントロール（`/effort`、`/model` のスライダー、`--effort`）で設定します。shunt はそれを Responses の `reasoning.effort` へマッピングし、`max` をサポートしないスラッグでは `max → xhigh` に折りたたみます（サポートするのは **gpt-5.6** と **gpt-6** ファミリー）。
 
 
 

--- a/site/src/content/docs/ja/guides/effort-and-context.mdx
+++ b/site/src/content/docs/ja/guides/effort-and-context.mdx
@@ -10,7 +10,7 @@ Claude Code のエフォートレベル（`/effort`、`/model` のスライダ�
 | Claude Code のエフォート | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | パススルー |
-| `max` | 受け入れるモデル（**gpt-5.6** ファミリー）ではパススルー、それ以外は `xhigh` に折りたたむ |
+| `max` | 受け入れるモデル（**gpt-5.6** と **gpt-6** ファミリー）ではパススルー、それ以外は `xhigh` に折りたたむ |
 
 Codex スラッグがどの reasoning レベルを受け入れるかは、openai/codex の [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)（`supported_reasoning_levels`）にモデルごとに記載されています。
 

--- a/site/src/content/docs/ja/guides/providers.mdx
+++ b/site/src/content/docs/ja/guides/providers.mdx
@@ -144,7 +144,7 @@ codex login
 
 <Aside type="caution" title="モデルスラッグ">
 
-ChatGPT アカウントの Codex バックエンドは `gpt-*-codex` スラッグを**拒否**します — アカウントがライブで entitle されているスラッグのみを受け入れます。信頼できるカタログは openai/codex の [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) です。現在のスラッグは `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`（フロンティア）と `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2` です。古いアカウントでは以前のものにしか entitle されていない場合があります。ルート内で `upstream_model` を使い、任意のエイリアスを entitle されたスラッグへマッピングしてください。
+ChatGPT アカウントの Codex バックエンドは `gpt-*-codex` スラッグを**拒否**します — アカウントがライブで entitle されているスラッグのみを受け入れます。信頼できるカタログは openai/codex の [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) です。現在のスラッグは `gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`（フロンティア）と `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2` です。古いアカウントでは以前のものにしか entitle されていない場合があります。ルート内で `upstream_model` を使い、任意のエイリアスを entitle されたスラッグへマッピングしてください。
 
 </Aside>
 

--- a/site/src/content/docs/ko/guides/codex.mdx
+++ b/site/src/content/docs/ko/guides/codex.mdx
@@ -119,7 +119,7 @@ ChatGPT 계정 백엔드는 `gpt-*-codex` 슬러그(예: `gpt-5.2-codex`)를 `40
 
 <Aside type="note" title="`Model not found <slug>`는 자격이 아니라 클라이언트 버전 게이팅입니다">
 
-일부 슬러그는 `minimal_client_version`을 요구합니다(예: `gpt-5.6-luna`는 ≥ 0.144.0 필요). 요청의 클라이언트 신원이 없거나 너무 오래되면 백엔드는 `Model not found <slug>`를 반환합니다. shunt는 고정된 Codex CLI 신원 헤더(`originator: codex_cli_rs`, `user-agent`, `version`)를 **openai/codex rust-v0.148.0**에 고정하여 보내므로 이를 피합니다. [openai/codex#31967](https://github.com/openai/codex/issues/31967)을 참고하세요.
+일부 슬러그는 `minimal_client_version`을 요구합니다(예: `gpt-6-astra`는 ≥ 0.153.0 필요). 요청의 클라이언트 신원이 없거나 너무 오래되면 백엔드는 `Model not found <slug>`를 반환합니다. shunt는 고정된 Codex CLI 신원 헤더(`originator: codex_cli_rs`, `user-agent`, `version`)를 **openai/codex rust-v0.153.3**에 고정하여 보내므로 이를 피합니다. [openai/codex#31967](https://github.com/openai/codex/issues/31967)을 참고하세요.
 
 </Aside>
 
@@ -222,7 +222,7 @@ provider = "codex"
 
 ## 5. 추론 노력
 
-Claude Code의 일반 컨트롤(`/effort`, `/model` 슬라이더, `--effort`)로 노력을 설정하세요. shunt는 이를 Responses `reasoning.effort`로 매핑하며, `max`를 지원하지 않는 슬러그에 대해서는 `max → xhigh`로 접습니다(오직 **gpt-5.6** 계열만 지원).
+Claude Code의 일반 컨트롤(`/effort`, `/model` 슬라이더, `--effort`)로 노력을 설정하세요. shunt는 이를 Responses `reasoning.effort`로 매핑하며, `max`를 지원하지 않는 슬러그에 대해서는 `max → xhigh`로 접습니다(**gpt-5.6** 및 **gpt-6** 계열이 지원).
 
 
 

--- a/site/src/content/docs/ko/guides/codex.mdx
+++ b/site/src/content/docs/ko/guides/codex.mdx
@@ -222,7 +222,7 @@ provider = "codex"
 
 ## 5. 추론 노력
 
-Claude Code의 일반 컨트롤(`/effort`, `/model` 슬라이더, `--effort`)로 노력을 설정하세요. shunt는 이를 Responses `reasoning.effort`로 매핑하며, `max`를 지원하지 않는 슬러그에 대해서는 `max → xhigh`로 접습니다(**gpt-5.6** 및 **gpt-6** 계열이 지원).
+Claude Code의 일반 컨트롤(`/effort`, `/model` 슬라이더, `--effort`)로 노력을 설정하세요. shunt는 이를 Responses `reasoning.effort`로 매핑하며, `max`를 지원하지 않는 슬러그에 대해서는 `max → xhigh`로 접습니다(**gpt-5.6** 및 **gpt-6** 계열만 지원).
 
 
 

--- a/site/src/content/docs/ko/guides/codex.mdx
+++ b/site/src/content/docs/ko/guides/codex.mdx
@@ -109,7 +109,7 @@ provider = "codex"
 
 <Aside type="caution" title="모델 슬러그 — `-codex` 금지">
 
-ChatGPT 계정 백엔드는 `gpt-*-codex` 슬러그(예: `gpt-5.2-codex`)를 `400`으로 **거부**합니다. 계정에 **실시간으로 부여된** 슬러그만 받아들입니다. 권위 있는 카탈로그(및 각 슬러그가 받아들이는 추론 레벨)는 openai/codex의 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)입니다. 현재 슬러그: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`(프런티어)와 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`. 오래된 계정은 이전 슬러그만 부여받았을 수 있습니다(무료 계정은 `gpt-5.5`로 해석된 바 있습니다). shunt는 백엔드 자체의 오류 `detail`을 노출하므로, 잘못된 슬러그는 실제 이유를 반환합니다.
+ChatGPT 계정 백엔드는 `gpt-*-codex` 슬러그(예: `gpt-5.2-codex`)를 `400`으로 **거부**합니다. 계정에 **실시간으로 부여된** 슬러그만 받아들입니다. 권위 있는 카탈로그(및 각 슬러그가 받아들이는 추론 레벨)는 openai/codex의 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)입니다. 현재 슬러그: `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`(프런티어)와 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`. 오래된 계정은 이전 슬러그만 부여받았을 수 있습니다(무료 계정은 `gpt-5.5`로 해석된 바 있습니다). shunt는 백엔드 자체의 오류 `detail`을 노출하므로, 잘못된 슬러그는 실제 이유를 반환합니다.
 
 </Aside>
 

--- a/site/src/content/docs/ko/guides/effort-and-context.mdx
+++ b/site/src/content/docs/ko/guides/effort-and-context.mdx
@@ -10,7 +10,7 @@ Claude Code의 노력 레벨(`/effort`, `/model` 슬라이더, `--effort`, 또�
 | Claude Code 노력 | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | 패스스루 |
-| `max` | 받아들이는 모델(**gpt-5.6** 계열)에서는 패스스루, 그 외에는 `xhigh`로 접힘 |
+| `max` | 받아들이는 모델(**gpt-5.6** 및 **gpt-6** 계열)에서는 패스스루, 그 외에는 `xhigh`로 접힘 |
 
 Codex 슬러그가 어떤 추론 레벨을 받아들이는지는 openai/codex의 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)에 모델별로(`supported_reasoning_levels`) 나열되어 있습니다.
 

--- a/site/src/content/docs/ko/guides/providers.mdx
+++ b/site/src/content/docs/ko/guides/providers.mdx
@@ -142,7 +142,7 @@ codex login
 
 <Aside type="caution" title="모델 슬러그">
 
-ChatGPT 계정 Codex 백엔드는 `gpt-*-codex` 슬러그를 **거부**합니다 — 계정에 실시간으로 부여된(live-entitled) 슬러그만 받아들입니다. 권위 있는 카탈로그는 openai/codex의 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)입니다. 현재 슬러그는 `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`(프런티어)와 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`입니다. 오래된 계정은 이전 슬러그만 부여받았을 수 있습니다. 라우트에서 `upstream_model`을 사용하면 임의의 별칭을 부여된 슬러그로 매핑할 수 있습니다.
+ChatGPT 계정 Codex 백엔드는 `gpt-*-codex` 슬러그를 **거부**합니다 — 계정에 실시간으로 부여된(live-entitled) 슬러그만 받아들입니다. 권위 있는 카탈로그는 openai/codex의 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)입니다. 현재 슬러그는 `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`(프런티어)와 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`입니다. 오래된 계정은 이전 슬러그만 부여받았을 수 있습니다. 라우트에서 `upstream_model`을 사용하면 임의의 별칭을 부여된 슬러그로 매핑할 수 있습니다.
 
 </Aside>
 

--- a/site/src/content/docs/zh-cn/guides/codex.mdx
+++ b/site/src/content/docs/zh-cn/guides/codex.mdx
@@ -131,7 +131,7 @@ ChatGPT 账户后端**拒绝** `gpt-*-codex` slug(例如 `gpt-5.2-codex`),返回
 它只接受你账户的**实时授权** slug。权威目录(以及每个 slug 接受的
 推理级别)是 openai/codex 的
 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)。
-当前 slug:`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`(前沿)以及
+当前 slug:`gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`(前沿)以及
 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`。较老的账户可能只被授权使用
 较早的那些(一个免费账户会解析到 `gpt-5.5`)。shunt 会透出后端自身的错误
 `detail`,因此错误的 slug 会返回真实原因。

--- a/site/src/content/docs/zh-cn/guides/codex.mdx
+++ b/site/src/content/docs/zh-cn/guides/codex.mdx
@@ -278,7 +278,7 @@ provider = "codex"
 
 用 Claude Code 的常规控制项设置力度(`/effort`、`/model` 滑块、`--effort`)。
 shunt 将其映射到 Responses 的 `reasoning.effort`,对不支持 `max` 的 slug 将
-`max → xhigh` 折叠(**gpt-5.6** 和 **gpt-6** 系列支持)。
+`max → xhigh` 折叠(只有 **gpt-5.6** 和 **gpt-6** 系列支持)。
 
 
 

--- a/site/src/content/docs/zh-cn/guides/codex.mdx
+++ b/site/src/content/docs/zh-cn/guides/codex.mdx
@@ -144,10 +144,10 @@ ChatGPT 账户后端**拒绝** `gpt-*-codex` slug(例如 `gpt-5.2-codex`),返回
 
 <Aside type="note" title="`Model not found <slug>` 是客户端版本门控,不是授权问题">
 
-一些 slug 带有 `minimal_client_version`(例如 `gpt-5.6-luna` 需要 ≥ 0.144.0)。当
+一些 slug 带有 `minimal_client_version`(例如 `gpt-6-astra` 需要 ≥ 0.153.0)。当
 请求的客户端身份缺失或过旧时,后端会应答 `Model not found <slug>`。
 shunt 通过发送固定的 Codex CLI 身份头(`originator: codex_cli_rs`、
-`user-agent`、`version`)来避免这一点,固定到 **openai/codex rust-v0.148.0**。见
+`user-agent`、`version`)来避免这一点,固定到 **openai/codex rust-v0.153.3**。见
 [openai/codex#31967](https://github.com/openai/codex/issues/31967)。
 
 </Aside>
@@ -278,7 +278,7 @@ provider = "codex"
 
 用 Claude Code 的常规控制项设置力度(`/effort`、`/model` 滑块、`--effort`)。
 shunt 将其映射到 Responses 的 `reasoning.effort`,对不支持 `max` 的 slug 将
-`max → xhigh` 折叠(只有 **gpt-5.6** 系列支持)。
+`max → xhigh` 折叠(**gpt-5.6** 和 **gpt-6** 系列支持)。
 
 
 

--- a/site/src/content/docs/zh-cn/guides/effort-and-context.mdx
+++ b/site/src/content/docs/zh-cn/guides/effort-and-context.mdx
@@ -10,7 +10,7 @@ Claude Code 的力度级别(`/effort`、`/model` 滑块、`--effort` 或 `CLAUDE
 | Claude Code 力度 | → `reasoning.effort` |
 | :-- | :-- |
 | `low` / `medium` / `high` / `xhigh` | 透传 |
-| `max` | 在接受它的模型上透传(**gpt-5.6** 系列),否则折叠为 `xhigh` |
+| `max` | 在接受它的模型上透传(**gpt-5.6** 和 **gpt-6** 系列),否则折叠为 `xhigh` |
 
 一个 Codex slug 接受哪些推理级别,按模型列在 openai/codex 的 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json) 中(`supported_reasoning_levels`)。
 

--- a/site/src/content/docs/zh-cn/guides/providers.mdx
+++ b/site/src/content/docs/zh-cn/guides/providers.mdx
@@ -133,7 +133,7 @@ codex login
 
 <Aside type="caution" title="模型 slug">
 
-ChatGPT 账户的 Codex 后端**拒绝** `gpt-*-codex` slug —— 它只接受该账户实时授权的 slug。权威目录是 openai/codex 的 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)。当前的 slug 有 `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`(前沿)以及 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`;较老的账户可能只被授权使用较早的那些。在路由中使用 `upstream_model` 可将任意别名映射到一个已授权的 slug。
+ChatGPT 账户的 Codex 后端**拒绝** `gpt-*-codex` slug —— 它只接受该账户实时授权的 slug。权威目录是 openai/codex 的 [`models.json`](https://github.com/openai/codex/blob/main/codex-rs/models-manager/models.json)。当前的 slug 有 `gpt-6-astra`、`gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`(前沿)以及 `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini` / `gpt-5.2`;较老的账户可能只被授权使用较早的那些。在路由中使用 `upstream_model` 可将任意别名映射到一个已授权的 slug。
 
 </Aside>
 


### PR DESCRIPTION
## Summary

Follow-up to #459, which pinned the Codex client identity to openai/codex rust-v0.153.3 and made `supports_max_effort` accept the gpt-6 family. The review bots on that PR (greptile, chatgpt-codex-connector, cubic) flagged that the docs were only partially synced; #459 merged before this could be pushed to the fork branch (maintainer edits were disabled), so it lands here.

- `docs/running.md`, `docs/codex-configuration.md`, `site/src/content/docs/guides/codex.mdx`: the `max` effort claims still said only the gpt-5.6 family accepts it; now name the gpt-5.6 and gpt-6 families, matching `supports_max_effort`. The client-version-gating example uses `gpt-6-astra` (≥ 0.153.0) like the site page already did.
- `ko` / `ja` / `zh-cn` copies of `guides/codex.mdx` and `guides/effort-and-context.mdx`: identity pin 0.148.0 → 0.153.3, the same gating example, and the same `max` effort claim, per the AGENTS.md rule that maintained translations ship with the English source.

- Second commit (from `/code-review --fix`): adds `gpt-6-astra` to the "current listed slugs" inventory in `docs/running.md`, `docs/codex-configuration.md`, and `guides/codex.mdx` + `guides/providers.mdx` across all four locales, and corrects the `ultra` attribution in `docs/running.md` — per rust-v0.153.3 `models.json`, `gpt-6-astra`/`sol`/`terra` list `ultra` while `gpt-5.6-luna` stops at `max`.

Docs-only; no code changes. The remaining slug-inventory copies (`connect-codex-cli.mdx`, `reference/troubleshooting.md` locales) stay tracked in #460.

## Milestone / spec

Docs sync for #459 — `docs/codex-configuration.md` §4.4 client identity and the effort mapping section; no spec deviation.

## Checklist

- [x] `cargo build` passes (no Rust changes)
- [x] `cargo test` passes (no Rust changes; behavior covered by `passes_max_effort_through_for_gpt_6` from #459)
- [x] `cargo clippy --all-targets -- -D warnings` clean (no Rust changes)
- [x] `cargo fmt --all --check` clean (no Rust changes)
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style (locale files are the maintained translations)
- [x] Frozen spec in `docs/` updated — `docs/running.md`, `docs/codex-configuration.md`
- [x] User-facing docs updated — `site/` English page and its three locale copies
- [x] Any new GitHub Action is pinned to a full commit SHA (none added)

## Notes for reviewers

`grep` over `docs/`, `site/src/content/docs/`, and the READMEs finds no remaining `0.148.0` / `0.144.0` / gpt-5.6-only `max` claims. Local reviewers (cubic, ocr, gpt) reported no findings on the diff.

Refs #459, #460
