### PR TITLE
docs: record ADR-0003 for the admin dashboard extension and cover the combined router surface

### DIFF
--- a/.please/docs/decisions/0003-admin-dashboard-extension.md
+++ b/.please/docs/decisions/0003-admin-dashboard-extension.md
@@ -45,8 +45,11 @@ three facts:
    are discarded when the stream finishes (`src/stream_metrics.rs:142-199`), and
    current per-account quota snapshots. `[server.pool] state_path` persists only
    the current `QuotaState` (`src/state_persist.rs:52-64`).
-2. **Nothing computes monetary cost.** No pricing table, no currency field, on
-   any path.
+2. **Nothing computes monetary cost.** There is no pricing table on any path,
+   and nothing multiplies usage by a rate. The one `currency` field that exists
+   is limit *policy*, not accounting: the spend-limit API stores it on
+   `SpendLimit` and rejects anything but `USD` (`src/gateway/spend/store.rs:54`,
+   `src/gateway/spend/api.rs:43`).
 3. **`[server.spend]` meters nothing.** `SpendStore` holds limit *policy* and an
    append-only mutation audit (`src/gateway/spend/store.rs:49-103`); it records
    no tokens, requests, or consumption. Ingested OTLP telemetry is relayed

--- a/.please/docs/decisions/0003-admin-dashboard-extension.md
+++ b/.please/docs/decisions/0003-admin-dashboard-extension.md
@@ -1,0 +1,238 @@
+# ADR-0003: Admin dashboard extension — UI platform first, optional SQLite history, no cost estimates
+
+## Status
+
+Accepted
+
+## Date
+
+2026-09-10
+
+## Context
+
+Two self-hosted CLIProxyAPI (CPA) panels — [CPA Manager Plus][cpamp] and
+[CPA Usage Keeper][keeper] — were proposed as references for growing shunt's
+admin surface. Both show a class of thing shunt's does not: persistent request
+history, cost analytics with synced model prices, usage trends and heatmaps,
+scheduled credential health inspection, and config management from the browser.
+A desktop build is also anticipated, which makes the delivery mechanism — not
+just the feature list — a decision to make now rather than discover later.
+
+[cpamp]: https://github.com/seakee/CPA-Manager-Plus
+[keeper]: https://github.com/Willxup/cpa-usage-keeper
+
+### What shunt has today
+
+`src/admin/` is 8,094 lines across seven files. `admin_router`
+(`src/admin/mod.rs:221-257`) registers 16 paths / 18 method+path pairs — a
+server-rendered login flow, four JSON reads, and the Claude/Codex provisioning
+mutations; the per-path inventory lives in
+[`admin-ui-delivery.md`](../../../docs/admin-ui-delivery.md). `/admin/observed`
+already builds per-credential usage rows for six providers. The UI itself is
+1,525 lines of HTML/CSS/JS held in Rust string literals (`src/admin/html.rs` 879,
+`src/admin/script.rs` 646).
+
+### The gap is a store, not a UI
+
+A survey of every observability and accounting module — `metrics.rs`,
+`observability.rs`, `usage.rs`, `usage_poll.rs`, `stream_metrics.rs`,
+`telemetry.rs`, `state_persist.rs`, `oauth_usage.rs`, `status_poll.rs`,
+`upstream_status.rs`, and the `gateway/` and `gateway/spend/` trees — establishes
+three facts:
+
+1. **There is no per-request event history anywhere.** shunt retains live
+   aggregates (Sentry/OTLP counters and histograms), per-stream diagnostics that
+   are discarded when the stream finishes (`src/stream_metrics.rs:142-199`), and
+   current per-account quota snapshots. `[server.pool] state_path` persists only
+   the current `QuotaState` (`src/state_persist.rs:52-64`).
+2. **Nothing computes monetary cost.** No pricing table, no currency field, on
+   any path.
+3. **`[server.spend]` meters nothing.** `SpendStore` holds limit *policy* and an
+   append-only mutation audit (`src/gateway/spend/store.rs:49-103`); it records
+   no tokens, requests, or consumption. Ingested OTLP telemetry is relayed
+   verbatim or discarded (`src/gateway/telemetry_ingest.rs:169-214`) and is never
+   read back.
+
+The majority of what the reference panels display therefore rests on a store
+shunt does not have. Their own architecture makes this explicit: each runs as a
+second service beside CPA with its own SQLite database, draining CPA's usage
+queue.
+
+### Constraints already fixed
+
+[`admin-ui-delivery.md`](../../../docs/admin-ui-delivery.md),
+[`storage.md`](../../../docs/storage.md), and
+[`desktop-app.md`](../../../docs/desktop-app.md) are binding here, not reopened.
+Three of their findings constrain the decision below; the rest is one link away:
+
+- **A second serving process is rejected** (Decision 1) — the admin handlers read
+  live in-process state (reload-aware `SharedState`, `AccountPool`,
+  `StatusStore`). This is where shunt and the reference panels diverge
+  irreconcilably: their deployment model is not portable here, so any analytics
+  must live inside the gateway.
+- **Plain SQLite is already the positioned engine** for history and audit, kept
+  separate from the multi-instance question PostgreSQL would answer, and optional
+  so the in-memory single-instance path stays the default.
+- **The frontend work and the store decision are independent** — neither blocks
+  the other, which is what makes the tracks below separable rather than a queue.
+
+### Why cost is not simply portable
+
+CPAMP's cost analytics assume per-token billing. shunt's primary case is consumer
+subscriptions (Claude Max, ChatGPT Plus/Pro), where — as issue #309 puts it —
+"there is no per-token bill, so a money figure would be fiction." Cost is
+meaningful only for API-key upstreams, so importing the feature wholesale would
+put a fabricated number on the surface an operator trusts most.
+
+## Decision
+
+Extend the admin surface in three separable tracks, and start with the first.
+
+### 1. The UI platform lands first
+
+Implement `admin-ui-delivery.md` Decisions 3 and 4 before any new data feature:
+move the admin JSON and mutations to `/admin/api/*` as one breaking change, and
+replace the Rust string literals with a React + Vite SPA embedded behind
+`--features ui`.
+
+This is first because it is the only prerequisite **shared** by both of the other
+tracks and by the desktop app — Decision 4 notes the Tauri shell loads the same
+bundle, so the desktop build reuses this frontend instead of growing a second
+one. It also stops `html.rs`/`script.rs` from growing further; they are already
+1,525 lines against the ~770 the design record measured when it argued the
+literals had run out of room.
+
+Sequencing within the track:
+
+1. The `build_router` smoke test with every optional surface enabled at once,
+   plus the path-inventory assertion. `admin-ui-delivery.md` names this as worth
+   landing before any UI route, independent of the rest of the design, and it is
+   the safety net for every route change that follows.
+2. `feat!` — the `/admin/api/*` move, with the path-migration table in
+   `endpoints.md` and a `BREAKING CHANGE:` commit footer pointing at it.
+3. The SPA scaffold: its own package and lockfile, the `--features ui` gate,
+   asset embedding, and an SPA fallback confined to the `/admin` mount.
+4. Port the existing views and delete the dashboard string literals.
+
+`[server.admin].bind` (Decision 2) is separable and may land at any point in or
+after this track; it carries its own fail-open access-control constraint and
+boot diagnostic.
+
+### 2. History is backed by optional SQLite
+
+When history lands, it is plain SQLite, opt-in, with the current in-memory path
+remaining the default so the single-binary local mode survives — `storage.md`'s
+own position, adopted here rather than left open. This is what makes the
+reference panels' analytics — per-request search, trends, retention — possible at
+all.
+
+It is explicitly **not** coupled to the multi-instance question. Sharing pool
+state, sessions, and refresh coordination across replicas is a different problem
+with a different engine, and `storage.md`'s hazard analysis (five refreshable
+stores, all single-flighting in-process only) is its audit scope, not this
+track's.
+
+The bounded in-memory ring proposed in issue #309 is not adopted as the
+destination. It remains available as a cheaper first increment if the store slips,
+but the target shape is durable.
+
+### 3. Monetary cost estimates are deferred
+
+No currency figure ships on the admin surface for now. The decision is revisited
+once the history store exists and the shape of the recorded data is known;
+attribution work in the meantime is expressed in tokens and quota-window fill,
+which is both measurable today and the question subscription operators actually
+have.
+
+## Corrections to the design record made alongside this ADR
+
+Three drifts were found while verifying the above and fixed in
+[`admin-ui-delivery.md`](../../../docs/admin-ui-delivery.md) before this ADR was
+accepted. The first is consequential, because Resolution 6 designates Decision
+3's blocked-path table as *the* migration inventory:
+
+- The table omitted `POST /admin/accounts/claude/{name}/refresh`
+  (`src/admin/mod.rs:237-240`), listing 12 of the 13 paths that must move. A
+  migration driven from the table as written would have left that route behind.
+  It is Claude-only — Codex has no refresh route — so it fell outside the paired
+  claude/codex shape every neighbouring row has.
+- The "Current surface" table credited `admin_router` with 15 paths / 17
+  method+path pairs. Those are M9's endpoint-table counts, not the router's: the
+  router has 16 / 18, and M9 documents 15 of them (all but `GET /admin/status`).
+  As written the row was self-contradictory — it claimed a total *and* an
+  omission from that same total.
+- The table cited `admin_router` at `src/admin/mod.rs:115-146`; it is now at
+  `src/admin/mod.rs:221-257`.
+
+## Consequences
+
+### Positive
+
+- One frontend serves the web dashboard and the Tauri desktop shell, so the
+  desktop build is an additional consumer rather than a second UI to maintain.
+- The `/admin/api/*` split lets the SPA claim clean `/admin/*` deep links
+  immediately, with no aliases to retire and no hash routing to live with.
+- `--features ui` keeps `cargo build` free of a Node toolchain; release CI
+  enables the feature, so release binaries carry the dashboard.
+- Deferring cost keeps a fabricated number off the surface while leaving the
+  door open once real data exists.
+- The two tracks are independent, so history work can start before the SPA is
+  finished, or after, without either blocking.
+
+### Negative
+
+- Track 1 ships **no new data**. The visible payoff is deferred to the port and
+  to track 2, which is a real cost in perceived progress.
+- The `/admin/api/*` move breaks every scripted caller documented in
+  `m9-admin-surface.md`. It must land in one release, and the release notes are
+  release-please prose built from commit footers, so the `BREAKING CHANGE:`
+  footer — not the PR body — is what carries it (issue #270).
+- An optional store is more work than either extreme: a feature that only works
+  when a store is configured is a second product surface to test.
+- A from-source build without `--features ui` has no dashboard.
+- The reference panels' deployment model, their SQLite schemas, and their
+  usage-queue drain cannot be reused; only their feature vocabulary transfers.
+
+### Neutral
+
+- `[server.spend]` keeps its current meaning — limit policy and audit, not
+  metering. A dashboard can show configured limits and their mutation history
+  today; it cannot show spend.
+- The dashboard remains one process's view. `storage.md` and
+  `admin-ui-delivery.md`'s topology table own the multi-instance question, and
+  whatever the UI shows must be labeled as this instance's view.
+- Existing admin issues (#207, #214, #309, #369, #375, #427, #440, #441) keep
+  their independent value; this ADR sequences the platform work around them
+  rather than superseding them.
+- Cost remains available as a later addition scoped to API-key upstreams, which
+  is the narrower shape the caveat above implies.
+
+## Alternatives Considered
+
+- **Data/history first, rendered in the current UI.** Rejected as the *starting*
+  slice: it would either strain 1,525 lines of string literals further or
+  produce views that are rewritten once the SPA lands. The track itself is
+  adopted, just not first.
+- **Breadth on the current UI** (more provider provisioning, config editing, a
+  live activity view). Rejected as the starting slice — cheapest, and it closes
+  visible gaps against CPAMP's credential management, but every screen added
+  this way is a screen ported twice.
+- **A separate service beside shunt, as CPAMP and Keeper do.** Rejected by
+  `admin-ui-delivery.md` Decision 1 and reaffirmed here: shunt's admin handlers
+  read live in-process state a second process does not have, so it would become
+  a proxy in front of a proxy with a duplicated auth surface.
+- **The #309 bounded in-memory ring as the destination for history.** Rejected
+  as the destination, retained as a possible increment. It answers "what is
+  consuming this subscription" with no store and no retention or PII question,
+  but it is lost on restart and covers streaming responses only — so the
+  Antigravity adapter, which returns non-streaming JSON when `stream:false`,
+  would read near zero.
+- **PostgreSQL for history.** Rejected. It answers the multi-instance question,
+  not the history one, and a gateway that requires PostgreSQL to boot is a
+  different product from one that runs from a single binary on a laptop.
+- **Full cost analytics with synced model prices, as CPAMP ships.** Rejected for
+  now; see the caveat above.
+- **Hash routing (`/admin/#/pool`) or a separate `/admin/ui/*` prefix.**
+  Rejected by Resolution 6 as permanent URL costs that only defer the collision.
+- **Committing `dist/`, or a network-fetching `build.rs`.** Rejected by
+  Resolution 1 — drift risk and a supply-chain surface respectively.

--- a/.please/docs/decisions/index.md
+++ b/.please/docs/decisions/index.md
@@ -6,3 +6,4 @@
 |-----|-------|------|--------|
 | [ADR-0001](0001-per-provider-upstream-model-map.md) | Per-provider upstream model map | 2026-07-20 | Accepted (amended by ADR-0002) |
 | [ADR-0002](0002-ordered-upstreams-failover.md) | Ordered upstreams with cross-provider failover | 2026-07-20 | Accepted |
+| [ADR-0003](0003-admin-dashboard-extension.md) | Admin dashboard extension: UI platform first, optional SQLite history, no cost estimates | 2026-09-10 | Accepted |

--- a/docs/admin-ui-delivery.md
+++ b/docs/admin-ui-delivery.md
@@ -48,7 +48,7 @@ baseline for any new route.
 | always | `GET` | `/health` — unauthenticated, exempt from the concurrency gate |
 | always | `GET` | `/protocol`, `/v1/models`, `/routes` |
 | always | `POST` | `/v1/messages`, `/v1/messages/count_tokens` |
-| `[server.admin]` | — | 15 paths under `/admin`, 17 method+path pairs — `admin_router` in `src/admin/mod.rs`. [M9's endpoint table](m9-admin-surface.md#endpoints-registered-only-when-serveradmin-is-set) documents all of them except `GET /admin/status` |
+| `[server.admin]` | — | 16 paths under `/admin`, 18 method+path pairs — `admin_router` in `src/admin/mod.rs`. [M9's endpoint table](m9-admin-surface.md#endpoints-registered-only-when-serveradmin-is-set) documents 15 of them — all except `GET /admin/status` |
 | `[server.gateway]` | `GET` | `/.well-known/oauth-authorization-server`, `/device`, `/device/callback`, `/managed/settings` |
 | `[server.gateway]` | `POST` | `/oauth/device_authorization`, `/oauth/token`, `/device`, `/device/authorize` |
 | `[server.gateway]` | `POST` | `/v1/metrics`, `/v1/logs`, `/v1/traces` (inbound OTLP ingest) |
@@ -311,7 +311,7 @@ looks at most. The clean break removes the collision instead of deferring it.
 the JSON `GET`s.** A `fallback` answers unmatched *paths*; a request whose path
 matches a route registered for other methods gets axum's `405 Method Not Allowed`
 instead, so a POST-only or DELETE-only path is just as unavailable to the SPA as
-a `GET` alias is. Reading `admin_router` (`src/admin/mod.rs:115-146`), these are
+a `GET` alias is. Reading `admin_router` (`src/admin/mod.rs:221-257`), these are
 the registered paths that move, and why each would have blocked a deep link had
 it stayed:
 
@@ -322,6 +322,7 @@ it stayed:
 | `/admin/accounts/claude/{name}`, `/admin/accounts/codex/{name}` | `DELETE` only | `405`, not the shell. An account **detail view** is the most natural deep link the UI will want, and both of its path shapes are taken. |
 | `/admin/accounts/claude` | `POST` only | `405` on the "add account" screen's natural URL. |
 | `/admin/accounts/claude/{name}/complete`, `/admin/accounts/codex/{name}/complete` | `POST` only | `405`. |
+| `/admin/accounts/claude/{name}/refresh` | `POST` only | `405`; Claude-only, as Codex has no refresh route. |
 | `/admin/oidc/start`, `/admin/logout` | `POST` only | `405`; unlikely SPA routes, listed for completeness. |
 
 `/admin` (`GET`) is the shell itself and `/admin/login` (`GET`+`POST`) and

--- a/docs/admin-ui-delivery.md
+++ b/docs/admin-ui-delivery.md
@@ -457,12 +457,16 @@ independent decision.
 
 ## Risks
 
-- **Duplicate-route panics are untested.** `axum::Router::merge` panics at boot
-  on a duplicate path+method — a real safety net for new UI routes, but it only
-  fires when both trees are registered. No test builds a router with
+- **Duplicate-route panics were untested; they are covered now.**
+  `axum::Router::merge` panics at boot on a duplicate path+method — a real safety
+  net for new UI routes, but it only fires when both trees are registered. Until
+  `tests/router_surface.rs` landed, no test built a router with
   `[server.admin]`, `[server.gateway]`, and `[server.codex_endpoint]` enabled
-  together, so a collision would surface on an operator's machine rather than in
-  CI. This is a gap today, independent of the UI work.
+  together, so a collision would have surfaced on an operator's machine rather
+  than in CI. `every_optional_surface_can_be_enabled_at_once` now builds that
+  router in CI, and the inventory tests beside it pin the method+path set it
+  registers. Recorded rather than deleted, because the hazard is why the test
+  exists and why it must keep every surface enabled.
 - **Breaking migration.** Removing the legacy `/admin/*` JSON and mutation paths
   breaks every scripted caller M9 documented. The path-migration table lives in
   `endpoints.md`, and the breaking change must be declared in a commit

--- a/docs/admin-ui-delivery.md
+++ b/docs/admin-ui-delivery.md
@@ -54,6 +54,8 @@ baseline for any new route.
 | `[server.gateway]` | `POST` | `/v1/metrics`, `/v1/logs`, `/v1/traces` (inbound OTLP ingest) |
 | `[server.codex_endpoint]` | `POST` | `/backend-api/codex/responses`, `/responses`, `/v1/responses` |
 | `[server.codex_endpoint]` | `POST` | `/backend-api/codex/analytics-events/events`, `/codex/analytics-events/events` |
+| `[server.spend]` | `GET`, `POST` | `/v1/organizations/spend_limits` — the only shunt-owned routes inside the otherwise reserved `/v1/organizations/*` namespace ([below](#reserved-namespace--v1organizations)) |
+| `[server.spend]` | `GET`, `DELETE` | `/v1/organizations/spend_limits/{id}` |
 | `[server.usage]` | `GET` | `/usage` |
 | `[server.oauth_usage]` | `GET` | `/api/oauth/usage` |
 
@@ -282,7 +284,7 @@ Any of them works — the load-bearing constraint is *one* call, fanned out.
 | :-- | :-- | :-- |
 | `/admin/*` | operator UI: HTML shell, SPA client routes, `/admin/assets/*` — minus the server-rendered pages that stay (`/admin/login`, `/admin/oidc/callback`), below | shunt |
 | `/admin/api/*` | shunt-specific JSON: pool, status, accounts, observed, provisioning | shunt |
-| `/v1/organizations/*` | **reserved** — see below | Anthropic |
+| `/v1/organizations/*` | **reserved**, minus the two spend-limit paths `[server.spend]` already serves — see below | Anthropic |
 
 ### Why the UI and the JSON API must split
 
@@ -367,11 +369,17 @@ retarget it by changing base URL alone. Its conventions — `type` on every obje
 `{type, error:{type,message}, request_id}` envelope, a `request-id` header on
 every response — are fixed by that contract.
 
-shunt does not implement this today, and this document does not put it in scope.
-Spend limits are out of scope for epic #186. The namespace is recorded here so
-that:
+shunt implements a **two-path subset** of this today, registered only when
+`[server.spend]` is set (`src/gateway/spend/mod.rs`): `GET`/`POST
+/v1/organizations/spend_limits` and `GET`/`DELETE
+/v1/organizations/spend_limits/{id}`. Those carry limit *policy* and its
+mutation audit — not spend counters. `/effective`, `/audit`, and the metering
+they presuppose are unimplemented, and the wider Admin API stays out of scope
+for epic #186. The namespace is recorded here so that:
 
-- No shunt-owned route ever claims `/v1/organizations/*`.
+- No shunt-owned route claims `/v1/organizations/*` **outside** that
+  spend-limit subset, and any extension of the subset follows the upstream
+  contract's shapes rather than inventing shunt's own.
 - The operator UI's own JSON stays at `/admin/api/*`, where shunt owns the shape,
   rather than being retrofitted into an Anthropic-shaped path later.
 
@@ -494,8 +502,8 @@ The seven questions this document originally left open are now decided:
    surface is not configured it does not silently edit config: it offers to run
    `shunt dashboard setup` and proceeds only on confirmation.
 5. **Single-instance is a limitation, not a decision.** Scaling out stays on the
-   roadmap and is owned by [`storage.md`](storage.md); the `/v1/organizations/*`
-   reservation is accordingly a roadmap item, not a non-goal.
+   roadmap and is owned by [`storage.md`](storage.md); the reservation over the
+   rest of `/v1/organizations/*` is accordingly a roadmap item, not a non-goal.
 6. **No aliases — the admin JSON moves in one breaking change.** Every JSON
    endpoint and every mutation under `/admin/*` outside the server-rendered
    login flow (`/admin/login`, `/admin/oidc/callback`) moves to `/admin/api/*`

--- a/docs/admin-ui-delivery.md
+++ b/docs/admin-ui-delivery.md
@@ -32,10 +32,12 @@ elsewhere, and three of them are load-bearing:
 - **Namespace.** `/admin` already mixes HTML pages and JSON API on the same
   prefix. An SPA that wants `/admin/pool` as a deep link collides with the
   `GET /admin/pool` JSON endpoint that exists today.
-- **Assets.** The current UI is ~770 lines of HTML/CSS/JS inside Rust string
-  literals (`src/admin/html.rs`, `src/admin/script.rs`). There is no build step,
-  no type checking, and no component model. `src/AGENTS.md` asks for files under
-  500 lines; two of these are already near that on presentation code alone.
+- **Assets.** The current UI is HTML/CSS/JS inside Rust string literals
+  (`src/admin/html.rs`, `src/admin/script.rs`) — ~770 lines when this record was
+  written on 2026-08-15, and 1,525 by 2026-09-10. There is no build step, no
+  type checking, and no component model. `src/AGENTS.md` asks for files under
+  500 lines; both files were near that then and both are past it now (879 and
+  646), on presentation code alone.
 
 ## Current surface
 

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -594,39 +594,85 @@ fn the_indirect_scan_finds_every_definition() {
     );
 }
 
+/// How many router trees each scanned source composes in, as
+/// `(file, merges, nests)`. Only `build_router` composes anything today: the
+/// four `.merge(` calls that bring in `admin_router`, `gateway_router`,
+/// `spend_router`, and the liveness tree built in `src/server.rs` itself.
+const COMPOSITION_COUNTS: [(&str, usize, usize); 4] = [
+    ("src/server.rs", 4, 0),
+    ("src/admin/mod.rs", 0, 0),
+    ("src/gateway/mod.rs", 0, 0),
+    ("src/gateway/spend/mod.rs", 0, 0),
+];
+
 /// The outer edge of the two scans above. They read paths out of four fixed
 /// source files, which covers everything registered *in* them — but a future
-/// module could register its own tree and have `build_router` compose it in,
-/// and nothing here would notice, because that module's source is never read.
+/// module could register its own tree and have one of these files compose it in,
+/// and nothing would notice, because that module's source is never read. A child
+/// router counts as much as `build_router` here: `gateway_router` merging a new
+/// module hides it just as effectively.
 ///
 /// This is a boundary guard, not a discovery mechanism: it does not find the new
-/// module. It fails when one is composed in, so the addition gets the path-split
-/// review `docs/admin-ui-delivery.md` asks for and `ROUTER_SOURCES` gets extended
-/// in the same change. A bare `.route(` added directly to `build_router` needs no
-/// guard — `src/server.rs` is itself scanned.
+/// module. It fails when one is composed in anywhere in the scanned set, so the
+/// addition gets the path-split review `docs/admin-ui-delivery.md` asks for and
+/// `ROUTER_SOURCES` gets extended in the same change. A bare `.route(` added to
+/// any of these files needs no guard — they are all scanned.
 #[test]
 fn no_router_tree_is_composed_in_from_an_unscanned_module() {
-    let server = ROUTER_SOURCES
-        .iter()
-        .find(|(file, _)| *file == "src/server.rs")
-        .map(|(_, source)| *source)
-        .expect("src/server.rs is one of the scanned router sources");
+    for (file, source) in ROUTER_SOURCES {
+        let (_, merges, nests) = COMPOSITION_COUNTS
+            .iter()
+            .find(|(name, _, _)| *name == file)
+            .unwrap_or_else(|| panic!("{file} has no entry in COMPOSITION_COUNTS"));
 
-    // `admin_router`, `gateway_router`, `spend_router`, and the liveness tree
-    // built in `src/server.rs` itself.
+        assert_eq!(
+            source.matches(".merge(").count(),
+            *merges,
+            "{file} composes a different number of router trees than the {merges} this test knows \
+             about. If a new one was added, add its source file to ROUTER_SOURCES so its paths are \
+             scanned, and review the routes it brings against the /admin, /admin/api and reserved \
+             /v1/organizations path split in docs/admin-ui-delivery.md."
+        );
+        assert_eq!(
+            source.matches(".nest(").count(),
+            *nests,
+            "{file} now nests a router tree. Nesting rewrites the paths its routes answer on, so \
+             neither the literal scan nor the inventory above describes the served surface any \
+             more — extend both before adopting it."
+        );
+    }
+}
+
+/// The last way a registration can go unseen: [`registered_literal_paths`] skips
+/// any `.route(` whose first argument is not a string literal, and skipping
+/// *silently* is the hazard — a future `.route(NEW_PATH, ...)` would change
+/// neither the literal count nor the inventory.
+///
+/// Counting the skips closes that. Together with the two count assertions above
+/// and the composition guard, the invariant across the scanned files is that no
+/// registration is silently dropped: every `.route(` either resolves to a literal
+/// path that must appear in the inventory, or is one of these five indirect sites
+/// whose definitions [`INDIRECT_PATH_SOURCES`] reads.
+#[test]
+fn every_nonliteral_route_call_is_one_this_test_already_tracks() {
+    let calls: usize = ROUTER_SOURCES
+        .iter()
+        .map(|(_, source)| source.matches(".route(").count())
+        .sum();
+    let literals: usize = ROUTER_SOURCES
+        .iter()
+        .map(|(_, source)| registered_literal_paths(source).len())
+        .sum();
+
+    // The two `codex_endpoint::PATHS` / `codex_analytics::PATHS` loops in
+    // `build_router`, and the three `Signal::path()` calls in `gateway_router`.
     assert_eq!(
-        server.matches(".merge(").count(),
-        4,
-        "src/server.rs composes a different number of router trees than the four this test knows \
-         about. If a new one was added, add its source file to ROUTER_SOURCES so its paths are \
-         scanned, and review the routes it brings against the /admin, /admin/api and reserved \
-         /v1/organizations path split in docs/admin-ui-delivery.md."
-    );
-    assert_eq!(
-        server.matches(".nest(").count(),
-        0,
-        "src/server.rs now nests a router tree. Nesting rewrites the paths its routes answer on, \
-         so neither the literal scan nor the inventory below describes the served surface any \
-         more — extend both before adopting it."
+        calls - literals,
+        5,
+        "the scanned sources make {calls} `.route(` calls of which {literals} pass a string \
+         literal, so {} are registered indirectly — not the 5 this test tracks through \
+         INDIRECT_PATH_SOURCES. A new indirect registration must be added there, or its paths go \
+         unscanned.",
+        calls - literals
     );
 }

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -593,3 +593,40 @@ fn the_indirect_scan_finds_every_definition() {
          removed, or one of these sets is no longer spelled the way the scan expects"
     );
 }
+
+/// The outer edge of the two scans above. They read paths out of four fixed
+/// source files, which covers everything registered *in* them — but a future
+/// module could register its own tree and have `build_router` compose it in,
+/// and nothing here would notice, because that module's source is never read.
+///
+/// This is a boundary guard, not a discovery mechanism: it does not find the new
+/// module. It fails when one is composed in, so the addition gets the path-split
+/// review `docs/admin-ui-delivery.md` asks for and `ROUTER_SOURCES` gets extended
+/// in the same change. A bare `.route(` added directly to `build_router` needs no
+/// guard — `src/server.rs` is itself scanned.
+#[test]
+fn no_router_tree_is_composed_in_from_an_unscanned_module() {
+    let server = ROUTER_SOURCES
+        .iter()
+        .find(|(file, _)| *file == "src/server.rs")
+        .map(|(_, source)| *source)
+        .expect("src/server.rs is one of the scanned router sources");
+
+    // `admin_router`, `gateway_router`, `spend_router`, and the liveness tree
+    // built in `src/server.rs` itself.
+    assert_eq!(
+        server.matches(".merge(").count(),
+        4,
+        "src/server.rs composes a different number of router trees than the four this test knows \
+         about. If a new one was added, add its source file to ROUTER_SOURCES so its paths are \
+         scanned, and review the routes it brings against the /admin, /admin/api and reserved \
+         /v1/organizations path split in docs/admin-ui-delivery.md."
+    );
+    assert_eq!(
+        server.matches(".nest(").count(),
+        0,
+        "src/server.rs now nests a router tree. Nesting rewrites the paths its routes answer on, \
+         so neither the literal scan nor the inventory below describes the served surface any \
+         more — extend both before adopting it."
+    );
+}

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -1,5 +1,5 @@
 //! Cross-surface router invariants: every optional surface can be enabled at
-//! once, and the registered path set stays exactly the one
+//! once, and the registered method+path set stays exactly the one
 //! `docs/admin-ui-delivery.md` documents.
 //!
 //! `axum::Router::merge` panics at boot on a duplicate path+method, which is a
@@ -12,7 +12,7 @@
 //! `docs/admin-ui-delivery.md`; these tests close it *before* any UI route
 //! claims a path, which is the order that document's "Testing" section asks for.
 //!
-//! **How path existence is probed.** `Router` exposes no route table, so the
+//! **How the router is probed.** `Router` exposes no route table, so the
 //! inventory is read back with a method no shunt route registers. axum answers
 //! `405` when the path matches a route registered for other methods and `404`
 //! when no route matches it at all — the very path-vs-method distinction
@@ -20,10 +20,18 @@
 //! subtlety is that `spend_router` attaches its own `fallback` to each
 //! `MethodRouter`; that fallback also answers `405`, so the oracle holds
 //! uniformly.
+//!
+//! That same `405` carries an `Allow` header listing exactly the methods the
+//! path *is* registered for, so the one probe that answers "does this path
+//! exist" also answers "with which methods" — no extra request, and no handler
+//! ever runs. That is what lets the inventory below pin method+path pairs
+//! rather than bare paths: adding or removing a method on an existing path
+//! moves the `Allow` value and fails
+//! `every_registered_method_set_matches_the_inventory`.
 
 use axum::{
     body::Body,
-    http::{Method, Request, StatusCode},
+    http::{header, Method, Request, StatusCode},
     Router,
 };
 use shunt::{
@@ -33,69 +41,82 @@ use shunt::{
     },
     server,
 };
+use std::collections::BTreeSet;
 use tower::ServiceExt;
 
 /// A method no route in the crate registers, so a response distinguishes
 /// "path exists" (`405`) from "path does not exist" (`404`).
 const UNREGISTERED_METHOD: Method = Method::PATCH;
 
-/// Every path the router registers with all optional surfaces enabled, grouped
-/// by the config table that gates it. This list **is** the inventory assertion:
-/// adding a route without adding it here fails
+/// Every `(path, allow)` pair the router registers with all optional surfaces
+/// enabled, grouped by the config table that gates it. This list **is** the
+/// inventory assertion: adding a route without adding it here fails
 /// `no_undocumented_path_is_registered`, which is what forces the conflict
 /// review `docs/admin-ui-delivery.md` asks for.
+///
+/// The second element is the method set the path answers, written the way axum
+/// spells it in the `Allow` header of a `405` — which means `GET` always brings
+/// `HEAD` with it, because axum derives one from the other. Ordering inside the
+/// string is not significant; the pairs are compared as sets.
 ///
 /// Paths are written **exactly as the source registers them**, placeholders
 /// included, so `every_registered_literal_path_is_documented` can compare
 /// against them directly; [`probe_path`] substitutes a concrete segment for the
 /// runtime probes.
-const BASE_PATHS: [&str; 7] = [
-    "/",
-    "/health",
-    "/protocol",
-    "/v1/models",
-    "/routes",
-    "/v1/messages",
-    "/v1/messages/count_tokens",
+const BASE_PATHS: [(&str, &str); 7] = [
+    ("/", "GET,HEAD"),
+    ("/health", "GET,HEAD"),
+    ("/protocol", "GET,HEAD"),
+    ("/v1/models", "GET,HEAD"),
+    ("/routes", "GET,HEAD"),
+    ("/v1/messages", "POST"),
+    ("/v1/messages/count_tokens", "POST"),
 ];
 
 /// 16 paths / 18 method+path pairs — the count `docs/admin-ui-delivery.md`
-/// records in its "Current surface" table.
-const ADMIN_PATHS: [&str; 16] = [
-    "/admin",
-    "/admin/login",
-    "/admin/oidc/start",
-    "/admin/oidc/callback",
-    "/admin/logout",
-    "/admin/accounts",
-    "/admin/observed",
-    "/admin/pool",
-    "/admin/status",
-    "/admin/accounts/claude",
-    "/admin/accounts/claude/{name}/complete",
-    "/admin/accounts/claude/{name}/refresh",
-    "/admin/accounts/claude/{name}",
-    "/admin/accounts/codex",
-    "/admin/accounts/codex/{name}/complete",
-    "/admin/accounts/codex/{name}",
+/// records in its "Current surface" table. Counting the `allow` column here
+/// (ignoring the `HEAD` axum adds to every `GET`) is what reproduces the 18.
+const ADMIN_PATHS: [(&str, &str); 16] = [
+    ("/admin", "GET,HEAD"),
+    ("/admin/login", "GET,HEAD,POST"),
+    ("/admin/oidc/start", "POST"),
+    ("/admin/oidc/callback", "GET,HEAD"),
+    ("/admin/logout", "POST"),
+    ("/admin/accounts", "GET,HEAD"),
+    ("/admin/observed", "GET,HEAD"),
+    ("/admin/pool", "GET,HEAD"),
+    ("/admin/status", "GET,HEAD"),
+    ("/admin/accounts/claude", "POST"),
+    ("/admin/accounts/claude/{name}/complete", "POST"),
+    ("/admin/accounts/claude/{name}/refresh", "POST"),
+    ("/admin/accounts/claude/{name}", "DELETE"),
+    ("/admin/accounts/codex", "GET,HEAD,POST"),
+    ("/admin/accounts/codex/{name}/complete", "POST"),
+    ("/admin/accounts/codex/{name}", "DELETE"),
 ];
 
-const GATEWAY_PATHS: [&str; 10] = [
-    "/.well-known/oauth-authorization-server",
-    "/oauth/device_authorization",
-    "/oauth/token",
-    "/device",
-    "/device/authorize",
-    "/device/callback",
-    "/managed/settings",
-    "/v1/metrics",
-    "/v1/logs",
-    "/v1/traces",
+const GATEWAY_PATHS: [(&str, &str); 10] = [
+    ("/.well-known/oauth-authorization-server", "GET,HEAD"),
+    ("/oauth/device_authorization", "POST"),
+    ("/oauth/token", "POST"),
+    ("/device", "GET,HEAD,POST"),
+    ("/device/authorize", "POST"),
+    ("/device/callback", "GET,HEAD"),
+    ("/managed/settings", "GET,HEAD"),
+    ("/v1/metrics", "POST"),
+    ("/v1/logs", "POST"),
+    ("/v1/traces", "POST"),
 ];
 
-const SPEND_PATHS: [&str; 2] = [
-    "/v1/organizations/spend_limits",
-    "/v1/organizations/spend_limits/{id}",
+/// The two paths whose `MethodRouter` carries a custom
+/// `.fallback(api::method_not_allowed)`. That fallback supplies the `405` body
+/// in place of axum's own and sets no header itself
+/// (`src/gateway/spend/api.rs:295`); axum attaches the `Allow` header around it
+/// regardless, which the probe confirms. So these pairs are gated exactly like
+/// the rest.
+const SPEND_PATHS: [(&str, &str); 2] = [
+    ("/v1/organizations/spend_limits", "GET,HEAD,POST"),
+    ("/v1/organizations/spend_limits/{id}", "GET,HEAD,DELETE"),
 ];
 
 /// Mirrors `codex_endpoint::PATHS` and `codex_analytics::PATHS`, which are
@@ -104,15 +125,15 @@ const SPEND_PATHS: [&str; 2] = [
 /// out of their defining source and compares them against this list, so a
 /// change to either one fails this test and gets re-reviewed against the path
 /// split — which is exactly the guard being installed.
-const CODEX_ENDPOINT_PATHS: [&str; 5] = [
-    "/backend-api/codex/responses",
-    "/responses",
-    "/v1/responses",
-    "/backend-api/codex/analytics-events/events",
-    "/codex/analytics-events/events",
+const CODEX_ENDPOINT_PATHS: [(&str, &str); 5] = [
+    ("/backend-api/codex/responses", "POST"),
+    ("/responses", "POST"),
+    ("/v1/responses", "POST"),
+    ("/backend-api/codex/analytics-events/events", "POST"),
+    ("/codex/analytics-events/events", "POST"),
 ];
 
-const USAGE_PATHS: [&str; 2] = ["/usage", "/api/oauth/usage"];
+const USAGE_PATHS: [(&str, &str); 2] = [("/usage", "GET,HEAD"), ("/api/oauth/usage", "GET,HEAD")];
 
 /// Substitute a concrete segment for each path placeholder, so a template from
 /// the inventory can be sent as a real request.
@@ -120,7 +141,8 @@ fn probe_path(template: &str) -> String {
     template.replace("{name}", "acct").replace("{id}", "spl_1")
 }
 
-fn all_registered_paths() -> Vec<&'static str> {
+/// Every inventory entry, in the order the groups above declare them.
+fn all_registered_entries() -> Vec<(&'static str, &'static str)> {
     BASE_PATHS
         .iter()
         .chain(ADMIN_PATHS.iter())
@@ -129,6 +151,25 @@ fn all_registered_paths() -> Vec<&'static str> {
         .chain(CODEX_ENDPOINT_PATHS.iter())
         .chain(USAGE_PATHS.iter())
         .copied()
+        .collect()
+}
+
+/// Just the paths of [`all_registered_entries`], for the source scans — they
+/// read path literals out of the source and have no method to compare against.
+fn all_registered_paths() -> Vec<&'static str> {
+    all_registered_entries()
+        .into_iter()
+        .map(|(path, _)| path)
+        .collect()
+}
+
+/// Split an `Allow` value into a set, so a difference in the order axum happens
+/// to list the methods in is not a difference in what the router allows.
+fn method_set(allow: &str) -> BTreeSet<&str> {
+    allow
+        .split(',')
+        .map(str::trim)
+        .filter(|method| !method.is_empty())
         .collect()
 }
 
@@ -270,6 +311,57 @@ async fn path_is_registered(router: &Router, path: &str) -> bool {
             "probing {path} with {UNREGISTERED_METHOD} answered {other}; the 404-vs-405 oracle \
              only holds while no route accepts that method and no layer answers ahead of routing"
         ),
+    }
+}
+
+/// The `Allow` header axum puts on the `405` answer to [`UNREGISTERED_METHOD`],
+/// listing the methods the path is registered for.
+async fn allowed_methods(router: &Router, path: &str) -> String {
+    let request = Request::builder()
+        .method(UNREGISTERED_METHOD)
+        .uri(path)
+        .body(Body::empty())
+        .expect("probe request builds");
+    let response = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("router answers the probe");
+    assert_eq!(
+        response.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "probing {path} with {UNREGISTERED_METHOD} did not answer 405, so it carries no Allow \
+         header to read the registered methods off"
+    );
+    response
+        .headers()
+        .get(header::ALLOW)
+        .unwrap_or_else(|| panic!("the 405 for {path} carries an Allow header"))
+        .to_str()
+        .expect("Allow is ASCII")
+        .to_string()
+}
+
+/// The direction the path-only inventory left open: adding or removing a method
+/// on a path that already exists changes no path string, so every other test in
+/// this file stays green while the surface has actually moved. The `405` probe
+/// already names the registered methods in its `Allow` header, so pinning them
+/// costs no extra request and runs no handler.
+#[tokio::test]
+async fn every_registered_method_set_matches_the_inventory() {
+    let (config, _env) = all_surfaces_config("methods");
+    let (router, _shared, _state) = server::build_router(config).expect("router builds");
+
+    for (path, documented) in all_registered_entries() {
+        let allowed = allowed_methods(&router, &probe_path(path)).await;
+        assert_eq!(
+            method_set(&allowed),
+            method_set(documented),
+            "{path} answers {allowed:?} but this test's inventory documents {documented:?}. \
+             Adding or removing a method on an existing path means updating it here too — and, \
+             per docs/admin-ui-delivery.md, reviewing it against the /admin, /admin/api and \
+             reserved /v1/organizations path split first."
+        );
     }
 }
 

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -640,6 +640,20 @@ fn no_router_tree_is_composed_in_from_an_unscanned_module() {
              neither the literal scan nor the inventory above describes the served surface any \
              more — extend both before adopting it."
         );
+
+        // `.route(` is not a substring of `.route_service(`, so the counts above
+        // see neither of axum's service-based registrations. They register paths
+        // exactly like their handler-based twins, which is why they are pinned at
+        // zero here rather than left out.
+        for api in [".route_service(", ".nest_service("] {
+            assert_eq!(
+                source.matches(api).count(),
+                0,
+                "{file} now registers a path with `{api}`, which none of the scans above read. \
+                 Its paths would be served without appearing in the inventory — add it to the \
+                 scans before adopting it."
+            );
+        }
     }
 }
 
@@ -652,7 +666,16 @@ fn no_router_tree_is_composed_in_from_an_unscanned_module() {
 /// and the composition guard, the invariant across the scanned files is that no
 /// registration is silently dropped: every `.route(` either resolves to a literal
 /// path that must appear in the inventory, or is one of these five indirect sites
-/// whose definitions [`INDIRECT_PATH_SOURCES`] reads.
+/// whose definitions [`INDIRECT_PATH_SOURCES`] reads, and the four remaining ways
+/// axum can register a path — `.route_service(`, `.nest(`, `.nest_service(`, and
+/// composing another tree in with `.merge(` — are each counted.
+///
+/// `Router::fallback` needs no count of its own: it claims no path, and a
+/// catch-all would make [`path_is_registered`] answer something other than `404`
+/// or `405` for an unrouted path, which it panics on. The two `.fallback(` calls
+/// in `spend_router` are `MethodRouter::fallback`, a different thing — they
+/// answer an unregistered *method* on a path that does exist, which the `Allow`
+/// probe already covers.
 #[test]
 fn every_nonliteral_route_call_is_one_this_test_already_tracks() {
     let calls: usize = ROUTER_SOURCES

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -1,0 +1,377 @@
+//! Cross-surface router invariants: every optional surface can be enabled at
+//! once, and the registered path set stays exactly the one
+//! `docs/admin-ui-delivery.md` documents.
+//!
+//! `axum::Router::merge` panics at boot on a duplicate path+method, which is a
+//! real safety net for a newly added route — but it only fires when both trees
+//! are registered, and until now no test built a router with `[server.admin]`,
+//! `[server.gateway]`, `[server.spend]`, `[server.codex_endpoint]`,
+//! `[server.usage]`, and `[server.oauth_usage]` all present at once. A
+//! collision between two optional surfaces would therefore have surfaced on an
+//! operator's machine rather than in CI. That gap is recorded under "Risks" in
+//! `docs/admin-ui-delivery.md`; these tests close it *before* any UI route
+//! claims a path, which is the order that document's "Testing" section asks for.
+//!
+//! **How path existence is probed.** `Router` exposes no route table, so the
+//! inventory is read back with a method no shunt route registers. axum answers
+//! `405` when the path matches a route registered for other methods and `404`
+//! when no route matches it at all — the very path-vs-method distinction
+//! Decision 3 of that document reasons about, used here as an oracle. The one
+//! subtlety is that `spend_router` attaches its own `fallback` to each
+//! `MethodRouter`; that fallback also answers `405`, so the oracle holds
+//! uniformly.
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    Router,
+};
+use shunt::{
+    config::{
+        AccountConfig, AdminConfig, AuthMode, CodexEndpointConfig, Config, GatewayConfig,
+        InboundAuthConfig, OauthUsageConfig, SpendConfig, UsageEndpointConfig,
+    },
+    server,
+};
+use tower::ServiceExt;
+
+/// A method no route in the crate registers, so a response distinguishes
+/// "path exists" (`405`) from "path does not exist" (`404`).
+const UNREGISTERED_METHOD: Method = Method::PATCH;
+
+/// Every path the router registers with all optional surfaces enabled, grouped
+/// by the config table that gates it. This list **is** the inventory assertion:
+/// adding a route without adding it here fails
+/// `no_undocumented_path_is_registered`, which is what forces the conflict
+/// review `docs/admin-ui-delivery.md` asks for.
+///
+/// Paths are written **exactly as the source registers them**, placeholders
+/// included, so `every_registered_literal_path_is_documented` can compare
+/// against them directly; [`probe_path`] substitutes a concrete segment for the
+/// runtime probes.
+const BASE_PATHS: [&str; 7] = [
+    "/",
+    "/health",
+    "/protocol",
+    "/v1/models",
+    "/routes",
+    "/v1/messages",
+    "/v1/messages/count_tokens",
+];
+
+/// 16 paths / 18 method+path pairs — the count `docs/admin-ui-delivery.md`
+/// records in its "Current surface" table.
+const ADMIN_PATHS: [&str; 16] = [
+    "/admin",
+    "/admin/login",
+    "/admin/oidc/start",
+    "/admin/oidc/callback",
+    "/admin/logout",
+    "/admin/accounts",
+    "/admin/observed",
+    "/admin/pool",
+    "/admin/status",
+    "/admin/accounts/claude",
+    "/admin/accounts/claude/{name}/complete",
+    "/admin/accounts/claude/{name}/refresh",
+    "/admin/accounts/claude/{name}",
+    "/admin/accounts/codex",
+    "/admin/accounts/codex/{name}/complete",
+    "/admin/accounts/codex/{name}",
+];
+
+const GATEWAY_PATHS: [&str; 10] = [
+    "/.well-known/oauth-authorization-server",
+    "/oauth/device_authorization",
+    "/oauth/token",
+    "/device",
+    "/device/authorize",
+    "/device/callback",
+    "/managed/settings",
+    "/v1/metrics",
+    "/v1/logs",
+    "/v1/traces",
+];
+
+const SPEND_PATHS: [&str; 2] = [
+    "/v1/organizations/spend_limits",
+    "/v1/organizations/spend_limits/{id}",
+];
+
+/// Mirrors `codex_endpoint::PATHS` and `codex_analytics::PATHS`, which are
+/// `pub(crate)` and so cannot be imported here. Duplicating them is deliberate:
+/// a change to either constant must fail this test and be re-reviewed against
+/// the path split, which is exactly the guard being installed.
+const CODEX_ENDPOINT_PATHS: [&str; 5] = [
+    "/backend-api/codex/responses",
+    "/responses",
+    "/v1/responses",
+    "/backend-api/codex/analytics-events/events",
+    "/codex/analytics-events/events",
+];
+
+const USAGE_PATHS: [&str; 2] = ["/usage", "/api/oauth/usage"];
+
+/// Substitute a concrete segment for each path placeholder, so a template from
+/// the inventory can be sent as a real request.
+fn probe_path(template: &str) -> String {
+    template.replace("{name}", "acct").replace("{id}", "spl_1")
+}
+
+fn all_registered_paths() -> Vec<&'static str> {
+    BASE_PATHS
+        .iter()
+        .chain(ADMIN_PATHS.iter())
+        .chain(GATEWAY_PATHS.iter())
+        .chain(SPEND_PATHS.iter())
+        .chain(CODEX_ENDPOINT_PATHS.iter())
+        .chain(USAGE_PATHS.iter())
+        .copied()
+        .collect()
+}
+
+/// `Config::default()` with **every** optional surface enabled at once.
+///
+/// Env-backed credentials get per-process-unique names because the process
+/// environment is shared across the test binary: a fixed name would let one
+/// test's value satisfy another test's config by accident.
+///
+/// Both `state_path` values are set to an empty path — the documented opt-out
+/// — so building a router never reads or writes the operator's real
+/// `~/.shunt` state.
+fn all_surfaces_config(label: &str) -> Config {
+    let suffix = format!("{}_{label}", std::process::id());
+    let admin_env = format!("SHUNT_ROUTER_SURFACE_ADMIN_{suffix}");
+    let client_env = format!("SHUNT_ROUTER_SURFACE_CLIENT_{suffix}");
+    let jwt_env = format!("SHUNT_ROUTER_SURFACE_JWT_{suffix}");
+    let users_env = format!("SHUNT_ROUTER_SURFACE_USERS_{suffix}");
+    std::env::set_var(&admin_env, "admin:admin-secret");
+    std::env::set_var(&client_env, "tester:client-secret");
+    std::env::set_var(&jwt_env, "0123456789abcdef0123456789abcdef");
+    std::env::set_var(&users_env, "dev@example.com:password");
+
+    let mut config = Config::default();
+
+    // `[server.auth]` is not itself a route, but `[server.usage]` requires it.
+    config.server.auth = Some(InboundAuthConfig {
+        header: "x-shunt-token".to_string(),
+        tokens_env: client_env,
+    });
+
+    config.server.admin = Some(AdminConfig {
+        header: "x-shunt-admin-token".to_string(),
+        tokens_env: admin_env,
+        tokens_file: None,
+        write_keys: Vec::new(),
+        read_keys: Vec::new(),
+        session_ttl_secs: 3600,
+        pending_ttl_secs: 600,
+        oidc: None,
+    });
+
+    config.server.gateway = Some(GatewayConfig {
+        public_url: "https://gateway.example".to_string(),
+        jwt_secret_env: Some(jwt_env),
+        users_env,
+        token_ttl_seconds: Some(3600),
+        trust_forwarded_for: false,
+        policies: None,
+        telemetry: None,
+        state_path: Some(std::path::PathBuf::new()),
+        oidc: None,
+        session: None,
+    });
+
+    config.server.spend = Some(SpendConfig {
+        state_path: Some(std::path::PathBuf::new()),
+        ..SpendConfig::default()
+    });
+
+    config.server.codex_endpoint = Some(CodexEndpointConfig {
+        provider: "codex".to_string(),
+        routes: Vec::new(),
+    });
+
+    config.server.usage = Some(UsageEndpointConfig::default());
+    config.server.oauth_usage = Some(OauthUsageConfig::default());
+
+    // A pool account is only valid on an OAuth provider, and giving `codex` one
+    // explicit account keeps router construction off the real account store.
+    let anthropic = config
+        .providers
+        .get_mut("anthropic")
+        .expect("built-in anthropic provider");
+    anthropic.auth = AuthMode::ClaudeOauth;
+    let codex = config
+        .providers
+        .get_mut("codex")
+        .expect("built-in codex provider");
+    codex.accounts = vec![AccountConfig {
+        name: "acct".to_string(),
+        ..AccountConfig::default()
+    }];
+
+    config
+}
+
+/// `true` when the router has any route registered at `path`.
+async fn path_is_registered(router: &Router, path: &str) -> bool {
+    let request = Request::builder()
+        .method(UNREGISTERED_METHOD)
+        .uri(path)
+        .body(Body::empty())
+        .expect("probe request builds");
+    let status = router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("router answers the probe")
+        .status();
+    match status {
+        StatusCode::METHOD_NOT_ALLOWED => true,
+        StatusCode::NOT_FOUND => false,
+        other => panic!(
+            "probing {path} with {UNREGISTERED_METHOD} answered {other}; the 404-vs-405 oracle \
+             only holds while no route accepts that method and no layer answers ahead of routing"
+        ),
+    }
+}
+
+/// The gap recorded under "Risks" in `docs/admin-ui-delivery.md`: `Router::merge`
+/// panics on a duplicate path+method, but only when both trees are registered.
+#[tokio::test]
+async fn every_optional_surface_can_be_enabled_at_once() {
+    let config = all_surfaces_config("builds");
+    let (_router, _shared, _state) =
+        server::build_router(config).expect("a config enabling every optional surface builds");
+}
+
+#[tokio::test]
+async fn every_documented_path_is_registered_when_all_surfaces_are_enabled() {
+    let (router, _shared, _state) =
+        server::build_router(all_surfaces_config("registered")).expect("router builds");
+
+    for path in all_registered_paths() {
+        assert!(
+            path_is_registered(&router, &probe_path(path)).await,
+            "{path} is documented as registered but no route answers it"
+        );
+    }
+}
+
+/// The other half of the inventory: paths adjacent to real ones, and the
+/// namespace reserved for a later milestone, must still be absent. Without this
+/// the test above would pass just as well against a catch-all fallback.
+#[tokio::test]
+async fn no_undocumented_path_is_registered() {
+    let (router, _shared, _state) =
+        server::build_router(all_surfaces_config("undocumented")).expect("router builds");
+
+    // Deliberately near-misses of registered paths, plus `/v1/organizations/*`
+    // members shunt does not implement (`docs/admin-ui-delivery.md` reserves
+    // that namespace for the Anthropic-shaped Admin API).
+    for path in [
+        "/nope",
+        "/v1/nope",
+        "/admin/nope",
+        "/admin/accounts/gemini",
+        "/admin/accounts/codex/acct/refresh",
+        "/oauth/authorize",
+        "/v1/organizations/spend_limits/spl_1/effective",
+        "/v1/organizations/spend_limits/spl_1/audit",
+    ] {
+        assert!(
+            !path_is_registered(&router, path).await,
+            "{path} answers but is not in the documented inventory"
+        );
+    }
+}
+
+/// `/` is a liveness probe target as well as a landing page, so any UI work
+/// that later claims a path must leave its `HEAD` answer intact.
+#[tokio::test]
+async fn root_still_answers_head_with_every_surface_enabled() {
+    let (router, _shared, _state) =
+        server::build_router(all_surfaces_config("head")).expect("router builds");
+
+    let request = Request::builder()
+        .method(Method::HEAD)
+        .uri("/")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Every router source file that registers a path as a string literal. Scanned
+/// at compile time, so this test needs no filesystem access at runtime.
+const ROUTER_SOURCES: [(&str, &str); 4] = [
+    ("src/server.rs", include_str!("../src/server.rs")),
+    ("src/admin/mod.rs", include_str!("../src/admin/mod.rs")),
+    ("src/gateway/mod.rs", include_str!("../src/gateway/mod.rs")),
+    (
+        "src/gateway/spend/mod.rs",
+        include_str!("../src/gateway/spend/mod.rs"),
+    ),
+];
+
+/// Extract the literal first argument of every `.route("…"` call in `source`.
+fn registered_literal_paths(source: &str) -> Vec<&str> {
+    source
+        .match_indices(".route(")
+        .filter_map(|(index, marker)| {
+            let rest = source[index + marker.len()..].trim_start();
+            // A non-literal first argument (`telemetry_ingest::Signal::…path()`,
+            // or the `path` loop variable in `server.rs`) is out of this scan's
+            // reach by construction; those paths are covered by the runtime
+            // probes above instead.
+            let literal = rest.strip_prefix('"')?;
+            let end = literal.find('"')?;
+            Some(&literal[..end])
+        })
+        .collect()
+}
+
+/// The half of the inventory the runtime probes cannot supply: `Router` exposes
+/// no route table, so a route added at a path this file has never heard of
+/// would answer requests without failing any probe. Reading the registrations
+/// back out of the source closes that, which is what makes the inventory an
+/// actual gate rather than a spot check.
+///
+/// Residual gap, stated rather than hidden: a route whose path is not a string
+/// literal at the call site is invisible here. There are two such sites today —
+/// the OTLP signals in `gateway_router` and the `codex_endpoint::PATHS` /
+/// `codex_analytics::PATHS` loops in `build_router` — and both are pinned by
+/// `every_documented_path_is_registered_when_all_surfaces_are_enabled`.
+#[test]
+fn every_registered_literal_path_is_documented() {
+    let inventory = all_registered_paths();
+    for (file, source) in ROUTER_SOURCES {
+        for path in registered_literal_paths(source) {
+            assert!(
+                inventory.contains(&path),
+                "{file} registers {path}, which is not in this test's inventory. Adding a route \
+                 means adding it here too — and, per docs/admin-ui-delivery.md, reviewing it \
+                 against the /admin, /admin/api and reserved /v1/organizations path split first."
+            );
+        }
+    }
+}
+
+/// The scan is only a gate while it actually finds the registrations; a
+/// refactor that changed the `.route("…"` spelling would otherwise leave
+/// `every_registered_literal_path_is_documented` vacuously green.
+#[test]
+fn the_source_scan_finds_every_literal_registration() {
+    let found: usize = ROUTER_SOURCES
+        .iter()
+        .map(|(_, source)| registered_literal_paths(source).len())
+        .sum();
+    // 9 in `server.rs` (7 base + `/usage` + `/api/oauth/usage`), 16 admin,
+    // 7 gateway (its 3 OTLP paths come from `Signal::path()`), 2 spend.
+    assert_eq!(
+        found, 34,
+        "the literal-path scan found {found} registrations, not 34; either a route was added or \
+         removed, or `.route(\"…\"` is no longer how they are spelled"
+    );
+}

--- a/tests/router_surface.rs
+++ b/tests/router_surface.rs
@@ -100,8 +100,10 @@ const SPEND_PATHS: [&str; 2] = [
 
 /// Mirrors `codex_endpoint::PATHS` and `codex_analytics::PATHS`, which are
 /// `pub(crate)` and so cannot be imported here. Duplicating them is deliberate:
-/// a change to either constant must fail this test and be re-reviewed against
-/// the path split, which is exactly the guard being installed.
+/// `every_indirectly_registered_path_is_documented` reads both constants back
+/// out of their defining source and compares them against this list, so a
+/// change to either one fails this test and gets re-reviewed against the path
+/// split — which is exactly the guard being installed.
 const CODEX_ENDPOINT_PATHS: [&str; 5] = [
     "/backend-api/codex/responses",
     "/responses",
@@ -139,7 +141,7 @@ fn all_registered_paths() -> Vec<&'static str> {
 /// Both `state_path` values are set to an empty path — the documented opt-out
 /// — so building a router never reads or writes the operator's real
 /// `~/.shunt` state.
-fn all_surfaces_config(label: &str) -> Config {
+fn all_surfaces_config(label: &str) -> (Config, EnvVars) {
     let suffix = format!("{}_{label}", std::process::id());
     let admin_env = format!("SHUNT_ROUTER_SURFACE_ADMIN_{suffix}");
     let client_env = format!("SHUNT_ROUTER_SURFACE_CLIENT_{suffix}");
@@ -149,6 +151,13 @@ fn all_surfaces_config(label: &str) -> Config {
     std::env::set_var(&client_env, "tester:client-secret");
     std::env::set_var(&jwt_env, "0123456789abcdef0123456789abcdef");
     std::env::set_var(&users_env, "dev@example.com:password");
+
+    // The config takes ownership of these names below, so the guard needs its
+    // own copies to remove them by.
+    let admin_env_name = admin_env.clone();
+    let client_env_name = client_env.clone();
+    let jwt_env_name = jwt_env.clone();
+    let users_env_name = users_env.clone();
 
     let mut config = Config::default();
 
@@ -211,7 +220,34 @@ fn all_surfaces_config(label: &str) -> Config {
         ..AccountConfig::default()
     }];
 
-    config
+    (
+        config,
+        EnvVars(vec![
+            admin_env_name,
+            client_env_name,
+            jwt_env_name,
+            users_env_name,
+        ]),
+    )
+}
+
+/// Removes the env vars [`all_surfaces_config`] set once the test holding it
+/// finishes. The per-process-unique names already stop one test's value from
+/// satisfying another's config, so this is hygiene rather than isolation — but
+/// it matches the set/remove pairing every other test file here uses
+/// (`tests/admin_surface.rs` pairs all 91 of its `set_var` calls), and keeps the
+/// variables from outliving their test for the rest of the binary's run.
+///
+/// Removal happens on drop, at the end of the test body, never at its start:
+/// clearing shared globals on entry is what breaks a neighbour mid-run.
+struct EnvVars(Vec<String>);
+
+impl Drop for EnvVars {
+    fn drop(&mut self) {
+        for name in &self.0 {
+            std::env::remove_var(name);
+        }
+    }
 }
 
 /// `true` when the router has any route registered at `path`.
@@ -241,15 +277,15 @@ async fn path_is_registered(router: &Router, path: &str) -> bool {
 /// panics on a duplicate path+method, but only when both trees are registered.
 #[tokio::test]
 async fn every_optional_surface_can_be_enabled_at_once() {
-    let config = all_surfaces_config("builds");
+    let (config, _env) = all_surfaces_config("builds");
     let (_router, _shared, _state) =
         server::build_router(config).expect("a config enabling every optional surface builds");
 }
 
 #[tokio::test]
 async fn every_documented_path_is_registered_when_all_surfaces_are_enabled() {
-    let (router, _shared, _state) =
-        server::build_router(all_surfaces_config("registered")).expect("router builds");
+    let (config, _env) = all_surfaces_config("registered");
+    let (router, _shared, _state) = server::build_router(config).expect("router builds");
 
     for path in all_registered_paths() {
         assert!(
@@ -264,8 +300,8 @@ async fn every_documented_path_is_registered_when_all_surfaces_are_enabled() {
 /// the test above would pass just as well against a catch-all fallback.
 #[tokio::test]
 async fn no_undocumented_path_is_registered() {
-    let (router, _shared, _state) =
-        server::build_router(all_surfaces_config("undocumented")).expect("router builds");
+    let (config, _env) = all_surfaces_config("undocumented");
+    let (router, _shared, _state) = server::build_router(config).expect("router builds");
 
     // Deliberately near-misses of registered paths, plus `/v1/organizations/*`
     // members shunt does not implement (`docs/admin-ui-delivery.md` reserves
@@ -291,8 +327,8 @@ async fn no_undocumented_path_is_registered() {
 /// that later claims a path must leave its `HEAD` answer intact.
 #[tokio::test]
 async fn root_still_answers_head_with_every_surface_enabled() {
-    let (router, _shared, _state) =
-        server::build_router(all_surfaces_config("head")).expect("router builds");
+    let (config, _env) = all_surfaces_config("head");
+    let (router, _shared, _state) = server::build_router(config).expect("router builds");
 
     let request = Request::builder()
         .method(Method::HEAD)
@@ -338,11 +374,12 @@ fn registered_literal_paths(source: &str) -> Vec<&str> {
 /// back out of the source closes that, which is what makes the inventory an
 /// actual gate rather than a spot check.
 ///
-/// Residual gap, stated rather than hidden: a route whose path is not a string
-/// literal at the call site is invisible here. There are two such sites today —
-/// the OTLP signals in `gateway_router` and the `codex_endpoint::PATHS` /
-/// `codex_analytics::PATHS` loops in `build_router` — and both are pinned by
-/// `every_documented_path_is_registered_when_all_surfaces_are_enabled`.
+/// A route whose path is not a string literal at the call site is invisible to
+/// this scan. There are two such sites today — the OTLP signals in
+/// `gateway_router` and the `codex_endpoint::PATHS` / `codex_analytics::PATHS`
+/// loops in `build_router`. `every_documented_path_is_registered_when_all_surfaces_are_enabled`
+/// catches a removal or rename in either set but **not** an addition, so
+/// [`INDIRECT_PATH_SOURCES`] scans those definitions to close that direction.
 #[test]
 fn every_registered_literal_path_is_documented() {
     let inventory = all_registered_paths();
@@ -373,5 +410,94 @@ fn the_source_scan_finds_every_literal_registration() {
         found, 34,
         "the literal-path scan found {found} registrations, not 34; either a route was added or \
          removed, or `.route(\"…\"` is no longer how they are spelled"
+    );
+}
+
+/// The path sets `build_router` and `gateway_router` register *indirectly*,
+/// paired with the marker that opens their definition and the marker that
+/// closes it. `registered_literal_paths` cannot see these — the call site
+/// passes a loop variable or a method call, not a literal — so an **addition**
+/// to one of them would otherwise register a live route while every other test
+/// in this file stayed green.
+const INDIRECT_PATH_SOURCES: [(&str, &str, &str, &str); 3] = [
+    (
+        "src/codex_endpoint.rs",
+        include_str!("../src/codex_endpoint.rs"),
+        "const PATHS: [&str; ",
+        "];",
+    ),
+    (
+        "src/codex_analytics.rs",
+        include_str!("../src/codex_analytics.rs"),
+        "const PATHS: [&str; ",
+        "];",
+    ),
+    (
+        "src/gateway/telemetry_ingest.rs",
+        include_str!("../src/gateway/telemetry_ingest.rs"),
+        "const fn path(self) -> &'static str {",
+        "\n    }",
+    ),
+];
+
+/// Extract every string literal between `open` and the first `close` after it.
+fn string_literals_in_block<'a>(source: &'a str, open: &str, close: &str) -> Vec<&'a str> {
+    let start = source
+        .find(open)
+        .unwrap_or_else(|| panic!("marker {open:?} not found; the definition was reshaped"))
+        + open.len();
+    let end = start
+        + source[start..]
+            .find(close)
+            .unwrap_or_else(|| panic!("terminator {close:?} not found after {open:?}"));
+
+    let mut literals = Vec::new();
+    let mut rest = &source[start..end];
+    while let Some(open_quote) = rest.find('"') {
+        rest = &rest[open_quote + 1..];
+        let Some(close_quote) = rest.find('"') else {
+            break;
+        };
+        literals.push(&rest[..close_quote]);
+        rest = &rest[close_quote + 1..];
+    }
+    literals
+}
+
+/// The direction `every_documented_path_is_registered_when_all_surfaces_are_enabled`
+/// cannot cover. That test proves each *documented* path is live, so removing or
+/// renaming a member of one of these sets fails it — but appending a member
+/// leaves it green, because nothing probes a path this file has never heard of.
+/// Reading the definitions back out of their own source closes that direction.
+#[test]
+fn every_indirectly_registered_path_is_documented() {
+    let inventory = all_registered_paths();
+    for (file, source, open, close) in INDIRECT_PATH_SOURCES {
+        for path in string_literals_in_block(source, open, close) {
+            assert!(
+                inventory.contains(&path),
+                "{file} registers {path} indirectly, which is not in this test's inventory. \
+                 Adding a path to one of these sets means adding it here too — and, per \
+                 docs/admin-ui-delivery.md, reviewing it against the /admin, /admin/api and \
+                 reserved /v1/organizations path split first."
+            );
+        }
+    }
+}
+
+/// The indirect scan is only a gate while it actually finds the definitions; a
+/// refactor that reshaped one of them would otherwise leave
+/// `every_indirectly_registered_path_is_documented` vacuously green.
+#[test]
+fn the_indirect_scan_finds_every_definition() {
+    let found: usize = INDIRECT_PATH_SOURCES
+        .iter()
+        .map(|(_, source, open, close)| string_literals_in_block(source, open, close).len())
+        .sum();
+    // 3 `codex_endpoint::PATHS` + 2 `codex_analytics::PATHS` + 3 OTLP signals.
+    assert_eq!(
+        found, 8,
+        "the indirect-path scan found {found} definitions, not 8; either a path was added or \
+         removed, or one of these sets is no longer spelled the way the scan expects"
     );
 }


### PR DESCRIPTION
## Summary

Groundwork for extending shunt's admin surface, prompted by two reference CLIProxyAPI panels (CPA Manager Plus, CPA Usage Keeper). This PR contains **no production source changes** — it is documentation plus tests.

- **ADR-0003 (`.please/docs/decisions/0003-admin-dashboard-extension.md`)** records three decisions. The admin UI platform work — the planned `/admin/api/*` split and an embedded React/Vite SPA — lands before new data features. Request/usage history, when it lands, is backed by optional SQLite, and the in-memory path stays the default. Monetary cost estimates are deferred, because shunt's primary case is consumer subscriptions with no per-token bill. The ADR rests on a survey finding that shunt today retains no per-request event history and computes no cost anywhere, and that `[server.spend]` stores limit policy and audit rather than consumption.
- **The design-record correction (`docs/admin-ui-delivery.md`)** fixes the blocked-path table that Resolution 6 designates as the migration inventory. The table omitted `POST /admin/accounts/claude/{name}/refresh`, so it listed 12 of 13 paths, and the "Current surface" row credited `admin_router` with M9's endpoint-table counts (15/17) rather than the router's own (16/18).
- **The new test file (`tests/router_surface.rs`)** closes the gap recorded under "Risks" in that design record. `axum::Router::merge` panics on a duplicate path+method, but only when both trees are registered, and no test built a router with every optional surface enabled at once. Six tests cover it: the all-surfaces build, a runtime path-inventory probe that uses the 404-vs-405 distinction as a path-existence oracle, an undocumented-path check, a `HEAD /` regression, and a compile-time `include_str!` source scan that catches a route added at a novel path — which the runtime probes alone do not.

## Milestone / spec

- ADR-0003 — `.please/docs/decisions/0003-admin-dashboard-extension.md`
- `docs/admin-ui-delivery.md` (blocked-path inventory for Resolution 6; "Risks" section)

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit) — n/a, no user-facing behavior changes
- [x] Any new GitHub Action is pinned to a full commit SHA — n/a, no workflow changes

## Verification

- `cargo fmt --all --check` → exit 0
- `cargo clippy --all-targets --all-features -- -D warnings` → exit 0, zero warning/error lines
- `cargo test --all-features --workspace` → exit 0, 2,547 passed, 0 failed
- Each new test was additionally proven non-vacuous by mutation: deleting a route, adding an undocumented route, duplicating `GET /v1/models` across two surfaces, and adding a route at a novel path each produced the expected distinct failure.

## Notes for reviewers

- No production source changes — review scope is the ADR's reasoning, the corrected path inventory, and whether the router-surface tests fail for the right reasons.
- The path-existence oracle in `tests/router_surface.rs` relies on axum returning 405 (not 404) for a registered path with an unmatched method; the compile-time source scan exists because that oracle cannot see a route registered at a path nobody probes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR-0003 and a router-surface test suite to establish the admin dashboard baseline and catch route conflicts before UI work begins. No production source changes.

**Documentation**
- Records the React/Vite SPA and `/admin/api/*` split as the first track, optional SQLite history, and deferred cost estimates.
- Corrects the admin inventory, including the Claude refresh and spend-limit routes, current counts, source location, asset-size date, and spend namespace details.
- Marks the duplicate-route risk as covered by the all-surfaces router smoke test.

**Tests**
- Builds the router with every optional surface enabled and checks documented and undocumented paths.
- Pins each path's method set through the `Allow` header, including `HEAD` behavior.
- Scans literal and indirectly registered paths, and pins the `.merge(`/`.nest(` composition points, the non-literal `.route(` call count, and the `.route_service(`/`.nest_service(` counts (at zero), so every registration form must be added to the reviewed inventory.

<sup>Written for commit e4b93197ca572133b0d0c5f8eea21b9371655f21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

