### PR TITLE
fix(deps): update h2 for empty-frame denial of service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,9 +909,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

Bumps the transitive `h2` lockfile entry to `0.4.16` to pick up the fix for RUSTSEC-2026-0258 / GHSA-q83h-524g-xf6h (unbounded empty DATA frames). `h2` is not a direct dependency, so the diff is lockfile-only: `cargo audit` reports 1 vulnerability on current `main`, 0 on this branch (the `chacha20` yanked warning predates it and is unchanged).

## Milestone / spec

None — dependency security bump.

## Checklist

- [x] `cargo build` passes
- [x] `cargo test` passes (new behavior is covered; tests run without network/loopback where possible)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Source files stay under 500 lines
- [x] English only; matches surrounding style
- [x] Frozen spec in `docs/` updated if this change deviates from it
- [x] User-facing docs updated for behavior/config/endpoint/CLI/provider/model changes — `README.md` / `site/` as applicable (`wiki/` is generated; don't hand-edit)
- [x] Any new GitHub Action is pinned to a full commit SHA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the transitive `h2` dependency from 0.4.15 to 0.4.16 to fix the empty DATA frame denial-of-service vulnerability (RUSTSEC-2026-0258 / GHSA-q83h-524g-xf6h). This lockfile-only change clears the `cargo audit` finding without changing application behavior or direct dependencies.

<sup>Written for commit a60a7903f5f38e194b59badcaff7dbd843d0ea56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

