### PR TITLE
fix(discovery): use the negotiated error shape for Codex catalog failures

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -7,7 +7,7 @@ use std::{
 use axum::{
     body::{Body, Bytes, HttpBody},
     extract::{Request, State},
-    http::{header::RETRY_AFTER, HeaderValue, StatusCode},
+    http::{header::RETRY_AFTER, HeaderValue, StatusCode, Uri},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -21,12 +21,14 @@ const OVERLOADED_MESSAGE: &str = "too many requests are already in flight";
 #[derive(Clone, Debug)]
 pub(crate) struct ConcurrencyLimit {
     permits: Arc<Semaphore>,
+    codex_endpoint_enabled: bool,
 }
 
 impl ConcurrencyLimit {
-    pub(crate) fn new(max_concurrent_requests: usize) -> Self {
+    pub(crate) fn new(max_concurrent_requests: usize, codex_endpoint_enabled: bool) -> Self {
         Self {
             permits: Arc::new(Semaphore::new(max_concurrent_requests)),
+            codex_endpoint_enabled,
         }
     }
 }
@@ -41,6 +43,7 @@ pub(crate) async fn limit_requests(
     next: Next,
 ) -> Response {
     let path = request.uri().path();
+    let codex_shape = is_codex_request(request.uri(), limit.codex_endpoint_enabled);
     // Move the `Arc` rather than cloning it: `try_acquire_owned` consumes an
     // `Arc<Semaphore>`, and axum's `State` extractor already handed us an owned
     // clone of the limiter, so cloning again would add a redundant refcount pair
@@ -54,7 +57,7 @@ pub(crate) async fn limit_requests(
             // and so never lands in `record_proxied_request` or a request span.
             tracing::debug!(path, "shedding request at inbound concurrency limit");
             crate::metrics::record_request_shed();
-            return overloaded_response(is_codex_path(path)).await;
+            return overloaded_response(codex_shape).await;
         }
     };
 
@@ -70,6 +73,17 @@ pub(crate) async fn limit_requests(
 /// would have matched and must classify by path. It reads the same constants the
 /// router registers from, so a Codex route cannot be added without also getting
 /// the correct error shape.
+pub(crate) fn is_codex_request(uri: &Uri, codex_endpoint_enabled: bool) -> bool {
+    let path = uri.path();
+    is_codex_path(path)
+        || crate::discovery::CODEX_PATHS.contains(&path)
+        || (codex_endpoint_enabled
+            && path == "/v1/models"
+            && crate::discovery::has_client_version_query(uri.query()))
+}
+
+/// Classify the unambiguous, path-only Codex routes shared by middleware that
+/// has no boot-time catalog negotiation state.
 pub(crate) fn is_codex_path(path: &str) -> bool {
     crate::codex_endpoint::PATHS.contains(&path) || crate::codex_analytics::PATHS.contains(&path)
 }
@@ -177,7 +191,7 @@ mod tests {
         http::{header::RETRY_AFTER, HeaderMap, HeaderValue, StatusCode},
         middleware,
         response::Response,
-        routing::post as post_route,
+        routing::{get as get_route, post as post_route},
         Router,
     };
     use futures_util::{stream, StreamExt};
@@ -203,13 +217,22 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(limit),
+                ConcurrencyLimit::new(limit, false),
                 limit_requests,
             ))
     }
 
     fn limited_router(path: &'static str, limit: usize) -> Router {
         limited_router_with_calls(path, limit, Arc::new(AtomicUsize::new(0)))
+    }
+
+    fn saturated_get_router(path: &'static str, codex_endpoint_enabled: bool) -> Router {
+        Router::new()
+            .route(path, get_route(|| async { StatusCode::NO_CONTENT }))
+            .layer(middleware::from_fn_with_state(
+                ConcurrencyLimit::new(0, codex_endpoint_enabled),
+                limit_requests,
+            ))
     }
 
     async fn json_body(response: Response) -> Value {
@@ -291,6 +314,68 @@ mod tests {
         assert_eq!(calls.load(Ordering::Relaxed), 0);
     }
 
+    #[tokio::test]
+    async fn saturated_codex_catalog_requests_use_the_negotiated_error_shape() {
+        for uri in [
+            "/models",
+            "/backend-api/codex/models",
+            "/v1/models?client_version=",
+            "/v1/models?client_version=one&client_version=two",
+            "/v1/models?%63lient_version=0.152.0",
+        ] {
+            let route = if uri.starts_with("/v1/models?") {
+                "/v1/models"
+            } else {
+                uri
+            };
+            let response = saturated_get_router(route, true)
+                .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE, "{uri}");
+            assert_eq!(response.headers()[RETRY_AFTER], "1", "{uri}");
+            assert_eq!(
+                json_body(response).await,
+                serde_json::json!({
+                    "error": {
+                        "message": "too many requests are already in flight",
+                        "type": "overloaded_error",
+                        "code": null
+                    }
+                }),
+                "{uri}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn saturated_plain_models_request_keeps_the_anthropic_error_shape() {
+        for (uri, codex_endpoint_enabled) in [
+            ("/v1/models?limit=1000", true),
+            ("/v1/models?client_version=0.152.0", false),
+        ] {
+            let response = saturated_get_router("/v1/models", codex_endpoint_enabled)
+                .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE, "{uri}");
+            assert_eq!(response.headers()[RETRY_AFTER], "1", "{uri}");
+            assert_eq!(
+                json_body(response).await,
+                serde_json::json!({
+                    "type": "error",
+                    "error": {
+                        "type": "overloaded_error",
+                        "message": "too many requests are already in flight"
+                    }
+                }),
+                "{uri}"
+            );
+        }
+    }
+
     /// Reports end-of-stream only *after* it has been polled, while never
     /// yielding a frame. A buffering wrapper delegating `is_end_stream()` to a
     /// drained inner body looks like this. Constructed not-yet-ended so it
@@ -323,7 +408,7 @@ mod tests {
     /// limit exists to prevent.
     #[tokio::test]
     async fn pending_frame_never_releases_even_when_inner_reports_end() {
-        let limit = ConcurrencyLimit::new(1);
+        let limit = ConcurrencyLimit::new(1, false);
         let permit = limit.permits.clone().try_acquire_owned().unwrap();
         let mut body = PermitBody::new(Body::new(EndsWhilePending::default()), permit);
         assert_eq!(limit.permits.available_permits(), 0);
@@ -345,7 +430,7 @@ mod tests {
 
     #[tokio::test]
     async fn trailers_survive_the_permit_body_wrapper() {
-        let limit = ConcurrencyLimit::new(1);
+        let limit = ConcurrencyLimit::new(1, false);
         let permit = limit.permits.clone().try_acquire_owned().unwrap();
         let mut trailers = HeaderMap::new();
         trailers.insert("x-stream-checksum", HeaderValue::from_static("verified"));
@@ -391,7 +476,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(1),
+                ConcurrencyLimit::new(1, false),
                 limit_requests,
             ));
 
@@ -443,7 +528,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(1),
+                ConcurrencyLimit::new(1, false),
                 limit_requests,
             ));
 
@@ -483,7 +568,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(3),
+                ConcurrencyLimit::new(3, false),
                 limit_requests,
             ));
 
@@ -537,7 +622,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(1),
+                ConcurrencyLimit::new(1, false),
                 limit_requests,
             ));
 
@@ -585,7 +670,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(1),
+                ConcurrencyLimit::new(1, false),
                 limit_requests,
             ));
 
@@ -631,7 +716,7 @@ mod tests {
                 }),
             )
             .layer(middleware::from_fn_with_state(
-                ConcurrencyLimit::new(1),
+                ConcurrencyLimit::new(1, false),
                 limit_requests,
             ))
     }
@@ -713,7 +798,7 @@ mod tests {
                     }),
                 )
                 .layer(middleware::from_fn_with_state(
-                    ConcurrencyLimit::new(1),
+                    ConcurrencyLimit::new(1, false),
                     limit_requests,
                 ));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1232,9 +1232,11 @@ fn validate_idp_url(
 /// `[server.codex_endpoint]` — opt-in inbound OpenAI Responses (Codex) endpoint.
 /// When present, shunt registers `POST /backend-api/codex/responses`,
 /// `POST /responses`, and `POST /v1/responses`, plus the Codex CLI model-catalog
-/// aliases, and proxies each inference request through the named provider's
-/// ChatGPT/Codex account pool without translating it to or from Anthropic
-/// Messages (a raw passthrough). Absent ⇒ none of those routes exist. See
+/// aliases, and proxies each inference request through the configured
+/// Responses-compatible provider without translating it to or from Anthropic
+/// Messages (a raw passthrough). The default provider is the ChatGPT/Codex
+/// account pool; exact `routes` entries may select other providers. Absent ⇒
+/// none of those routes exist. See
 /// `docs/m11-inbound-codex-endpoint.md`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CodexEndpointConfig {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -296,6 +296,14 @@ mod tests {
 
     use super::get;
 
+    struct OwnedEnvGuard(String);
+
+    impl Drop for OwnedEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var(&self.0);
+        }
+    }
+
     #[tokio::test]
     async fn returns_configured_models_with_optional_display_name() {
         let config = crate::config::Config {
@@ -651,6 +659,7 @@ mod tests {
             CODEX_AUTH_COUNTER.fetch_add(1, Ordering::Relaxed)
         );
         std::env::set_var(&env, "tester:catalog-secret");
+        let _env_guard = OwnedEnvGuard(env.clone());
         let mut config = codex_enabled_config();
         config.server.auth = Some(InboundAuthConfig {
             header: "x-shunt-token".to_string(),
@@ -721,8 +730,6 @@ mod tests {
                 }
             })
         );
-
-        std::env::remove_var(env);
     }
 
     const ADMIN_WRITE_KEY: &str = "admin-write-key-0123456789abcdef0";

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,7 +6,11 @@ use axum::{
 };
 use serde::Serialize;
 
-use crate::{auth::slots::ShuntCredentials, error::ShuntError, server::AppState};
+use crate::{
+    auth::slots::ShuntCredentials,
+    error::{into_openai_error_shape, ShuntError},
+    server::AppState,
+};
 
 pub(crate) mod upstream;
 
@@ -124,7 +128,11 @@ impl ModelEntry {
 /// enabled at boot.
 pub(crate) const CODEX_PATHS: [&str; 2] = ["/models", "/backend-api/codex/models"];
 
-fn authentication_error(state: &AppState, headers: &HeaderMap) -> Option<Response> {
+async fn authentication_error(
+    state: &AppState,
+    headers: &HeaderMap,
+    codex_shape: bool,
+) -> Option<Response> {
     let static_client = state
         .inbound_auth
         .as_ref()
@@ -155,10 +163,13 @@ fn authentication_error(state: &AppState, headers: &HeaderMap) -> Option<Respons
             }
             (None, None) => unreachable!("authentication gate requires configured auth"),
         };
-        return Some(
-            ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
-                .into_response(),
-        );
+        let response = ShuntError::new(StatusCode::UNAUTHORIZED, "authentication_error", message)
+            .into_response();
+        return Some(if codex_shape {
+            into_openai_error_shape(response).await
+        } else {
+            response
+        });
     }
     if let Some(client) = static_client {
         tracing::info!(client = %client, "inbound client authenticated for GET /v1/models");
@@ -216,7 +227,7 @@ async fn anthropic_models(state: AppState, headers: HeaderMap) -> Response {
 pub async fn get(State(state): State<AppState>, headers: HeaderMap) -> Response {
     // Snapshot the live config so this response reflects the latest reload.
     let state = state.refreshed();
-    if let Some(response) = authentication_error(&state, &headers) {
+    if let Some(response) = authentication_error(&state, &headers, false).await {
         return response;
     }
     anthropic_models(state, headers).await
@@ -232,12 +243,10 @@ pub async fn get_negotiated(
     RawQuery(raw_query): RawQuery,
 ) -> Response {
     let state = state.refreshed();
-    if let Some(response) = authentication_error(&state, &headers) {
+    let is_codex = has_client_version_query(raw_query.as_deref());
+    if let Some(response) = authentication_error(&state, &headers, is_codex).await {
         return response;
     }
-    let is_codex = raw_query.as_deref().is_some_and(|query| {
-        url::form_urlencoded::parse(query.as_bytes()).any(|(key, _)| key == "client_version")
-    });
     if is_codex {
         return codex_models_response();
     }
@@ -248,10 +257,19 @@ pub async fn get_negotiated(
 /// the strict Codex schema and avoids inventing incomplete `ModelInfo` rows.
 pub async fn get_codex(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let state = state.refreshed();
-    if let Some(response) = authentication_error(&state, &headers) {
+    if let Some(response) = authentication_error(&state, &headers, true).await {
         return response;
     }
     codex_models_response()
+}
+
+/// Whether an URL-form query contains the Codex catalog negotiation key.
+/// Values are deliberately ignored: empty and duplicate fields still identify
+/// a Codex request, matching the CLI's presence-based negotiation contract.
+pub(crate) fn has_client_version_query(raw_query: Option<&str>) -> bool {
+    raw_query.is_some_and(|query| {
+        url::form_urlencoded::parse(query.as_bytes()).any(|(key, _)| key == "client_version")
+    })
 }
 
 fn codex_models_response() -> Response {
@@ -500,10 +518,7 @@ mod tests {
             }],
             ..crate::config::Config::default()
         };
-        config.server.codex_endpoint = Some(CodexEndpointConfig {
-            provider: "codex".to_string(),
-            collaboration: false,
-        });
+        config.server.codex_endpoint = Some(CodexEndpointConfig::default());
         config
     }
 
@@ -519,19 +534,31 @@ mod tests {
     #[tokio::test]
     async fn client_version_negotiates_codex_shape_before_header_hints() {
         let (router, _, _) = server::build_router(codex_enabled_config()).unwrap();
-        let response = router
-            .oneshot(
-                Request::get("/v1/models?client_version=0.152.0")
-                    .header("anthropic-version", "2023-06-01")
-                    .header("user-agent", "claude-code/2.1.0")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        for query in [
+            "client_version=0.152.0",
+            "client_version=",
+            "client_version&client_version=0.152.0",
+            "%63lient_version=0.152.0",
+        ] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::get(format!("/v1/models?{query}"))
+                        .header("anthropic-version", "2023-06-01")
+                        .header("user-agent", "claude-code/2.1.0")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response_json(response).await, json!({"models": []}));
+            assert_eq!(response.status(), StatusCode::OK, "query: {query}");
+            assert_eq!(
+                response_json(response).await,
+                json!({"models": []}),
+                "query: {query}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -633,6 +660,9 @@ mod tests {
 
         for path in [
             "/v1/models?client_version=0.152.0",
+            "/v1/models?client_version=",
+            "/v1/models?client_version=one&client_version=two",
+            "/v1/models?%63lient_version=0.152.0",
             "/models",
             "/backend-api/codex/models",
         ] {
@@ -647,8 +677,15 @@ mod tests {
                 "unauthorized path: {path}"
             );
             assert_eq!(
-                response_json(unauthorized).await["error"]["type"],
-                "authentication_error"
+                response_json(unauthorized).await,
+                json!({
+                    "error": {
+                        "message": "missing or invalid credential: this gateway requires a client token (via x-shunt-token, x-api-key, or Authorization: Bearer) for model discovery; ask the operator for one",
+                        "type": "authentication_error",
+                        "code": null
+                    }
+                }),
+                "unauthorized path: {path}"
             );
 
             let authorized = router
@@ -664,6 +701,26 @@ mod tests {
             assert_eq!(authorized.status(), StatusCode::OK, "path: {path}");
             assert_eq!(response_json(authorized).await, json!({"models": []}));
         }
+
+        let unauthorized = router
+            .oneshot(
+                Request::get("/v1/models?limit=1000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response_json(unauthorized).await,
+            json!({
+                "type": "error",
+                "error": {
+                    "type": "authentication_error",
+                    "message": "missing or invalid credential: this gateway requires a client token (via x-shunt-token, x-api-key, or Authorization: Bearer) for model discovery; ask the operator for one"
+                }
+            })
+        );
 
         std::env::remove_var(env);
     }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -138,7 +138,7 @@ fn authentication_error(state: &AppState, headers: &HeaderMap) -> Option<Respons
         && gateway_identity.is_none()
     {
         tracing::warn!(
-            "inbound auth failed for model discovery: missing or invalid client credential"
+            "inbound auth failed for GET /v1/models: missing or invalid client credential"
         );
         let message = match (&state.inbound_auth, &state.gateway_auth) {
             (Some(auth), Some(_)) => format!(
@@ -161,9 +161,9 @@ fn authentication_error(state: &AppState, headers: &HeaderMap) -> Option<Respons
         );
     }
     if let Some(client) = static_client {
-        tracing::info!(client = %client, "inbound client authenticated for model discovery");
+        tracing::info!(client = %client, "inbound client authenticated for GET /v1/models");
     } else if let Some(identity) = gateway_identity.as_ref() {
-        tracing::info!(client = %identity.email, "gateway user authenticated for model discovery");
+        tracing::info!(client = %identity.email, "gateway user authenticated for GET /v1/models");
     }
     None
 }
@@ -277,14 +277,6 @@ mod tests {
     };
 
     use super::get;
-
-    struct OwnedEnvGuard(String);
-
-    impl Drop for OwnedEnvGuard {
-        fn drop(&mut self) {
-            std::env::remove_var(&self.0);
-        }
-    }
 
     #[tokio::test]
     async fn returns_configured_models_with_optional_display_name() {
@@ -508,7 +500,10 @@ mod tests {
             }],
             ..crate::config::Config::default()
         };
-        config.server.codex_endpoint = Some(CodexEndpointConfig::default());
+        config.server.codex_endpoint = Some(CodexEndpointConfig {
+            provider: "codex".to_string(),
+            collaboration: false,
+        });
         config
     }
 
@@ -629,7 +624,6 @@ mod tests {
             CODEX_AUTH_COUNTER.fetch_add(1, Ordering::Relaxed)
         );
         std::env::set_var(&env, "tester:catalog-secret");
-        let _env_guard = OwnedEnvGuard(env.clone());
         let mut config = codex_enabled_config();
         config.server.auth = Some(InboundAuthConfig {
             header: "x-shunt-token".to_string(),
@@ -670,6 +664,8 @@ mod tests {
             assert_eq!(authorized.status(), StatusCode::OK, "path: {path}");
             assert_eq!(response_json(authorized).await, json!({"models": []}));
         }
+
+        std::env::remove_var(env);
     }
 
     const ADMIN_WRITE_KEY: &str = "admin-write-key-0123456789abcdef0";

--- a/src/http_tuning.rs
+++ b/src/http_tuning.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 
 use crate::{
-    concurrency::is_codex_path,
+    concurrency::is_codex_request,
     config::{AccessControlConfig, LimitsConfig},
     error::{into_openai_error_shape, ShuntError, UpstreamError},
     gateway::device::client_ip,
@@ -19,13 +19,19 @@ use crate::{
 pub(crate) struct HttpTuningLayer {
     access_control: AccessControlConfig,
     limits: LimitsConfig,
+    codex_endpoint_enabled: bool,
 }
 
 impl HttpTuningLayer {
-    pub(crate) fn new(access_control: AccessControlConfig, limits: LimitsConfig) -> Self {
+    pub(crate) fn new(
+        access_control: AccessControlConfig,
+        limits: LimitsConfig,
+        codex_endpoint_enabled: bool,
+    ) -> Self {
         Self {
             access_control,
             limits,
+            codex_endpoint_enabled,
         }
     }
 }
@@ -36,7 +42,7 @@ pub(crate) async fn enforce_http_tuning(
     next: Next,
 ) -> Response {
     let path = request.uri().path();
-    let codex_shape = is_codex_path(path);
+    let codex_shape = is_codex_request(request.uri(), tuning.codex_endpoint_enabled);
     let allow_exempt = matches!(path, "/" | "/health");
     if tuning.access_control.enabled() {
         let peer = request
@@ -183,13 +189,21 @@ mod tests {
     }
 
     fn app(access_control: AccessControlConfig, limits: LimitsConfig) -> Router {
+        app_with_codex(access_control, limits, false)
+    }
+
+    fn app_with_codex(
+        access_control: AccessControlConfig,
+        limits: LimitsConfig,
+        codex_endpoint_enabled: bool,
+    ) -> Router {
         Router::new()
             .route("/", get(|| async { StatusCode::NO_CONTENT }))
             .route("/health", get(|| async { StatusCode::NO_CONTENT }))
             .route("/v1/messages", post(|| async { StatusCode::NO_CONTENT }))
             .route("/v1/responses", post(|| async { StatusCode::NO_CONTENT }))
             .layer(middleware::from_fn_with_state(
-                HttpTuningLayer::new(access_control, limits),
+                HttpTuningLayer::new(access_control, limits, codex_endpoint_enabled),
                 enforce_http_tuning,
             ))
     }
@@ -315,6 +329,24 @@ mod tests {
         let codex = body(codex).await;
         assert!(codex.get("type").is_none());
         assert_eq!(codex["error"]["type"], "permission_error");
+    }
+
+    #[tokio::test]
+    async fn catalog_access_errors_use_openai_shape() {
+        let configured = access(&[], &["192.0.2.0/24"]);
+        for path in [
+            "/models",
+            "/backend-api/codex/models",
+            "/v1/models?client_version=0.152.0",
+        ] {
+            let response = app_with_codex(configured.clone(), LimitsConfig::default(), true)
+                .oneshot(request(path, Some("192.0.2.1".parse().unwrap())))
+                .await
+                .unwrap();
+            let body = body(response).await;
+            assert!(body.get("type").is_none(), "{path}: {body}");
+            assert_eq!(body["error"]["type"], "permission_error", "{path}: {body}");
+        }
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -160,6 +160,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState, AppState), C
     let http_tuning = HttpTuningLayer::new(
         config.server.access_control.clone(),
         config.server.limits.clone(),
+        config.server.codex_endpoint.is_some(),
     );
     let http_tuning_enabled = config.server.access_control.enabled()
         || config.server.limits.max_request_header_bytes.is_some()

--- a/src/server.rs
+++ b/src/server.rs
@@ -298,7 +298,7 @@ pub fn build_router(config: Config) -> Result<(Router, SharedState, AppState), C
     // zero value preserves the previous unlimited behavior without a layer.
     if max_concurrent_requests > 0 {
         router = router.layer(middleware::from_fn_with_state(
-            ConcurrencyLimit::new(max_concurrent_requests),
+            ConcurrencyLimit::new(max_concurrent_requests, codex_endpoint_enabled),
             limit_requests,
         ));
     }


### PR DESCRIPTION
## Summary

Stacked on #509 — please merge that first. Until then this PR also contains the F-01 catalog-schema commit.

When the inbound Codex catalog is enabled, saturation and auth failures on those paths now use the error envelope the client negotiated:

- OpenAI error shape for Codex catalog / inbound-codex paths
- existing Anthropic error shape for plain `GET /v1/models`

The concurrency limiter also tracks Codex-endpoint requests so a saturated gateway can tell those clients apart. This keeps Codex CLI from rendering a generic failure instead of the real reason.

Review the unique commit only:
- `3589886` `fix(discovery): resolve F-03 Codex catalog errors`

Unique diff is 3 files: `src/concurrency.rs`, `src/discovery.rs`, `src/server.rs`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --workspace`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Codex CLI model-catalog routes and fixes their failure shapes: when the inbound Codex endpoint is enabled, `GET /models` and `GET /backend-api/codex/models` return the valid empty catalog, and saturation, auth, and access-control errors on Codex paths now use the OpenAI envelope the CLI expects, while plain `/v1/models` keeps the Anthropic shape. The concurrency limiter and HTTP tuning layer classify Codex-endpoint requests so a saturated or blocked gateway responds correctly.

**Changes**
- Registers `GET /models` and `GET /backend-api/codex/models`, returning the valid empty fallback `{"models":[]}` only when the inbound Codex endpoint is enabled.
- On shared `/v1/models`, a `client_version` query (empty or duplicate values included) selects the Codex shape; without it the Anthropic discovery response is unchanged.
- All catalog variants go through the existing model-discovery auth gate.

<sup>Written for commit 1c13f6f6fc45598c4e5e3c9f366668676587bbbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

