### PR TITLE
fix(gateway): accept the device page's own form POST despite a null Origin

### DIFF
--- a/docs/gateway-login.md
+++ b/docs/gateway-login.md
@@ -164,10 +164,13 @@ form remains available when `users_env` is populated; when it is absent, only th
 SSO button is rendered.
 
 The browser form is server-rendered and uses no client-side script. Its mutation
-is accepted only with a same-origin `Origin` or `Referer`, a same-origin/same-site
-Fetch Metadata signal, or a browser-navigation `Sec-Fetch-Site: none` request
-without contradictory cross-site hints. A rejected request returns a human-readable
-HTML error page with a non-success HTTP status.
+is accepted with a `Sec-Fetch-Site: same-origin` Fetch Metadata signal (decisive
+on its own), a same-origin `Origin` or `Referer`, a same-site Fetch Metadata
+signal, or a browser-navigation `Sec-Fetch-Site: none` request without
+contradictory cross-site hints. Fetch Metadata is consulted before `Origin`
+because the page is served with `Referrer-Policy: no-referrer`, under which
+browsers send `Origin: null` on the page's own form submission. A rejected
+request returns a human-readable HTML error page with a non-success HTTP status.
 
 ## State and operational boundary
 

--- a/docs/gateway-login.md
+++ b/docs/gateway-login.md
@@ -170,7 +170,9 @@ signal, or a browser-navigation `Sec-Fetch-Site: none` request without
 contradictory cross-site hints. Fetch Metadata is consulted before `Origin`
 because the page is served with `Referrer-Policy: no-referrer`, under which
 browsers send `Origin: null` on the page's own form submission. A rejected
-request returns a human-readable HTML error page with a non-success HTTP status.
+request re-renders the approval page carrying a human-readable message:
+`POST /device` answers `200 OK` so the form stays available for a retry, while
+`POST /device/authorize` answers `403 Forbidden`.
 
 ## State and operational boundary
 

--- a/site/src/content/docs/guides/gateway-login.mdx
+++ b/site/src/content/docs/guides/gateway-login.mdx
@@ -106,7 +106,7 @@ Start Claude Code and run `/login`. The CLI shows a device code and opens the ga
 2. Select the SSO button (**Sign in with Google** for Google, **Sign in with SSO** for other providers), then finish the provider login. If static users are also configured, entering an email and secret and selecting **Approve device** remains available.
 3. Return to Claude Code after the success page appears.
 
-Pre-filling the code never auto-approves it. The password approval POST is same-origin protected. The external callback instead binds the cross-site redirect with a single-use, ten-minute OAuth state and PKCE; provider errors are never echoed into the page.
+Pre-filling the code never auto-approves it. The password approval POST is same-origin protected: the gateway trusts the browser's `Sec-Fetch-Site: same-origin` Fetch Metadata signal, because the page's `Referrer-Policy: no-referrer` makes the browser send `Origin: null` on its own form submission. A reverse proxy that strips `Sec-Fetch-*` headers therefore blocks every approval with "This request came from another site and was blocked.". The external callback instead binds the cross-site redirect with a single-use, ten-minute OAuth state and PKCE; provider errors are never echoed into the page.
 
 ## Sign in from the terminal instead
 

--- a/site/src/content/docs/ja/guides/gateway-login.mdx
+++ b/site/src/content/docs/ja/guides/gateway-login.mdx
@@ -106,7 +106,7 @@ Claude Code を起動して `/login` を実行します。CLI がデバイスコ
 2. SSO ボタン（Google なら **Sign in with Google**、その他のプロバイダーなら **Sign in with SSO**）を選び、プロバイダーのログインを完了します。静的ユーザーも設定されている場合は、メールアドレスとシークレットを入力して **Approve device** を選ぶ方法も引き続き利用できます。
 3. 成功ページが表示されたら Claude Code に戻ります。
 
-コードが事前入力されていても、それによって自動承認されることはありません。パスワード承認の POST は same-origin で保護されます。外部コールバックは代わりに、使い捨てで 10 分間有効な OAuth state と PKCE によってクロスサイトのリダイレクトを束縛します。プロバイダーのエラーがページへそのまま出力されることはありません。
+コードが事前入力されていても、それによって自動承認されることはありません。パスワード承認の POST は same-origin で保護されます。ゲートウェイはブラウザーの `Sec-Fetch-Site: same-origin` Fetch Metadata シグナルを信頼します。ページの `Referrer-Policy: no-referrer` により、ブラウザーは自身のフォーム送信でも `Origin: null` を送るためです。したがって `Sec-Fetch-*` ヘッダーを取り除くリバースプロキシを経由すると、すべての承認が "This request came from another site and was blocked." で拒否されます。外部コールバックは代わりに、使い捨てで 10 分間有効な OAuth state と PKCE によってクロスサイトのリダイレクトを束縛します。プロバイダーのエラーがページへそのまま出力されることはありません。
 
 ## ターミナルからサインインする
 

--- a/site/src/content/docs/ko/guides/gateway-login.mdx
+++ b/site/src/content/docs/ko/guides/gateway-login.mdx
@@ -106,7 +106,7 @@ Claude Code를 시작하고 `/login`을 실행하세요. CLI가 디바이스 코
 2. SSO 버튼(Google은 **Sign in with Google**, 그 외 프로바이더는 **Sign in with SSO**)을 선택한 뒤 프로바이더 로그인을 마칩니다. 정적 사용자도 함께 구성되어 있다면, 이메일과 시크릿을 입력하고 **Approve device**를 선택하는 방법도 계속 사용할 수 있습니다.
 3. 성공 페이지가 나타나면 Claude Code로 돌아갑니다.
 
-코드를 미리 채워 넣어도 자동 승인되지는 않습니다. 비밀번호 승인 POST는 same-origin으로 보호됩니다. 외부 callback은 대신 일회용 10분짜리 OAuth state와 PKCE로 교차 사이트 리디렉션을 바인딩하며, 프로바이더 오류가 페이지에 그대로 출력되는 일은 없습니다.
+코드를 미리 채워 넣어도 자동 승인되지는 않습니다. 비밀번호 승인 POST는 same-origin으로 보호됩니다. 게이트웨이는 브라우저의 `Sec-Fetch-Site: same-origin` Fetch Metadata 신호를 신뢰하는데, 페이지의 `Referrer-Policy: no-referrer` 때문에 브라우저가 자기 폼 제출에도 `Origin: null`을 보내기 때문입니다. 따라서 `Sec-Fetch-*` 헤더를 제거하는 리버스 프록시를 거치면 모든 승인이 "This request came from another site and was blocked."로 차단됩니다. 외부 callback은 대신 일회용 10분짜리 OAuth state와 PKCE로 교차 사이트 리디렉션을 바인딩하며, 프로바이더 오류가 페이지에 그대로 출력되는 일은 없습니다.
 
 ## 터미널에서 로그인하기
 

--- a/site/src/content/docs/zh-cn/guides/gateway-login.mdx
+++ b/site/src/content/docs/zh-cn/guides/gateway-login.mdx
@@ -100,7 +100,7 @@ Google 使用默认的 `openid email profile` scope。shunt 要求 Google UserIn
 2. 选择 SSO 按钮(Google 为 **Sign in with Google**,其他提供方为 **Sign in with SSO**),然后完成提供方登录。如果同时配置了静态用户,输入 email 与 secret 并选择 **Approve device** 的方式依然可用。
 3. 出现成功页面后返回 Claude Code。
 
-预填设备码绝不会自动批准它。密码批准的 POST 受同源保护。而外部 callback 则用一次性、十分钟有效的 OAuth state 与 PKCE 绑定这次跨站重定向;提供方的错误绝不会被回显到页面上。
+预填设备码绝不会自动批准它。密码批准的 POST 受同源保护：网关信任浏览器的 `Sec-Fetch-Site: same-origin` Fetch Metadata 信号，因为页面的 `Referrer-Policy: no-referrer` 使浏览器在提交自己的表单时也发送 `Origin: null`。因此，经过会剥离 `Sec-Fetch-*` 头的反向代理时，所有批准都会被 "This request came from another site and was blocked." 拒绝。而外部 callback 则用一次性、十分钟有效的 OAuth state 与 PKCE 绑定这次跨站重定向;提供方的错误绝不会被回显到页面上。
 
 ## 改用终端登录
 

--- a/src/gateway/device.rs
+++ b/src/gateway/device.rs
@@ -142,6 +142,15 @@ pub(super) fn same_origin(headers: &HeaderMap, public_url: &str) -> bool {
     if fetch_site.is_some_and(|site| site.eq_ignore_ascii_case("cross-site")) {
         return false;
     }
+    // Fetch Metadata is set by the browser, never by page content, so a
+    // `same-origin` verdict is decisive on its own. It must also be checked
+    // before `Origin`: the device page is served with
+    // `Referrer-Policy: no-referrer`, and under that policy browsers send
+    // `Origin: null` on the page's own form POST (Fetch, "append a request
+    // `Origin` header"), which would never equal `public_url`.
+    if fetch_site.is_some_and(|site| site.eq_ignore_ascii_case("same-origin")) {
+        return true;
+    }
 
     let mut has_origin_signal = false;
     if let Some(origin) = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok()) {
@@ -417,5 +426,25 @@ mod tests {
         navigation.insert("sec-fetch-site", HeaderValue::from_static("none"));
         assert!(same_origin(&navigation, "https://gateway.example"));
         assert!(!same_origin(&HeaderMap::new(), "https://gateway.example"));
+    }
+
+    /// A browser submitting the device page's own form sends `Origin: null`
+    /// because the page carries `Referrer-Policy: no-referrer`; the
+    /// `Sec-Fetch-Site: same-origin` signal it sends alongside is what proves
+    /// the request is legitimate.
+    #[test]
+    fn csrf_accepts_null_origin_when_fetch_metadata_says_same_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ORIGIN, HeaderValue::from_static("null"));
+        headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
+        assert!(same_origin(&headers, "https://gateway.example"));
+
+        // Without Fetch Metadata a `null` origin proves nothing, so it stays
+        // rejected; and Fetch Metadata saying cross-site still wins.
+        let mut bare = HeaderMap::new();
+        bare.insert(header::ORIGIN, HeaderValue::from_static("null"));
+        assert!(!same_origin(&bare, "https://gateway.example"));
+        bare.insert("sec-fetch-site", HeaderValue::from_static("cross-site"));
+        assert!(!same_origin(&bare, "https://gateway.example"));
     }
 }

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -1263,6 +1263,35 @@ async fn device_grant_error_table_and_csrf_rejection_match_contract() {
     assert_eq!(response.status(), StatusCode::OK);
     let html = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert!(String::from_utf8_lossy(&html).contains("another site"));
+
+    // What a real browser sends when it submits the device page's own form:
+    // `Origin: null` (the page is served with `Referrer-Policy: no-referrer`)
+    // plus `Sec-Fetch-Site: same-origin`. The guard must let it through to
+    // credential verification instead of blocking it as cross-site.
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/device")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .header(header::ORIGIN, "null")
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::from(format!(
+                    "user_code={user_code}&login=dev%40example.com&secret=wrong"
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let html = String::from_utf8_lossy(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+        .into_owned();
+    assert!(!html.contains("another site"), "{html}");
+    assert!(
+        html.contains("The login or secret was not accepted."),
+        "{html}"
+    );
     assert!(state.gateway_stores.device_grants.approve(
         user_code,
         Identity {


### PR DESCRIPTION
## Summary

Every browser approval on the gateway `/device` page (and `/device/authorize`) was rejected with "This request came from another site and was blocked."

The page is served with `Referrer-Policy: no-referrer`. Under that policy browsers send `Origin: null` on the page's own form POST (Fetch spec, "append a request `Origin` header"). `gateway::device::same_origin` compared `Origin` against `public_url` before consulting Fetch Metadata, so `null` never matched.

This was verified with a real Chromium session against a probe server: the same-origin POST arrived with `Origin: null`, no `Referer`, and `Sec-Fetch-Site: same-origin`; without the `Referrer-Policy` header the origin was the real one. Existing tests never sent `Origin: null`, so they stayed green. The admin surface was immune because it decides on `Sec-Fetch-Site` first.

The fix treats `Sec-Fetch-Site: same-origin` as decisive before the Origin comparison. `cross-site` still rejects first, `same-site` still falls through to Origin/Referer, and a bare `Origin: null` without Fetch Metadata still fails closed. The same function guards `/device/authorize`, so the OIDC path is fixed too.

## Milestone / spec

`docs/gateway-login.md` — the paragraph on the CSRF guard for the device approval POST is updated in this PR.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA (none added)

`README.md` and `site/` need no change: they only say the POST is "same-origin protected", which stays true. No config key, endpoint, or CLI change.

Verification: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features --workspace` (2398 passed, 0 failed).

## Notes for reviewers

- Tests: a unit test in `src/gateway/device.rs` (null origin + `Sec-Fetch-Site: same-origin` accepted; bare null rejected; null + `cross-site` rejected) and an integration step in `src/gateway/tests.rs` that posts the exact browser header set and asserts the credential error rather than the cross-site block. Reverting the one-line accept makes exactly those two tests fail.
- Caveat / follow-up: browsers that send no `Sec-Fetch-Site` at all (Safari before 16.4) still send `Origin: null` and remain blocked. Switching the page to `Referrer-Policy: same-origin` would cover them, but that changes a response header, so it is deliberately left out of this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the gateway device approval page rejecting every browser form submission with "This request came from another site and was blocked." The page is served with `Referrer-Policy: no-referrer`, so browsers send `Origin: null` on the page's own POST; the guard now trusts `Sec-Fetch-Site: same-origin` before comparing Origin, and the same fix applies to `/device/authorize`.

**Notes**
- Bare `Origin: null` without Fetch Metadata still fails closed; `cross-site` still rejects first.
- Safari before 16.4 sends no `Sec-Fetch-Site` and remains blocked.
- A reverse proxy that strips `Sec-Fetch-*` headers blocks every approval; the site guides now warn operators about this.
- Docs now state the real status codes: `POST /device` re-renders the form with `200 OK`; only `POST /device/authorize` answers `403 Forbidden`.

<sup>Written for commit 23947ef68363499043fec7817a4b5a0344b21455. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

