### PR TITLE
fix(gateway): allow the device page's SSO form to redirect to the identity provider

### DIFF
--- a/docs/gateway-login.md
+++ b/docs/gateway-login.md
@@ -175,11 +175,17 @@ request re-renders the approval page carrying a human-readable message:
 `POST /device/authorize` answers `403 Forbidden`.
 
 The page ships a strict Content Security Policy (`form-action 'self'`). When the
-SSO form is rendered, `form-action` is widened to any `https` origin plus
-loopback `http`, matching what the IdP endpoint validation accepts: Chrome and
-WebKit enforce `form-action` against the post-submission redirect chain, so the
-strict policy would block the `POST /device/authorize` → `302` → IdP hop in the
-browser before it is sent. Pages without the SSO form keep `'self'`.
+SSO form is rendered, `form-action` is widened to
+`'self' https: http://127.0.0.1:* http://localhost:*`: Chrome and WebKit enforce
+`form-action` against the post-submission redirect chain, so the strict policy
+would block the `POST /device/authorize` → `302` → IdP hop in the browser before
+it is sent. Pages without the SSO form — including the approved-device view —
+keep `'self'`. That widened list approximates but does not exactly match the
+endpoint validation, which accepts `https` plus **any** loopback host: CSP's
+host-source grammar cannot express an IPv6 literal, so an identity provider
+served from `http://[::1]:…` (or another `127.0.0.0/8` address) validates yet is
+still blocked by the browser. Front such a provider with `https`, `localhost`,
+or `127.0.0.1`.
 
 ## State and operational boundary
 

--- a/docs/gateway-login.md
+++ b/docs/gateway-login.md
@@ -123,7 +123,7 @@ allowed_domains = ["example.com"]
 
 | Key | Default | Meaning |
 | :-- | :-- | :-- |
-| `issuer` | required | OIDC discovery issuer; HTTPS is required except for loopback HTTP |
+| `issuer` | required | OIDC discovery issuer; HTTPS is required except for HTTP on `localhost` or `127.0.0.1` |
 | `client_id` | required | Non-empty OIDC client identifier |
 | `client_secret_env` | `SHUNT_GATEWAY_OIDC_SECRET` | Environment variable holding the non-empty client secret |
 | `allowed_domains` | `[]` | Case-insensitive email domains allowed to approve a device |
@@ -137,7 +137,9 @@ At least one `allowed_domains` or `allowed_emails` entry is required. When an
 endpoint override is omitted, shunt resolves it from
 `{issuer}/.well-known/openid-configuration` and requires the returned issuer to
 match the configured issuer exactly. Every configured or discovered endpoint
-must use HTTPS, except that HTTP is accepted on loopback. Providers that do not
+must use HTTPS, except that HTTP is accepted on `localhost` and `127.0.0.1`, the
+only loopback hosts a browser Content Security Policy can name (see below); an
+IdP on `[::1]` or another `127.0.0.0/8` address is refused. Providers that do not
 expose standard OIDC, including GitHub or a SAML identity provider, should be
 connected through an OIDC broker such as Dex; direct OAuth2 integrations are
 out of scope.
@@ -180,12 +182,12 @@ SSO form is rendered, `form-action` is widened to
 `form-action` against the post-submission redirect chain, so the strict policy
 would block the `POST /device/authorize` → `302` → IdP hop in the browser before
 it is sent. Pages without the SSO form — including the approved-device view —
-keep `'self'`. That widened list approximates but does not exactly match the
-endpoint validation, which accepts `https` plus **any** loopback host: CSP's
-host-source grammar cannot express an IPv6 literal, so an identity provider
-served from `http://[::1]:…` (or another `127.0.0.0/8` address) validates yet is
-still blocked by the browser. Front such a provider with `https`, `localhost`,
-or `127.0.0.1`.
+keep `'self'`. That list admits exactly what the IdP URL validation admits:
+CSP's host-source grammar cannot express an IPv6 literal, and a port wildcard
+does not widen `127.0.0.1` to the rest of `127.0.0.0/8`, so plain-`http` IdP
+URLs are accepted only on `localhost` and `127.0.0.1`. An IdP on another
+loopback address fails at startup (configured override) or at discovery
+(discovered endpoint) instead of silently in the browser.
 
 ## State and operational boundary
 

--- a/docs/gateway-login.md
+++ b/docs/gateway-login.md
@@ -174,6 +174,13 @@ request re-renders the approval page carrying a human-readable message:
 `POST /device` answers `200 OK` so the form stays available for a retry, while
 `POST /device/authorize` answers `403 Forbidden`.
 
+The page ships a strict Content Security Policy (`form-action 'self'`). When the
+SSO form is rendered, `form-action` is widened to any `https` origin plus
+loopback `http`, matching what the IdP endpoint validation accepts: Chrome and
+WebKit enforce `form-action` against the post-submission redirect chain, so the
+strict policy would block the `POST /device/authorize` → `302` → IdP hop in the
+browser before it is sent. Pages without the SSO form keep `'self'`.
+
 ## State and operational boundary
 
 Device grants, IdP states, discovery results, and rate-limit counters are

--- a/docs/m9-admin-surface.md
+++ b/docs/m9-admin-surface.md
@@ -154,7 +154,8 @@ allowed_domains = ["example.com"]
 The registered redirect URI is
 `{public_url}/admin/oidc/callback`. `public_url` must be a bare HTTPS origin
 (loopback HTTP is allowed for local development). The issuer and optional endpoint
-overrides use HTTPS or loopback HTTP only. Startup also fails closed for an empty
+overrides use HTTPS, or HTTP on `localhost`/`127.0.0.1` only (the loopback
+hosts the login page's CSP `form-action` can name). Startup also fails closed for an empty
 issuer/client id, missing or empty client-secret environment variable, or an empty
 email/domain allowlist.
 

--- a/site/src/content/docs/guides/gateway-login.mdx
+++ b/site/src/content/docs/guides/gateway-login.mdx
@@ -72,6 +72,8 @@ surface shunt expects, put an OIDC identity provider such as [Dex](https://dexid
 in front of it and configure the Dex issuer here. Direct provider-specific OAuth2
 integrations are out of scope.
 
+The issuer and every endpoint must use HTTPS. Plain HTTP is accepted only at `localhost` or `127.0.0.1`: those are the only loopback hosts the approval page's Content Security Policy can name, so an IdP on `[::1]` or another `127.0.0.0/8` address is refused at startup rather than blocked later in the browser.
+
 At least one non-empty `allowed_domains` or `allowed_emails` entry is required;
 shunt refuses to start without it. `users_env` becomes optional when
 `[server.gateway.oidc]` is configured. Leave `SHUNT_GATEWAY_USERS` set to show

--- a/site/src/content/docs/ja/guides/gateway-login.mdx
+++ b/site/src/content/docs/ja/guides/gateway-login.mdx
@@ -72,6 +72,8 @@ GitHub、SAML、その他 shunt が期待する標準の OIDC
 アイデンティティプロバイダーを前段に置き、その Dex の issuer をここに設定してください。プロバイダー固有の
 OAuth2 を直接統合することはスコープ外です。
 
+issuer とすべてのエンドポイントは HTTPS を使う必要があります。平文の HTTP は `localhost` または `127.0.0.1` でのみ許可されます。承認ページの Content Security Policy が名前で指定できるループバックホストはその 2 つだけなので、`[::1]` やその他の `127.0.0.0/8` アドレス上の IdP は、後でブラウザーにブロックされる代わりに起動時に拒否されます。
+
 空でない `allowed_domains` または `allowed_emails` のエントリが少なくとも 1 つ必要です。それがないと
 shunt は起動を拒否します。`[server.gateway.oidc]` を設定すると `users_env`
 は任意になります。`SHUNT_GATEWAY_USERS` を設定したままにすると SSO

--- a/site/src/content/docs/ko/guides/gateway-login.mdx
+++ b/site/src/content/docs/ko/guides/gateway-login.mdx
@@ -72,6 +72,8 @@ GitHub, SAML 등 shunt가 기대하는 표준 OIDC 화면을 노출하지 않는
 앞단에 두고 여기에 Dex issuer를 구성하세요. 프로바이더별 직접 OAuth2
 통합은 범위 밖입니다.
 
+issuer와 모든 endpoint는 HTTPS를 써야 합니다. 평문 HTTP는 `localhost` 또는 `127.0.0.1`에서만 허용됩니다. 승인 페이지의 Content Security Policy가 이름 붙일 수 있는 loopback 호스트가 그 둘뿐이므로, `[::1]`이나 다른 `127.0.0.0/8` 주소의 IdP는 나중에 브라우저에서 막히는 대신 시작 시점에 거부됩니다.
+
 비어 있지 않은 `allowed_domains` 또는 `allowed_emails` 항목이 최소 하나 필요하며,
 없으면 shunt는 시작을 거부합니다. `[server.gateway.oidc]`가 구성되면
 `users_env`는 선택이 됩니다. SSO와 비밀번호 로그인을 함께 보여주려면

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -133,15 +133,15 @@ Presence of this subtable adds an OIDC/SSO button to the admin browser login pag
 | Key | Default | Meaning |
 | :-- | :-- | :-- |
 | `public_url` | required | Externally reachable bare HTTPS origin for the admin surface; loopback HTTP is allowed. The redirect URI is `{public_url}/admin/oidc/callback` |
-| `issuer` | required | OIDC discovery issuer. Must use HTTPS, except HTTP on loopback; a path is allowed |
+| `issuer` | required | OIDC discovery issuer. Must use HTTPS, except HTTP on `localhost` or `127.0.0.1`; a path is allowed |
 | `client_id` | required | OIDC client id |
 | `client_secret_env` | `SHUNT_ADMIN_OIDC_SECRET` | Env var holding the non-empty client secret |
 | `allowed_domains` | `[]` | Case-insensitive email domains allowed to administer shunt |
 | `allowed_emails` | `[]` | Case-insensitive full email addresses allowed to administer shunt |
 | `scopes` | `openid email profile` | Scopes sent to the authorization endpoint |
-| `authorization_endpoint` | discovery | Advanced authorization URL override; HTTPS or loopback HTTP only |
-| `token_endpoint` | discovery | Advanced token URL override; HTTPS or loopback HTTP only |
-| `userinfo_endpoint` | discovery | Advanced OIDC UserInfo URL override; HTTPS or loopback HTTP only |
+| `authorization_endpoint` | discovery | Advanced authorization URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
+| `token_endpoint` | discovery | Advanced token URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
+| `userinfo_endpoint` | discovery | Advanced OIDC UserInfo URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
 
 At least one non-empty `allowed_domains` or `allowed_emails` entry is mandatory. Startup also fails closed for an invalid `public_url`, empty issuer/client id, or missing client secret. shunt accepts only a non-empty UserInfo email with `email_verified = true`. The browser flow uses PKCE and a `pending_ttl_secs`-bound, single-use state; callback/token/UserInfo failures produce generic browser messages without echoing provider input. The callback re-checks the current hot-reloaded allowlist before minting the same HttpOnly admin session cookie as token login, then redirects to the fixed `/admin` target.
 
@@ -219,15 +219,15 @@ Presence of this subtable replaces or supplements the password approval form wit
 
 | Key | Default | Meaning |
 | :-- | :-- | :-- |
-| `issuer` | required | OIDC discovery issuer. Must use HTTPS, except HTTP on loopback; a path is allowed |
+| `issuer` | required | OIDC discovery issuer. Must use HTTPS, except HTTP on `localhost` or `127.0.0.1`; a path is allowed |
 | `client_id` | required | OIDC client id |
 | `client_secret_env` | `SHUNT_GATEWAY_OIDC_SECRET` | Env var holding the non-empty client secret |
 | `allowed_domains` | `[]` | Case-insensitive email domains allowed to approve a device |
 | `allowed_emails` | `[]` | Case-insensitive full email addresses allowed to approve a device |
 | `scopes` | `openid email profile` | Scopes sent to the authorization endpoint; custom values must include `openid` and `email` |
-| `authorization_endpoint` | discovery | Advanced authorization URL override; HTTPS or loopback HTTP only |
-| `token_endpoint` | discovery | Advanced token URL override; HTTPS or loopback HTTP only |
-| `userinfo_endpoint` | discovery | Advanced OIDC UserInfo URL override; HTTPS or loopback HTTP only |
+| `authorization_endpoint` | discovery | Advanced authorization URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
+| `token_endpoint` | discovery | Advanced token URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
+| `userinfo_endpoint` | discovery | Advanced OIDC UserInfo URL override; HTTPS, or HTTP on `localhost`/`127.0.0.1` only |
 
 At least one non-empty `allowed_domains` or `allowed_emails` entry is mandatory. shunt accepts only a non-empty UserInfo email with `email_verified = true`. The browser flow uses a single-use ten-minute state and PKCE, and callback/token/UserInfo failures produce generic browser messages without echoing provider input. The redirect URI registered at the provider is `{public_url}/device/callback`. For GitHub, SAML, or another non-OIDC provider, use an OIDC broker such as Dex; direct provider-specific OAuth2 integrations are out of scope.
 

--- a/site/src/content/docs/zh-cn/guides/gateway-login.mdx
+++ b/site/src/content/docs/zh-cn/guides/gateway-login.mdx
@@ -69,6 +69,8 @@ Google 使用默认的 `openid email profile` scope。shunt 要求 Google UserIn
 
 对于 GitHub、SAML 或其他不暴露 shunt 所需标准 OIDC 界面的提供方,请在其前面放一个诸如 [Dex](https://dexidp.io/docs/connectors/) 的 OIDC 身份提供方,并在此处配置 Dex 的 issuer。直接对接特定提供方的 OAuth2 集成不在范围内。
 
+issuer 和每个 endpoint 都必须使用 HTTPS。明文 HTTP 仅在 `localhost` 或 `127.0.0.1` 上被接受：批准页面的 Content Security Policy 只能点名这两个回环主机，因此位于 `[::1]` 或其他 `127.0.0.0/8` 地址上的 IdP 会在启动时被拒绝，而不是之后在浏览器中被拦截。
+
 `allowed_domains` 或 `allowed_emails` 至少需要一个非空条目;缺少它时 shunt 拒绝启动。配置了 `[server.gateway.oidc]` 后,`users_env` 变为可选。保留 `SHUNT_GATEWAY_USERS` 会同时显示 SSO 和密码登录,取消设置则只显示提供方按钮。
 
 所有非回环部署都请使用 HTTPS。默认情况下,`/device` 忽略 `X-Forwarded-For` 与 `X-Real-IP`,并按 socket 对端限流。如果 shunt 只能通过一个可信的反向代理触达,可以设置 `trust_forwarded_for = true`,并把该代理配置为先移除客户端提供的转发头部,再写入它自己可信的客户端地址。绝不要在直接暴露的网关上启用这个选项。

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1658,26 +1658,25 @@ pub(super) fn html_page(body: String) -> Response {
 }
 
 pub(super) fn html_body(body: String) -> Response {
-    html_body_with_form_action(body, "'self'")
+    html_body_with_form_action(body, crate::gateway::idp_client::SELF_FORM_ACTION)
 }
 
 /// The login page, with the CSP `form-action` widened to the identity provider
 /// when the SSO form is present: Chrome and WebKit enforce `form-action`
 /// against the post-submission redirect chain (w3c/webappsec-csp#8), so the
 /// strict `'self'` policy would block the
-/// `POST /admin/oidc/start` -> `302` -> IdP hop. The discovered authorization
-/// endpoint is not known when this page renders, so allow what
-/// `idp_client::validate_endpoint` accepts: any `https` origin plus loopback
-/// `http` (IPv6 loopback is not expressible as a CSP host-source).
+/// `POST /admin/oidc/start` -> `302` -> IdP hop. See
+/// [`IDP_REDIRECT_FORM_ACTION`](crate::gateway::idp_client) for the source
+/// list and the loopback hosts it cannot express.
 pub(super) fn login_response(
     status: StatusCode,
     error: Option<&str>,
     sso_label: Option<&str>,
 ) -> Response {
     let form_action = if sso_label.is_some() {
-        "'self' https: http://127.0.0.1:* http://localhost:*"
+        crate::gateway::idp_client::IDP_REDIRECT_FORM_ACTION
     } else {
-        "'self'"
+        crate::gateway::idp_client::SELF_FORM_ACTION
     };
     let mut response = html_body_with_form_action(html::login_page(error, sso_label), form_action);
     *response.status_mut() = status;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1203,7 +1203,14 @@ fn validate_idp_url(
     let url = reqwest::Url::parse(raw)
         .map_err(|error| section.invalid(format!("{key} is not a valid URL: {error}")))?;
     let invalid_issuer_parts = issuer && url.query().is_some();
-    if !url_uses_safe_transport(&url)
+    // Narrower than `url_uses_safe_transport`: an IdP URL is also a browser
+    // redirect target, and the device and admin login pages can only name
+    // `localhost` and `127.0.0.1` in their CSP `form-action`, so any other
+    // loopback host must fail here rather than in the browser.
+    let safe_transport = url.scheme() == "https"
+        || url.scheme() == "http"
+            && crate::gateway::idp_client::host_is_csp_loopback(url.host_str().unwrap_or_default());
+    if !safe_transport
         || url.host_str().is_none()
         || !url.username().is_empty()
         || url.password().is_some()
@@ -1216,7 +1223,7 @@ fn validate_idp_url(
             "userinfo or fragment"
         };
         return Err(section.invalid(format!(
-            "{key} must use https (or http on loopback), include a host, and contain no {parts}"
+            "{key} must use https (or http on localhost or 127.0.0.1), include a host, and contain no {parts}"
         )));
     }
     Ok(url)
@@ -5746,6 +5753,20 @@ mod tests {
             Err(ConfigError::InvalidGatewayOidc { .. })
         ));
         oidc.provider.authorization_endpoint = Some("http://127.0.0.1:8787/authorize".into());
+        assert!(oidc.resolve().is_ok());
+        // Loopback hosts a CSP host-source cannot name are refused at
+        // configuration time, so the browser never sees the blocked redirect.
+        for blocked in [
+            "http://[::1]:8787/authorize",
+            "http://127.0.0.2:8787/authorize",
+        ] {
+            oidc.provider.authorization_endpoint = Some(blocked.into());
+            assert!(
+                matches!(oidc.resolve(), Err(ConfigError::InvalidGatewayOidc { .. })),
+                "{blocked}"
+            );
+        }
+        oidc.provider.authorization_endpoint = Some("http://localhost:8787/authorize".into());
         assert!(oidc.resolve().is_ok());
         std::env::remove_var(secret_env);
     }

--- a/src/gateway/device.rs
+++ b/src/gateway/device.rs
@@ -119,18 +119,40 @@ pub async fn post(
     ))
 }
 
-pub(super) fn device_page(body: String) -> Response {
-    const CSP: &str = "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; \
-base-uri 'none'; frame-ancestors 'none'";
+/// A rendered approval page plus the one fact the response headers depend on:
+/// whether it carries the SSO form. That form's `POST /device/authorize`
+/// answers with a `302` to the identity provider, and Chrome and WebKit
+/// enforce CSP `form-action` against that post-submission redirect chain
+/// (w3c/webappsec-csp#8), so a strict `'self'` policy blocks the SSO hop in
+/// the browser before the request is ever sent.
+pub(super) struct DevicePage {
+    pub(super) body: String,
+    pub(super) sso_form: bool,
+}
+
+pub(super) fn device_page(page: DevicePage) -> Response {
+    // The discovered authorization endpoint is not known when this page
+    // renders, so when the SSO form is present allow what
+    // `idp_client::validate_endpoint` accepts: any `https` origin plus
+    // loopback `http`. Every other rendering keeps the strict policy.
+    let form_action = if page.sso_form {
+        "'self' https: http://127.0.0.1:* http://localhost:*"
+    } else {
+        "'self'"
+    };
+    let csp = format!(
+        "default-src 'none'; style-src 'unsafe-inline'; form-action {form_action}; \
+base-uri 'none'; frame-ancestors 'none'"
+    );
     (
         [
-            (header::CONTENT_SECURITY_POLICY, CSP),
-            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-            (header::X_FRAME_OPTIONS, "DENY"),
-            (header::REFERRER_POLICY, "no-referrer"),
-            (header::CACHE_CONTROL, "no-store"),
+            (header::CONTENT_SECURITY_POLICY, csp),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff".to_string()),
+            (header::X_FRAME_OPTIONS, "DENY".to_string()),
+            (header::REFERRER_POLICY, "no-referrer".to_string()),
+            (header::CACHE_CONTROL, "no-store".to_string()),
         ],
-        Html(body),
+        Html(page.body),
     )
         .into_response()
 }
@@ -248,14 +270,21 @@ pub(super) fn auth_page(
     user_code: &str,
     notice: Option<&str>,
     success: bool,
-) -> String {
-    page(
-        user_code,
-        notice,
-        success,
-        auth.oidc().map(super::ResolvedIdp::button_label),
-        auth.approval_provider().is_some(),
-    )
+) -> DevicePage {
+    let oidc_label = auth.oidc().map(super::ResolvedIdp::button_label);
+    // `page` renders no forms at all on the success view, so the SSO form is
+    // present exactly when an IdP is configured and this is not that view.
+    let sso_form = !success && oidc_label.is_some();
+    DevicePage {
+        body: page(
+            user_code,
+            notice,
+            success,
+            oidc_label,
+            auth.approval_provider().is_some(),
+        ),
+        sso_form,
+    }
 }
 
 pub(super) fn page(
@@ -340,7 +369,7 @@ mod tests {
 
     use axum::http::{header, HeaderMap, HeaderValue};
 
-    use super::{client_ip, device_page, normalize_user_code, page, same_origin};
+    use super::{client_ip, device_page, normalize_user_code, page, same_origin, DevicePage};
 
     #[test]
     fn page_escapes_prefilled_code_and_never_auto_submits() {
@@ -352,7 +381,10 @@ mod tests {
 
     #[test]
     fn device_page_sets_browser_security_headers() {
-        let response = device_page(page("ABCD-EFGH", None, false, None, true));
+        let response = device_page(DevicePage {
+            body: page("ABCD-EFGH", None, false, None, true),
+            sso_form: false,
+        });
         let headers = response.headers();
 
         assert_eq!(
@@ -366,6 +398,36 @@ mod tests {
         assert_eq!(headers.get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
         assert_eq!(headers.get(header::REFERRER_POLICY).unwrap(), "no-referrer");
         assert_eq!(headers.get(header::CACHE_CONTROL).unwrap(), "no-store");
+    }
+
+    /// The SSO form's POST answers with a redirect to the identity provider,
+    /// which Chrome and WebKit check against `form-action`; the page that
+    /// renders that form must therefore allow the IdP origin, while every
+    /// other rendering keeps the strict `'self'` policy.
+    #[test]
+    fn device_page_widens_form_action_only_when_sso_form_is_rendered() {
+        let csp = |page: DevicePage| {
+            device_page(page)
+                .headers()
+                .get(header::CONTENT_SECURITY_POLICY)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+        let sso = csp(DevicePage {
+            body: page("ABCD-EFGH", None, false, Some("Sign in with SSO"), false),
+            sso_form: true,
+        });
+        assert!(
+            sso.contains("form-action 'self' https: http://127.0.0.1:* http://localhost:*;"),
+            "{sso}"
+        );
+        let strict = csp(DevicePage {
+            body: page("ABCD-EFGH", None, false, None, true),
+            sso_form: false,
+        });
+        assert!(strict.contains("form-action 'self';"), "{strict}");
     }
 
     #[test]

--- a/src/gateway/device.rs
+++ b/src/gateway/device.rs
@@ -10,6 +10,8 @@ use serde::Deserialize;
 
 use crate::server::AppState;
 
+use super::idp_client;
+
 #[derive(Default, Deserialize)]
 pub struct DeviceQuery {
     #[serde(default)]
@@ -125,20 +127,19 @@ pub async fn post(
 /// enforce CSP `form-action` against that post-submission redirect chain
 /// (w3c/webappsec-csp#8), so a strict `'self'` policy blocks the SSO hop in
 /// the browser before the request is ever sent.
+///
+/// `sso_form` is set by [`page`] itself, from the branch that emits the form,
+/// so the policy cannot drift away from the markup it protects.
 pub(super) struct DevicePage {
-    pub(super) body: String,
-    pub(super) sso_form: bool,
+    body: String,
+    sso_form: bool,
 }
 
 pub(super) fn device_page(page: DevicePage) -> Response {
-    // The discovered authorization endpoint is not known when this page
-    // renders, so when the SSO form is present allow what
-    // `idp_client::validate_endpoint` accepts: any `https` origin plus
-    // loopback `http`. Every other rendering keeps the strict policy.
     let form_action = if page.sso_form {
-        "'self' https: http://127.0.0.1:* http://localhost:*"
+        idp_client::IDP_REDIRECT_FORM_ACTION
     } else {
-        "'self'"
+        idp_client::SELF_FORM_ACTION
     };
     let csp = format!(
         "default-src 'none'; style-src 'unsafe-inline'; form-action {form_action}; \
@@ -271,20 +272,13 @@ pub(super) fn auth_page(
     notice: Option<&str>,
     success: bool,
 ) -> DevicePage {
-    let oidc_label = auth.oidc().map(super::ResolvedIdp::button_label);
-    // `page` renders no forms at all on the success view, so the SSO form is
-    // present exactly when an IdP is configured and this is not that view.
-    let sso_form = !success && oidc_label.is_some();
-    DevicePage {
-        body: page(
-            user_code,
-            notice,
-            success,
-            oidc_label,
-            auth.approval_provider().is_some(),
-        ),
-        sso_form,
-    }
+    page(
+        user_code,
+        notice,
+        success,
+        auth.oidc().map(super::ResolvedIdp::button_label),
+        auth.approval_provider().is_some(),
+    )
 }
 
 pub(super) fn page(
@@ -293,7 +287,7 @@ pub(super) fn page(
     success: bool,
     oidc_label: Option<&str>,
     password_enabled: bool,
-) -> String {
+) -> DevicePage {
     let user_code = escape_html(user_code);
     let notice = notice
         .map(|message| {
@@ -304,24 +298,26 @@ pub(super) fn page(
             )
         })
         .unwrap_or_default();
-    let forms = if success {
-        String::new()
-    } else {
-        let sso_form = oidc_label
-            .map(|label| {
-                format!(
-                    r#"<form method="post" action="/device/authorize">
+    // The success view renders no forms at all, so the SSO form is present
+    // exactly when an IdP is configured and this is not that view. `sso_form`
+    // on the returned page is read straight off this value, which is also what
+    // gates the markup below.
+    let sso_label = if success { None } else { oidc_label };
+    let sso_form = sso_label
+        .map(|label| {
+            format!(
+                r#"<form method="post" action="/device/authorize">
 <label for="sso-user-code">Device code</label>
 <input id="sso-user-code" name="user_code" value="{user_code}" autocomplete="one-time-code" spellcheck="false" required autofocus>
 <button type="submit">{}</button>
 </form>"#,
-                    escape_html(label)
-                )
-            })
-            .unwrap_or_default();
-        let password_form = if password_enabled {
-            format!(
-                r#"<form method="post" action="/device">
+                escape_html(label)
+            )
+        })
+        .unwrap_or_default();
+    let password_form = if password_enabled && !success {
+        format!(
+            r#"<form method="post" action="/device">
 <label for="user-code">Device code</label>
 <input id="user-code" name="user_code" value="{user_code}" autocomplete="one-time-code" spellcheck="false" required{}>
 <label for="login">Email</label>
@@ -330,18 +326,17 @@ pub(super) fn page(
 <input id="current-password" name="secret" type="password" autocomplete="current-password" required enterkeyhint="done">
 <button type="submit">Approve device</button>
 </form>"#,
-                if oidc_label.is_none() {
-                    " autofocus"
-                } else {
-                    ""
-                }
-            )
-        } else {
-            String::new()
-        };
-        format!("{sso_form}{password_form}")
+            if sso_label.is_none() {
+                " autofocus"
+            } else {
+                ""
+            }
+        )
+    } else {
+        String::new()
     };
-    format!(
+    let forms = format!("{sso_form}{password_form}");
+    let body = format!(
         r#"<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>shunt gateway — approve device</title><style>
@@ -360,7 +355,11 @@ input:focus-visible, button:focus-visible {{ outline: 3px solid #315ee8; outline
 </style></head><body><main><div class="card"><h1>Approve this device</h1>
 <p>Enter the code shown by Claude Code, then sign in with a gateway account.</p>
 {notice}{forms}</div></main></body></html>"#
-    )
+    );
+    DevicePage {
+        body,
+        sso_form: sso_label.is_some(),
+    }
 }
 
 #[cfg(test)]
@@ -371,9 +370,19 @@ mod tests {
 
     use super::{client_ip, device_page, normalize_user_code, page, same_origin, DevicePage};
 
+    fn csp(page: DevicePage) -> String {
+        device_page(page)
+            .headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
     #[test]
     fn page_escapes_prefilled_code_and_never_auto_submits() {
-        let html = page("<script>", None, false, None, true);
+        let html = page("<script>", None, false, None, true).body;
         assert!(html.contains("&lt;script&gt;"));
         assert!(!html.contains("<script"));
         assert!(html.contains("method=\"post\""));
@@ -381,10 +390,7 @@ mod tests {
 
     #[test]
     fn device_page_sets_browser_security_headers() {
-        let response = device_page(DevicePage {
-            body: page("ABCD-EFGH", None, false, None, true),
-            sso_form: false,
-        });
+        let response = device_page(page("ABCD-EFGH", None, false, None, true));
         let headers = response.headers();
 
         assert_eq!(
@@ -403,31 +409,31 @@ mod tests {
     /// The SSO form's POST answers with a redirect to the identity provider,
     /// which Chrome and WebKit check against `form-action`; the page that
     /// renders that form must therefore allow the IdP origin, while every
-    /// other rendering keeps the strict `'self'` policy.
+    /// other rendering keeps the strict `'self'` policy. The success view
+    /// renders no forms even with an IdP configured, so it must stay strict.
     #[test]
     fn device_page_widens_form_action_only_when_sso_form_is_rendered() {
-        let csp = |page: DevicePage| {
-            device_page(page)
-                .headers()
-                .get(header::CONTENT_SECURITY_POLICY)
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string()
-        };
-        let sso = csp(DevicePage {
-            body: page("ABCD-EFGH", None, false, Some("Sign in with SSO"), false),
-            sso_form: true,
-        });
+        let sso = csp(page(
+            "ABCD-EFGH",
+            None,
+            false,
+            Some("Sign in with SSO"),
+            false,
+        ));
         assert!(
             sso.contains("form-action 'self' https: http://127.0.0.1:* http://localhost:*;"),
             "{sso}"
         );
-        let strict = csp(DevicePage {
-            body: page("ABCD-EFGH", None, false, None, true),
-            sso_form: false,
-        });
-        assert!(strict.contains("form-action 'self';"), "{strict}");
+        let no_idp = csp(page("ABCD-EFGH", None, false, None, true));
+        assert!(no_idp.contains("form-action 'self';"), "{no_idp}");
+        let success = csp(page(
+            "ABCD-EFGH",
+            None,
+            true,
+            Some("Sign in with SSO"),
+            true,
+        ));
+        assert!(success.contains("form-action 'self';"), "{success}");
     }
 
     #[test]

--- a/src/gateway/idp_client.rs
+++ b/src/gateway/idp_client.rs
@@ -277,19 +277,24 @@ fn sanitize_error_description(value: &str) -> Option<String> {
     (!sanitized.trim().is_empty()).then_some(sanitized)
 }
 
+/// The loopback hosts a CSP host-source can name. CSP's host-source grammar
+/// admits only letters, digits, and hyphens in a host, so an IPv6 literal such
+/// as `[::1]` cannot be expressed at all, and a port wildcard does not widen
+/// `127.0.0.1` to the rest of `127.0.0.0/8`. Plain-`http` identity-provider
+/// URLs are therefore accepted only on these two hosts, so that everything
+/// [`validate_endpoint`] admits is also reachable through
+/// [`IDP_REDIRECT_FORM_ACTION`]; an IdP on any other loopback address fails at
+/// configuration or discovery time instead of silently in the browser.
+pub(crate) fn host_is_csp_loopback(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1"
+}
+
 /// CSP `form-action` source list for a page whose form POST answers with a
 /// redirect to the identity provider. Chrome and WebKit enforce `form-action`
 /// against that post-submission redirect chain (w3c/webappsec-csp#8), and the
 /// authorization endpoint is not known when such a page renders, so this
-/// approximates the set `validate_endpoint` accepts: any `https` origin plus
-/// loopback `http`.
-///
-/// The approximation is deliberately not exact. `validate_endpoint` accepts
-/// every loopback host, but CSP's host-source grammar cannot express an IPv6
-/// literal and a port wildcard does not widen the address, so an IdP served
-/// from `http://[::1]:…` or another `127.0.0.0/8` address passes validation
-/// and is still blocked by the browser. Such a deployment must front the IdP
-/// with `https`, `localhost`, or `127.0.0.1`.
+/// allows exactly the set `validate_endpoint` accepts: any `https` origin plus
+/// `http` on the hosts [`host_is_csp_loopback`] names.
 pub(crate) const IDP_REDIRECT_FORM_ACTION: &str =
     "'self' https: http://127.0.0.1:* http://localhost:*";
 
@@ -299,8 +304,7 @@ pub(crate) const SELF_FORM_ACTION: &str = "'self'";
 fn validate_endpoint(raw: &str, name: &str) -> Result<()> {
     let url = Url::parse(raw).with_context(|| format!("discovered {name} is not a valid URL"))?;
     let safe_transport = url.scheme() == "https"
-        || url.scheme() == "http"
-            && crate::config::host_is_loopback(url.host_str().unwrap_or_default());
+        || url.scheme() == "http" && host_is_csp_loopback(url.host_str().unwrap_or_default());
     if !safe_transport
         || url.host_str().is_none()
         || !url.username().is_empty()
@@ -319,6 +323,43 @@ fn local_part(email: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The transport rule and the CSP source list must admit the same set:
+    /// an endpoint that validates but that the browser's `form-action` blocks
+    /// is the failure this pairing exists to prevent.
+    #[test]
+    fn endpoint_transport_rule_matches_csp_form_action() {
+        for accepted in [
+            "https://accounts.example.com/authorize",
+            "http://localhost:5556/dex/auth",
+            "http://LOCALHOST:5556/dex/auth",
+            "http://127.0.0.1:5556/dex/auth",
+        ] {
+            assert!(
+                validate_endpoint(accepted, "authorization_endpoint").is_ok(),
+                "{accepted}"
+            );
+        }
+        for rejected in [
+            "http://[::1]:5556/dex/auth",
+            "http://127.0.0.2:5556/dex/auth",
+            "http://idp.example/authorize",
+        ] {
+            assert!(
+                validate_endpoint(rejected, "authorization_endpoint").is_err(),
+                "{rejected}"
+            );
+        }
+        for host in ["localhost", "127.0.0.1"] {
+            assert!(host_is_csp_loopback(host));
+            assert!(
+                IDP_REDIRECT_FORM_ACTION.contains(&format!("http://{host}:*")),
+                "{host} is accepted by validation but absent from the CSP source list"
+            );
+        }
+        assert!(!host_is_csp_loopback("[::1]"));
+        assert!(!host_is_csp_loopback("127.0.0.2"));
+    }
 
     #[test]
     fn error_fields_are_sanitized_and_bounded() {

--- a/src/gateway/idp_client.rs
+++ b/src/gateway/idp_client.rs
@@ -277,6 +277,25 @@ fn sanitize_error_description(value: &str) -> Option<String> {
     (!sanitized.trim().is_empty()).then_some(sanitized)
 }
 
+/// CSP `form-action` source list for a page whose form POST answers with a
+/// redirect to the identity provider. Chrome and WebKit enforce `form-action`
+/// against that post-submission redirect chain (w3c/webappsec-csp#8), and the
+/// authorization endpoint is not known when such a page renders, so this
+/// approximates the set `validate_endpoint` accepts: any `https` origin plus
+/// loopback `http`.
+///
+/// The approximation is deliberately not exact. `validate_endpoint` accepts
+/// every loopback host, but CSP's host-source grammar cannot express an IPv6
+/// literal and a port wildcard does not widen the address, so an IdP served
+/// from `http://[::1]:…` or another `127.0.0.0/8` address passes validation
+/// and is still blocked by the browser. Such a deployment must front the IdP
+/// with `https`, `localhost`, or `127.0.0.1`.
+pub(crate) const IDP_REDIRECT_FORM_ACTION: &str =
+    "'self' https: http://127.0.0.1:* http://localhost:*";
+
+/// CSP `form-action` source list for a page whose forms all post same-origin.
+pub(crate) const SELF_FORM_ACTION: &str = "'self'";
+
 fn validate_endpoint(raw: &str, name: &str) -> Result<()> {
     let url = Url::parse(raw).with_context(|| format!("discovered {name} is not a valid URL"))?;
     let safe_transport = url.scheme() == "https"

--- a/src/gateway/tests.rs
+++ b/src/gateway/tests.rs
@@ -284,6 +284,25 @@ async fn oidc_device_page_modes_and_disabled_password_post() {
     assert!(html.contains("method=\"post\" action=\"/device/authorize\""));
     assert!(!html.contains("Approve device"));
 
+    // The SSO form's POST redirects to the IdP, and browsers enforce CSP
+    // `form-action` against that redirect, so the page carrying the form must
+    // allow the IdP origin rather than only `'self'`.
+    let response = router
+        .clone()
+        .oneshot(get_request("/device?user_code=BCDF-GHJK"))
+        .await
+        .unwrap();
+    let csp = response
+        .headers()
+        .get(header::CONTENT_SECURITY_POLICY)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        csp.contains("form-action 'self' https: http://127.0.0.1:* http://localhost:*;"),
+        "{csp}"
+    );
+
     let (_, html) = html_response(
         router,
         Request::builder()


### PR DESCRIPTION
## Summary

Follow-up to the just-merged #471 (the null-Origin CSRF fix) — not a fix for it. After #471 the password path on the gateway `/device` page works, but choosing the SSO button is blocked in the browser console with:

```
Sending form data to 'https://<gateway>/device/authorize' violates the following Content Security Policy directive: "form-action 'self'"
```

The request never reaches the gateway.

**Root cause.** The device page is served with CSP `form-action 'self'`; the SSO form's `POST /device/authorize` answers with a 302 to the identity provider, and Chrome and WebKit enforce `form-action` against the post-submission redirect chain ([w3c/webappsec-csp#8](https://github.com/w3c/webappsec-csp/issues/8)). The admin login page already carries this exact fix (`login_response` in `src/admin/mod.rs`); the device page never got it.

**Fix.** `auth_page` returns a `DevicePage { body, sso_form }`; `device_page` widens `form-action` to `'self' https: http://127.0.0.1:* http://localhost:*` only when the SSO form is rendered, matching what `idp_client::validate_endpoint` accepts for the IdP. Password-only, success, and no-IdP renderings keep `'self'`. All eleven call sites are textually unchanged.

**Tests.** New unit test asserting both branches of the policy, plus a router-level assertion added to the existing OIDC page integration test that `GET /device` serves the widened header. Reverting the widening fails exactly those two tests.

**Docs.** `docs/gateway-login.md` gained a CSP paragraph. `README.md` and `site/` do not mention the CSP, so no change there; no config key, endpoint, or CLI change.

## Milestone / spec

`docs/gateway-login.md` — device approval page CSP.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Source files stay under 500 lines — `src/gateway/device.rs` grew 450 → 512 lines; see reviewer notes
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA — none added

Verification run: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features --workspace` (2399 passed, 0 failed).

## Notes for reviewers

- The widened policy still forbids `http` to non-loopback hosts — the same boundary the IdP endpoint validation enforces at config time.
- `src/gateway/device.rs` now sits at 512 lines, just past the 500-line guideline. Happy to split the page-rendering helpers into their own module if you'd prefer that in this PR rather than a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the device approval page's SSO form so the browser no longer blocks the redirect to the identity provider, and narrows IdP URL validation so plain-HTTP IdPs are accepted only on `localhost` and `127.0.0.1`. Chrome and WebKit enforce the page's CSP `form-action 'self'` against the POST `/device/authorize` → 302 redirect to the IdP, so the SSO button never reached the gateway; the password path was unaffected.

**Changes**
- Widens `form-action` to `'self' https: http://127.0.0.1:* http://localhost:*` only when the SSO form is rendered; password-only, success, and no-IdP pages keep `'self'`.
- Plain-HTTP IdP URLs are accepted only on `localhost` and `127.0.0.1`; an IdP on `[::1]` or another `127.0.0.0/8` host now fails at configuration or discovery time instead of being blocked in the browser. This applies to the admin OIDC login too.
- The page's CSP is derived from the form it renders, and the source lists are shared constants in `idp_client.rs` that the admin login page also uses.
- Adds unit tests for both policy branches, a router-level assertion that `GET /device` serves the widened header, and a test tying the accepted hosts to the CSP source list.
- Documents the CSP behavior and the validation rule in `docs/gateway-login.md` and the site guides (four locales); no config key, endpoint, or CLI change.
- `src/gateway/device.rs` now sits at 512 lines, just past the 500-line guideline; happy to split page-rendering helpers into their own module if preferred.

<sup>Written for commit a807976ef8cf3d2f5a81becc60222abd6f6f21b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

