### PR TITLE
feat(server): bound graceful shutdown drain with configurable timeout

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -40,8 +40,8 @@ brew services start shunt
 
 ログは `$(brew --prefix)/var/log/shunt.log` に出力されます。`brew services stop` は `SIGTERM` を送信し、
 shunt は処理中のリクエストを完了させてから終了します — 待機するのは最大で `[server] shutdown_timeout_seconds`
-(既定は 30 秒)であり、その時点で残っている処理はキャンセルされるため、静かな SSE ストリームがプロセスを
-無期限に保持することはできません。Unix では、シャットダウンの開始時に Antigravity のエージェントターンが
+(既定は 30 秒。この値の変更には再起動が必要)であり、それを過ぎると待機をやめて終了するため、静かな SSE
+ストリームがプロセスを無期限に保持することはできません。Unix では、シャットダウンの開始時に Antigravity のエージェントターンが
 終了させられるため、その分離されたプロセスグループがドレインを引き延ばすことはできません。
 その後に設定ファイルを編集しても再起動は不要です —
 自動的に[ホットリロード](docs/config-reload.md)されます。詳細: [サービスとして実行](docs/running.md#run-as-a-background-service-homebrew)。

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,8 +39,10 @@ brew services start shunt
 ```
 
 ログは `$(brew --prefix)/var/log/shunt.log` に出力されます。`brew services stop` は `SIGTERM` を送信し、
-shunt は処理中のリクエストを完了させてから終了します。Unix では、シャットダウンの開始時に Antigravity の
-エージェントターンが終了させられるため、その分離されたプロセスグループがドレインを引き延ばすことはできません。
+shunt は処理中のリクエストを完了させてから終了します — 待機するのは最大で `[server] shutdown_timeout_seconds`
+(既定は 30 秒)であり、その時点で残っている処理はキャンセルされるため、静かな SSE ストリームがプロセスを
+無期限に保持することはできません。Unix では、シャットダウンの開始時に Antigravity のエージェントターンが
+終了させられるため、その分離されたプロセスグループがドレインを引き延ばすことはできません。
 その後に設定ファイルを編集しても再起動は不要です —
 自動的に[ホットリロード](docs/config-reload.md)されます。詳細: [サービスとして実行](docs/running.md#run-as-a-background-service-homebrew)。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,8 +39,10 @@ brew services start shunt
 ```
 
 로그는 `$(brew --prefix)/var/log/shunt.log`에 남습니다. `brew services stop`은 `SIGTERM`을 보내고
-shunt는 처리 중인 요청을 모두 마친 뒤 종료합니다. Unix에서는 종료가 시작될 때 Antigravity 에이전트 턴이
-함께 종료되므로, 격리된 프로세스 그룹이 드레인을 붙잡아 둘 수 없습니다. 이후 설정 파일을 수정해도
+shunt는 처리 중인 요청을 마친 뒤 종료합니다 — 최대 `[server] shutdown_timeout_seconds`(기본 30초)까지
+기다리며, 그 시점에도 남아 있는 작업은 취소되므로 조용한 SSE 스트림이 프로세스를 무한정 붙잡을 수 없습니다.
+Unix에서는 종료가 시작될 때 Antigravity 에이전트 턴이 함께 종료되므로, 격리된 프로세스 그룹이 드레인을
+붙잡아 둘 수 없습니다. 이후 설정 파일을 수정해도
 재시작이 필요 없습니다 — 자동으로 [핫 리로드](docs/config-reload.md)됩니다. 자세한 내용은
 [서비스로 실행하기](docs/running.md#run-as-a-background-service-homebrew)를 참고하세요.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,8 +39,9 @@ brew services start shunt
 ```
 
 로그는 `$(brew --prefix)/var/log/shunt.log`에 남습니다. `brew services stop`은 `SIGTERM`을 보내고
-shunt는 처리 중인 요청을 마친 뒤 종료합니다 — 최대 `[server] shutdown_timeout_seconds`(기본 30초)까지
-기다리며, 그 시점에도 남아 있는 작업은 취소되므로 조용한 SSE 스트림이 프로세스를 무한정 붙잡을 수 없습니다.
+shunt는 처리 중인 요청을 마친 뒤 종료합니다 — 최대 `[server] shutdown_timeout_seconds`(기본 30초, 이 값
+변경은 재시작 필요)까지 기다리고, 그 시점이 지나면 더 기다리지 않고 종료하므로 조용한 SSE 스트림이 프로세스를
+무한정 붙잡을 수 없습니다.
 Unix에서는 종료가 시작될 때 Antigravity 에이전트 턴이 함께 종료되므로, 격리된 프로세스 그룹이 드레인을
 붙잡아 둘 수 없습니다. 이후 설정 파일을 수정해도
 재시작이 필요 없습니다 — 자동으로 [핫 리로드](docs/config-reload.md)됩니다. 자세한 내용은

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ brew services start shunt
 
 Logs go to `$(brew --prefix)/var/log/shunt.log`. `brew services stop` sends `SIGTERM`, and shunt
 drains in-flight requests before exiting — for up to `[server] shutdown_timeout_seconds`
-(default 30), after which whatever is still running is cancelled so a quiet SSE stream cannot hold
-the process open forever. On Unix, Antigravity agent turns are terminated when shutdown starts so
+(default 30; changing this one does need a restart), after which shunt stops waiting and exits, so
+a quiet SSE stream cannot hold the process open forever. On Unix, Antigravity agent turns are terminated when shutdown starts so
 their isolated process groups cannot hold the drain open. Editing the config file
 afterwards doesn't need a restart — it [hot-reloads](docs/config-reload.md) automatically. Details:
 [Running as a service](docs/running.md#run-as-a-background-service-homebrew).

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ brew services start shunt
 ```
 
 Logs go to `$(brew --prefix)/var/log/shunt.log`. `brew services stop` sends `SIGTERM`, and shunt
-drains in-flight requests before exiting; on Unix, Antigravity agent turns are terminated when
-shutdown starts so their isolated process groups cannot hold the drain open. Editing the config file
+drains in-flight requests before exiting — for up to `[server] shutdown_timeout_seconds`
+(default 30), after which whatever is still running is cancelled so a quiet SSE stream cannot hold
+the process open forever. On Unix, Antigravity agent turns are terminated when shutdown starts so
+their isolated process groups cannot hold the drain open. Editing the config file
 afterwards doesn't need a restart — it [hot-reloads](docs/config-reload.md) automatically. Details:
 [Running as a service](docs/running.md#run-as-a-background-service-homebrew).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,8 +39,9 @@ brew services start shunt
 ```
 
 日志会写入 `$(brew --prefix)/var/log/shunt.log`。`brew services stop` 会发送 `SIGTERM`,
-shunt 会先处理完正在进行的请求再退出;在 Unix 上,关机开始时 Antigravity 的 agent 轮次会被终止,
-因此它们各自独立的进程组无法拖住这次排空。之后修改配置文件不需要重启 ——
+shunt 会先处理完正在进行的请求再退出 —— 最多等待 `[server] shutdown_timeout_seconds`(默认 30 秒),
+到期后仍未完成的工作会被取消,因此安静的 SSE 流无法无限期地拖住进程。在 Unix 上,关机开始时 Antigravity
+的 agent 轮次会被终止,因此它们各自独立的进程组无法拖住这次排空。之后修改配置文件不需要重启 ——
 会自动[热重载](docs/config-reload.md)。详见 [作为服务运行](docs/running.md#run-as-a-background-service-homebrew)。
 
 ## 快速开始

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,8 +39,8 @@ brew services start shunt
 ```
 
 日志会写入 `$(brew --prefix)/var/log/shunt.log`。`brew services stop` 会发送 `SIGTERM`,
-shunt 会先处理完正在进行的请求再退出 —— 最多等待 `[server] shutdown_timeout_seconds`(默认 30 秒),
-到期后仍未完成的工作会被取消,因此安静的 SSE 流无法无限期地拖住进程。在 Unix 上,关机开始时 Antigravity
+shunt 会先处理完正在进行的请求再退出 —— 最多等待 `[server] shutdown_timeout_seconds`(默认 30 秒;
+修改该值需要重启),超时后不再等待并退出,因此安静的 SSE 流无法无限期地拖住进程。在 Unix 上,关机开始时 Antigravity
 的 agent 轮次会被终止,因此它们各自独立的进程组无法拖住这次排空。之后修改配置文件不需要重启 ——
 会自动[热重载](docs/config-reload.md)。详见 [作为服务运行](docs/running.md#run-as-a-background-service-homebrew)。
 

--- a/docs/bounded-shutdown.md
+++ b/docs/bounded-shutdown.md
@@ -1,0 +1,30 @@
+# Bounded shutdown
+
+Shunt treats shutdown as a process-lifecycle boundary. The first `SIGTERM` or
+`SIGINT` permanently stops Axum listener admission and begins graceful drain for
+active HTTP responses, SSE streams, and inbound WebSocket sessions. The drain
+deadline is `[server] shutdown_timeout_seconds`, which defaults to 30 seconds
+and must be between 1 and 3600 inclusive.
+
+The timeout starts when the first signal is observed—not when the process
+starts. It is one absolute budget shared by every connection; individual
+streams do not receive fresh extensions. Requests that finish within the budget
+complete normally, including response-body cleanup and admission-lease release.
+
+If work remains at the deadline, Shunt drops the owned Axum server future and
+returns from `run`. The Tokio runtime then cancels remaining connection,
+WebSocket, and process-lifetime background tasks; Rust RAII guards release
+account-admission slots, response bodies, and subprocess handles. This is a
+normal return rather than `process::exit`, so telemetry exporters receive their
+usual drop/flush opportunity. Periodic pool-state persistence remains
+best-effort; this lifecycle does not promise a new final state transaction.
+
+On Unix, isolated Antigravity process groups are terminated as soon as the first
+signal arrives, because they do not inherit gateway signals and must not pin the
+drain. A second `SIGTERM` or `SIGINT` remains the explicit emergency escape
+hatch: it exits immediately with status 143 or 130 respectively, terminates the
+process groups again, and skips normal telemetry flushing.
+
+`shutdown_timeout_seconds` is captured at boot. A hot reload accepts a changed
+value into the configuration snapshot but logs that a restart is required for
+the new deadline to take effect.

--- a/docs/bounded-shutdown.md
+++ b/docs/bounded-shutdown.md
@@ -40,10 +40,19 @@ an uninterruptible process would matter.
 
 The two budgets cover different work classes and are deliberately not the same
 number. A configured `shutdown_timeout_seconds = 30` means "up to 30 seconds of
-draining, then up to 5 seconds for blocking work" — a worst case of 35 seconds,
-not a silent 60. The blocking grace is fixed rather than configurable because
-this crate's blocking tasks are short, bounded CPU jobs (compression in
-`offload`, token counting in `proxy::failover`), not open-ended waits.
+draining, then up to 5 seconds for blocking work" — 35 seconds, not a silent 60.
+That figure bounds the drain plus Tokio teardown, not process exit: the Sentry
+and telemetry guards are dropped after `run` returns and flush on their own
+exporter timeouts, so termination can take slightly longer.
+
+The blocking grace is fixed rather than configurable because nothing should need
+to raise it. Some `spawn_blocking` work here is short bounded CPU (compression
+in `offload`, token counting in `proxy::failover`), but not all of it — credential
+and state files, advisory file locks (`auth::shared::file_lock`), and admin
+operations are also blocking, and those *can* stall on a slow or hung
+filesystem. Such work is not waited out: it is abandoned when the grace expires
+and its thread is leaked, which is the point. A configurable grace would only
+let an operator extend a window in which the process cannot be interrupted.
 
 On Unix, isolated Antigravity process groups are terminated as soon as the first
 signal arrives, because they do not inherit gateway signals and must not pin the

--- a/docs/bounded-shutdown.md
+++ b/docs/bounded-shutdown.md
@@ -28,6 +28,16 @@ begins. So teardown is bounded explicitly: already-started blocking work gets a
 fixed five-second grace (`BLOCKING_SHUTDOWN_GRACE` in `src/main.rs`), after
 which its threads are leaked and the process exits regardless.
 
+The second-signal escape hatch does not cover that final grace. Its watcher is
+itself a Tokio task, so it is gone once teardown starts, and Tokio leaves its
+signal handler installed after the listener drops — a signal arriving in that
+window is captured and discarded rather than falling through to the default
+disposition. This is deliberate rather than overlooked: the hatch exists to
+escape an *unbounded* wait, and a wait that is already bounded at five seconds
+is served by the bound itself. It is also why the grace is a small constant
+instead of a configurable value that an operator could raise to a length where
+an uninterruptible process would matter.
+
 The two budgets cover different work classes and are deliberately not the same
 number. A configured `shutdown_timeout_seconds = 30` means "up to 30 seconds of
 draining, then up to 5 seconds for blocking work" — a worst case of 35 seconds,

--- a/docs/bounded-shutdown.md
+++ b/docs/bounded-shutdown.md
@@ -19,6 +19,22 @@ normal return rather than `process::exit`, so telemetry exporters receive their
 usual drop/flush opportunity. Periodic pool-state persistence remains
 best-effort; this lifecycle does not promise a new final state transaction.
 
+Cancellation reaches async tasks only. Work already running on a blocking thread
+(`tokio::task::spawn_blocking`) cannot be aborted — see `offload::spawn_bounded` —
+and simply *dropping* the runtime would wait for it with no deadline at all,
+which would put the process back past `shutdown_timeout_seconds` and past the
+second-signal escape hatch, whose watcher is itself cancelled once teardown
+begins. So teardown is bounded explicitly: already-started blocking work gets a
+fixed five-second grace (`BLOCKING_SHUTDOWN_GRACE` in `src/main.rs`), after
+which its threads are leaked and the process exits regardless.
+
+The two budgets cover different work classes and are deliberately not the same
+number. A configured `shutdown_timeout_seconds = 30` means "up to 30 seconds of
+draining, then up to 5 seconds for blocking work" — a worst case of 35 seconds,
+not a silent 60. The blocking grace is fixed rather than configurable because
+this crate's blocking tasks are short, bounded CPU jobs (compression in
+`offload`, token counting in `proxy::failover`), not open-ended waits.
+
 On Unix, isolated Antigravity process groups are terminated as soon as the first
 signal arrives, because they do not inherit gateway signals and must not pin the
 drain. A second `SIGTERM` or `SIGINT` remains the explicit emergency escape

--- a/docs/config-reload.md
+++ b/docs/config-reload.md
@@ -51,6 +51,8 @@ shunt logs a `warn!` so the change is not mistaken for live:
 - **`server.bind`** — the listener is already bound at the old address.
 - **`server.max_concurrent_requests`** — the shared concurrency semaphore and
   router layer are created once at startup.
+- **`server.shutdown_timeout_seconds`** — the process shutdown coordinator
+  captures its deadline once at startup.
 - **`[sentry]`** — the Sentry client is initialized once before the runtime
   starts and cannot be hot-swapped.
 - **`[otel]`** — the OpenTelemetry exporters are likewise initialized once at

--- a/docs/running.md
+++ b/docs/running.md
@@ -76,6 +76,7 @@ cp shunt.yaml.example shunt.yaml  # YAML
 bind = "127.0.0.1:3001"        # address shunt listens on
 default_provider = "anthropic" # provider for any model with no route (pass-through)
 max_concurrent_requests = 1024  # shed excess in-flight requests with 503; 0 disables
+shutdown_timeout_seconds = 30   # drain deadline after first SIGTERM/SIGINT; 1..=3600
 
 # Each provider is a [providers.<name>] table (see §3.2 for every key).
 [providers.anthropic]
@@ -376,15 +377,18 @@ Installed via Homebrew, shunt can run under `brew services` instead of a foregro
 ```bash
 brew services start shunt    # launches `shunt run` in the background
 brew services restart shunt  # e.g. after a binary upgrade
-brew services stop shunt     # sends SIGTERM; shunt drains in-flight requests, then exits
+brew services stop shunt     # sends SIGTERM; shunt drains to its deadline, then exits
 brew services info shunt
 ```
 
-`SIGTERM` and ctrl-c both start the same drain. On Unix, Antigravity `agy` runs are the exception:
-shunt terminates their isolated process groups as soon as shutdown starts, because gateway signals do
-not reach those groups and an unattended agent must not hold the drain open. Other in-flight requests
-continue draining with no deadline — an open SSE stream keeps the process alive for as long as its
-client keeps reading. Send a **second** signal (another ctrl-c, or `kill` again) to skip the drain and
+`SIGTERM` and ctrl-c both stop new admission and start the same bounded drain. Active HTTP responses,
+SSE streams, and upgraded WebSocket sessions may finish within `[server] shutdown_timeout_seconds`
+(default `30`, valid `1..=3600`). One absolute deadline starts at the first signal and covers every
+connection; when it expires, shunt cancels the remaining server work and returns normally so Rust
+drop cleanup and telemetry flushing still run. See [Bounded shutdown](bounded-shutdown.md).
+On Unix, Antigravity `agy` runs are the exception: shunt terminates their isolated process groups as soon
+as shutdown starts, because gateway signals do not reach those groups and an unattended agent must not hold
+the drain open. Send a **second** signal (another ctrl-c, or `kill` again) to skip the drain and
 exit immediately with the conventional 128+signal exit status: 143 for a second `SIGTERM`, 130 for
 a second ctrl-c/`SIGINT`. The immediate-exit path also terminates any Antigravity groups before the
 process exits.

--- a/shunt.toml.example
+++ b/shunt.toml.example
@@ -8,6 +8,8 @@
 [server]
 bind = "127.0.0.1:3001"        # address shunt listens on (ANTHROPIC_BASE_URL points here)
 default_provider = "anthropic" # provider for any model with no route -> pass-through to Anthropic
+# shutdown_timeout_seconds = 30 # (default) first SIGTERM/SIGINT drains HTTP/SSE/WS
+                                # to this deadline; valid range 1..=3600; restart-only
 # max_concurrent_requests = 1024 # (default) inbound requests held through response-body
                                  # completion; excess is shed with 503; 0 disables
 # sse_keepalive_seconds = 30   # (default) inject an SSE `ping` after this much upstream

--- a/shunt.yaml.example
+++ b/shunt.yaml.example
@@ -8,6 +8,7 @@
 server:
   bind: "127.0.0.1:3001"
   default_provider: anthropic
+  # shutdown_timeout_seconds: 30 # valid range 1..=3600; restart-only
   # max_concurrent_requests: 1024 # 0 disables
 
 providers:

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -26,7 +26,9 @@ brew services start shunt
 ```
 
 Logs go to `$(brew --prefix)/var/log/shunt.log`. `brew services stop` sends `SIGTERM`, and shunt
-drains in-flight requests before exiting. On Unix, Antigravity agent turns are terminated when
+drains in-flight requests before exiting — for up to `[server] shutdown_timeout_seconds`
+(default 30; changing this one does need a restart), after which shunt stops waiting and exits. On
+Unix, Antigravity agent turns are terminated when
 shutdown starts so their isolated process groups cannot hold the drain open. Config changes don't need
 a restart — shunt [hot-reloads](https://github.com/pleaseai/shunt/blob/main/docs/config-reload.md)
 the file automatically. See [Running as a

--- a/site/src/content/docs/ja/getting-started/installation.mdx
+++ b/site/src/content/docs/ja/getting-started/installation.mdx
@@ -26,7 +26,9 @@ brew services start shunt
 ```
 
 ログは `$(brew --prefix)/var/log/shunt.log` に出力されます。`brew services stop` は `SIGTERM`
-を送信し、shunt は実行中のリクエストを完了させてから終了します。設定ファイルを変更しても再起動は不要です
+を送信し、shunt は実行中のリクエストを完了させてから終了します — 待機するのは最大で
+`[server] shutdown_timeout_seconds`(既定は 30 秒。この値の変更には再起動が必要)であり、それを過ぎると
+待機をやめて終了します。設定ファイルを変更しても再起動は不要です
 — shunt が自動的に[ホットリロード](https://github.com/pleaseai/shunt/blob/main/docs/config-reload.md)します。
 詳細（設定探索パスなど）は [Running as a
 service](https://github.com/pleaseai/shunt/blob/main/docs/running.md#run-as-a-background-service-homebrew)

--- a/site/src/content/docs/ja/reference/configuration.md
+++ b/site/src/content/docs/ja/reference/configuration.md
@@ -19,6 +19,7 @@ description: すべての shunt.toml キー — server、providers、routes、mo
 | :-- | :-- | :-- |
 | `bind` | `127.0.0.1:3001` | shunt がリッスンするアドレス |
 | `default_provider` | `anthropic` | マッチするルートがないモデルのプロバイダー |
+| `shutdown_timeout_seconds` | `30` | 最初の SIGTERM/SIGINT 後、実行中の HTTP/SSE/WebSocket をドレインしてから残りをキャンセルするまでの秒数。`1`–`3600` が必須で、変更後は再起動が必要です |
 | `max_concurrent_requests` | `1024` | レスポンスボディの完了まで実行中として数えるインバウンドリクエストの最大数。超過したリクエストはキューに入れず、即座に `503` と `Retry-After: 1` で拒否します。`0` で制限を無効化でき、`/` と `/health` は対象外です。このキーを変更した後は再起動が必要です |
 | `sse_keepalive_seconds` | `30` | SSE `ping` が注入されるまでのアイドル秒数。`0` で無効化（[詳細](/ja/guides/shared-gateway/#sse-キープアライブ-ping)） |
 

--- a/site/src/content/docs/ko/getting-started/installation.mdx
+++ b/site/src/content/docs/ko/getting-started/installation.mdx
@@ -26,7 +26,8 @@ brew services start shunt
 ```
 
 로그는 `$(brew --prefix)/var/log/shunt.log`에 출력됩니다. `brew services stop`은 `SIGTERM`을 보내고
-shunt는 처리 중인 요청을 모두 마친 뒤 종료합니다. 설정을 변경해도 재시작이 필요 없습니다 — shunt가
+shunt는 처리 중인 요청을 마친 뒤 종료합니다 — 최대 `[server] shutdown_timeout_seconds`(기본 30초, 이 값
+변경은 재시작 필요)까지 기다리고, 그 시점이 지나면 더 기다리지 않고 종료합니다. 설정을 변경해도 재시작이 필요 없습니다 — shunt가
 자동으로 [핫 리로드](https://github.com/pleaseai/shunt/blob/main/docs/config-reload.md)합니다. 설정
 탐색 경로 등 자세한 내용은 [Running as a
 service](https://github.com/pleaseai/shunt/blob/main/docs/running.md#run-as-a-background-service-homebrew)를

--- a/site/src/content/docs/ko/reference/configuration.md
+++ b/site/src/content/docs/ko/reference/configuration.md
@@ -19,6 +19,7 @@ description: 모든 shunt.toml 키 — server, providers, routes, models.
 | :-- | :-- | :-- |
 | `bind` | `127.0.0.1:3001` | shunt가 리슨하는 주소 |
 | `default_provider` | `anthropic` | 일치하는 라우트가 없는 모든 모델의 프로바이더 |
+| `shutdown_timeout_seconds` | `30` | 첫 SIGTERM/SIGINT 뒤 진행 중인 HTTP/SSE/WebSocket 작업을 드레인한 후 나머지를 취소하기까지의 초. `1`–`3600`이어야 하며 변경 후 재시작 필요 |
 | `max_concurrent_requests` | `1024` | 응답 본문이 끝날 때까지 진행 중으로 계산하는 인바운드 요청의 최대 수. 초과 요청은 대기열에 넣지 않고 즉시 `503`과 `Retry-After: 1`로 거부합니다. `0`은 제한을 비활성화하며 `/`와 `/health`는 제한에서 제외됩니다. 이 키를 변경한 뒤에는 재시작해야 합니다 |
 | `sse_keepalive_seconds` | `30` | SSE `ping`이 주입되기 전의 유휴 초; `0`은 비활성화([상세](/ko/guides/shared-gateway/#sse-keepalive-ping)) |
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -26,6 +26,7 @@ The existing `tokens_env`, `jwt_secret_env`, `client_secret_env`, `api_key_env`,
 | :-- | :-- | :-- |
 | `bind` | `127.0.0.1:3001` | Address shunt listens on |
 | `default_provider` | `anthropic` | Provider for any model with no matching route |
+| `shutdown_timeout_seconds` | `30` | Seconds after the first SIGTERM/SIGINT for active HTTP/SSE/WebSocket work to drain before the remainder is cancelled. Must be `1`–`3600`; changing it requires a restart |
 | `max_concurrent_requests` | `1024` | Maximum inbound requests in flight through response-body completion. Excess requests are shed immediately with `503` and `Retry-After: 1`; `0` disables the limit. `/` and `/health` are exempt. A restart is required after changing this key |
 | `sse_keepalive_seconds` | `30` | Idle seconds before an SSE `ping` is injected; `0` disables ([details](/guides/shared-gateway/#sse-keepalive-pings)) |
 

--- a/site/src/content/docs/zh-cn/getting-started/installation.mdx
+++ b/site/src/content/docs/zh-cn/getting-started/installation.mdx
@@ -26,7 +26,8 @@ brew services start shunt
 ```
 
 日志会写入 `$(brew --prefix)/var/log/shunt.log`。`brew services stop` 会发送 `SIGTERM`,
-shunt 会先耗尽正在处理的请求再退出。修改配置文件后不需要重启 —— shunt 会自动
+shunt 会先耗尽正在处理的请求再退出 —— 最多等待 `[server] shutdown_timeout_seconds`(默认 30 秒;
+修改该值需要重启),超时后不再等待并退出。修改配置文件后不需要重启 —— shunt 会自动
 [热重载](https://github.com/pleaseai/shunt/blob/main/docs/config-reload.md)该文件。
 更多细节(如配置查找路径)参见 [Running as a
 service](https://github.com/pleaseai/shunt/blob/main/docs/running.md#run-as-a-background-service-homebrew)。

--- a/site/src/content/docs/zh-cn/reference/configuration.md
+++ b/site/src/content/docs/zh-cn/reference/configuration.md
@@ -19,6 +19,7 @@ description: 每一个 shunt.toml 键 —— server、providers、routes、model
 | :-- | :-- | :-- |
 | `bind` | `127.0.0.1:3001` | shunt 监听的地址 |
 | `default_provider` | `anthropic` | 面向任何无匹配路由的模型的提供方 |
+| `shutdown_timeout_seconds` | `30` | 第一次 SIGTERM/SIGINT 后，活动 HTTP/SSE/WebSocket 工作排空并取消其余工作的秒数。必须为 `1`–`3600`；更改后需要重启 |
 | `max_concurrent_requests` | `1024` | 入站并发请求上限，请求会一直计数到响应正文结束。超出上限的请求不会排队，而是立即以 `503` 和 `Retry-After: 1` 拒绝。`0` 表示禁用限制，`/` 和 `/health` 不受限制。更改此键后需要重启 |
 | `sse_keepalive_seconds` | `30` | 注入 SSE `ping` 前的闲置秒数;`0` 禁用([详情](/zh-cn/guides/shared-gateway/#sse-keepalive-ping)) |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,11 @@ pub struct ServerConfig {
     /// `0` disables injection (M5).
     #[serde(default = "default_sse_keepalive_seconds")]
     pub sse_keepalive_seconds: u64,
+    /// Seconds to wait for in-flight requests and connections to drain after
+    /// the first shutdown signal before forcing termination. `0` and values
+    /// above 3600 are rejected by validation.
+    #[serde(default = "default_shutdown_timeout_seconds")]
+    pub shutdown_timeout_seconds: u64,
     /// Maximum inbound client requests in flight at once on the limited routes
     /// (`/` and `/health` are merged outside the gate and always answer). `0`
     /// disables the limit. Over-limit requests are shed with 503 rather than
@@ -178,6 +183,12 @@ fn default_sse_keepalive_seconds() -> u64 {
 fn default_max_concurrent_requests() -> usize {
     1024
 }
+
+fn default_shutdown_timeout_seconds() -> u64 {
+    30
+}
+
+pub(crate) const MAX_SHUTDOWN_TIMEOUT_SECONDS: u64 = 3600;
 
 /// Upper bound accepted for `[server] max_concurrent_requests`, mirroring
 /// `tokio::sync::Semaphore::MAX_PERMITS` (`usize::MAX >> 3`). Tokio's
@@ -2390,6 +2401,8 @@ pub enum ConfigError {
         max_concurrent_requests: usize,
         limit: usize,
     },
+    #[error("server.shutdown_timeout_seconds must be between 1 and {limit}, got {seconds}")]
+    InvalidShutdownTimeout { seconds: u64, limit: u64 },
     #[error("server.access_control.{field}[{index}] is not a valid CIDR `{value}`: {message}")]
     InvalidAccessControlCidr {
         field: &'static str,
@@ -2650,6 +2663,7 @@ impl Default for Config {
                 status: None,
                 sse_keepalive_seconds: default_sse_keepalive_seconds(),
                 max_concurrent_requests: default_max_concurrent_requests(),
+                shutdown_timeout_seconds: default_shutdown_timeout_seconds(),
                 access_control: AccessControlConfig::default(),
                 limits: LimitsConfig::default(),
                 timeouts: TimeoutsConfig::default(),
@@ -3214,6 +3228,12 @@ impl Config {
             return Err(ConfigError::InvalidMaxConcurrentRequests {
                 max_concurrent_requests: self.server.max_concurrent_requests,
                 limit: MAX_CONCURRENT_REQUESTS_LIMIT,
+            });
+        }
+        if !(1..=MAX_SHUTDOWN_TIMEOUT_SECONDS).contains(&self.server.shutdown_timeout_seconds) {
+            return Err(ConfigError::InvalidShutdownTimeout {
+                seconds: self.server.shutdown_timeout_seconds,
+                limit: MAX_SHUTDOWN_TIMEOUT_SECONDS,
             });
         }
         self.server.access_control.validate()?;
@@ -4174,7 +4194,7 @@ mod tests {
         GatewayTelemetryConfig, GatewayTelemetryDestination, InboundAuthConfig, ModelConfig,
         OauthUsageConfig, OidcProviderConfig, PoolConfig, ProviderConfig, ProviderKind,
         ResponsesFlavor, RetryConfig, Secret, SpendConfig, StatusConfig, StatusSource,
-        UsageEndpointConfig, CONFIG_ENV_LOCK,
+        UsageEndpointConfig, CONFIG_ENV_LOCK, MAX_SHUTDOWN_TIMEOUT_SECONDS,
     };
 
     fn model_config(id: &str, upstream_model: Option<BTreeMap<String, String>>) -> ModelConfig {
@@ -4376,6 +4396,34 @@ mod tests {
             .validate()
             .expect("the boundary value itself is valid");
         let _ = tokio::sync::Semaphore::new(MAX_CONCURRENT_REQUESTS_LIMIT);
+    }
+
+    #[test]
+    fn shutdown_timeout_is_finite_by_default_and_validated() {
+        assert_eq!(Config::default().server.shutdown_timeout_seconds, 30);
+
+        for seconds in [0, MAX_SHUTDOWN_TIMEOUT_SECONDS + 1] {
+            let mut config = Config::default();
+            config.server.shutdown_timeout_seconds = seconds;
+            assert!(
+                matches!(
+                    config.validate(),
+                    Err(ConfigError::InvalidShutdownTimeout {
+                        seconds: rejected,
+                        limit: MAX_SHUTDOWN_TIMEOUT_SECONDS,
+                    }) if rejected == seconds
+                ),
+                "shutdown timeout {seconds} must fail closed"
+            );
+        }
+
+        for seconds in [1, MAX_SHUTDOWN_TIMEOUT_SECONDS] {
+            let mut config = Config::default();
+            config.server.shutdown_timeout_seconds = seconds;
+            config
+                .validate()
+                .unwrap_or_else(|error| panic!("boundary {seconds} rejected: {error}"));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,6 +510,46 @@ fn prompt_claude_mode() -> anyhow::Result<LoginMode> {
     }
 }
 
+/// How long runtime teardown waits for `spawn_blocking` work that has already
+/// started, after `[server] shutdown_timeout_seconds` has bounded the async
+/// drain. Deliberately a small fixed grace rather than a second full copy of
+/// the configured deadline: the two budgets cover different work classes, and
+/// this crate's blocking tasks are short, bounded CPU jobs (compression in
+/// `offload`, token counting in `proxy::failover`), not open-ended waits. A
+/// configured 30s therefore means "up to 30s of draining, then up to 5s for
+/// blocking work" — not a silent 60s.
+const BLOCKING_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Drives `future` to completion on `runtime`, then bounds runtime teardown
+/// instead of letting the runtime drop.
+///
+/// `serve`'s own deadline bounds the *async* drain, but cancellation never
+/// reaches a `spawn_blocking` task that has already started — `offload::
+/// spawn_bounded` says so outright ("A blocking task cannot be aborted") — and
+/// simply dropping a runtime *waits* on those threads with no deadline at all.
+/// A stalled compression or token-count job could therefore hold the process
+/// past `[server] shutdown_timeout_seconds`, and past the second-signal escape
+/// hatch as well, since that watcher is itself cancelled once teardown begins:
+/// the operator would be left with nothing but `SIGKILL`. `shutdown_timeout`
+/// waits at most `grace` for that work, then leaks the threads so the process
+/// exits regardless.
+///
+/// Split out of [`run`] so this is reachable from a test: the bound is one call
+/// that is easy to delete by accident, and its absence is invisible until a
+/// blocking task hangs in production.
+fn block_on_bounded<F>(
+    runtime: tokio::runtime::Runtime,
+    future: F,
+    grace: std::time::Duration,
+) -> F::Output
+where
+    F: std::future::Future,
+{
+    let output = runtime.block_on(future);
+    runtime.shutdown_timeout(grace);
+    output
+}
+
 /// The runtime is built by hand (not `#[tokio::main]`) so `run` can initialize
 /// Sentry before any runtime thread exists, per sentry-rust guidance.
 fn runtime() -> anyhow::Result<tokio::runtime::Runtime> {
@@ -585,7 +625,9 @@ fn run(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     // Both guards must outlive the runtime so buffered events flush on shutdown.
     let _sentry = init_sentry(config.sentry.as_ref());
     let _telemetry = init_telemetry(config.otel.as_ref());
-    let result = runtime().and_then(|runtime| runtime.block_on(serve(config, path)));
+    let result = runtime().and_then(|runtime| {
+        block_on_bounded(runtime, serve(config, path), BLOCKING_SHUTDOWN_GRACE)
+    });
     if let Err(error) = &result {
         sentry::integrations::anyhow::capture_anyhow(error);
     }
@@ -1605,6 +1647,46 @@ mod tests {
             .expect("serve returns before the test deadline")
             .expect("serve task join")
             .expect("graceful shutdown returns Ok once drained");
+    }
+
+    /// The drain deadline only bounds async work: cancellation never reaches a
+    /// `spawn_blocking` task that has already started, and dropping the runtime
+    /// would wait on it forever. Uses a short grace of its own rather than
+    /// `BLOCKING_SHUTDOWN_GRACE` so proving this costs the suite ~200ms, not 5s.
+    ///
+    /// Deleting the `shutdown_timeout` call in `block_on_bounded` turns this
+    /// red: teardown would then block for the blocking task's full 10 seconds.
+    #[test]
+    fn block_on_bounded_does_not_wait_out_started_blocking_work() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let grace = Duration::from_millis(200);
+        let runtime = runtime().expect("runtime builds");
+        let (started_tx, started_rx) = mpsc::channel();
+
+        let began = Instant::now();
+        block_on_bounded(
+            runtime,
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    // Signal from *inside* the blocking thread so teardown is
+                    // provably racing work that already holds a pool thread,
+                    // not one still queued (which drops without waiting).
+                    started_tx.send(()).expect("receiver is alive");
+                    std::thread::sleep(Duration::from_secs(10));
+                });
+                started_rx.recv().expect("blocking task starts");
+            },
+            grace,
+        );
+        let elapsed = began.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "teardown must abandon started blocking work after the grace, \
+             but it took {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -647,6 +647,7 @@ async fn serve(config: Config, path: Option<PathBuf>) -> anyhow::Result<()> {
     if routes_to_antigravity(&config) {
         shunt::auth::antigravity::version::spawn_refresher(reqwest::Client::new());
     }
+    let shutdown_timeout = std::time::Duration::from_secs(config.server.shutdown_timeout_seconds);
     let (router, shared, state) =
         server::build_router(config).context("failed to initialize gateway")?;
     // Reload triggers (SIGHUP and config-file watch) run as background tasks and
@@ -675,17 +676,28 @@ async fn serve(config: Config, path: Option<PathBuf>) -> anyhow::Result<()> {
     // ChatGPT/Codex OAuth usage APIs in the background, sharing the router's
     // account pool. A no-op when the key is unset.
     shunt::usage_poll::spawn_usage_poller(state);
-    axum::serve(
+    let (drain_started_tx, drain_started_rx) = tokio::sync::oneshot::channel();
+    let server = axum::serve(
         listener,
         router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
-    // Stops accepting new connections on the first shutdown trigger but lets
-    // in-flight ones (including open SSE streams) finish before this call
-    // returns, so `run` returns Ok and drops the sentry/telemetry guards
-    // normally (flushing buffered events on exit) rather than the process
-    // being hard-killed mid-request.
-    .with_graceful_shutdown(shutdown::shutdown_signal())
-    .await?;
+    // Stops accepting new connections on the first shutdown trigger and lets
+    // in-flight ones (including open SSE streams) finish until the configured
+    // deadline. The bounded drain drops the server future on timeout, then
+    // `run` returns normally so runtime teardown cancels remaining tasks and
+    // the sentry/telemetry guards get their ordinary drop path.
+    .with_graceful_shutdown(shutdown::shutdown_signal(drain_started_tx));
+    match shutdown::await_bounded_drain(server, drain_started_rx, shutdown_timeout).await? {
+        shutdown::DrainOutcome::Drained => {
+            tracing::info!("graceful shutdown drain completed");
+        }
+        shutdown::DrainOutcome::TimedOut => {
+            tracing::warn!(
+                timeout_seconds = shutdown_timeout.as_secs(),
+                "graceful shutdown deadline expired; cancelling remaining work"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -1593,5 +1605,66 @@ mod tests {
             .expect("serve returns before the test deadline")
             .expect("serve task join")
             .expect("graceful shutdown returns Ok once drained");
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_timed_out_cancels_work_and_returns() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::{oneshot, Notify};
+
+        let started = Arc::new(Notify::new());
+        let finish = Arc::new(Notify::new());
+        let app = axum::Router::new().route(
+            "/slow",
+            axum::routing::get({
+                let started = started.clone();
+                let finish = finish.clone();
+                move || {
+                    let started = started.clone();
+                    let finish = finish.clone();
+                    async move {
+                        started.notify_one();
+                        finish.notified().await;
+                        "done"
+                    }
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("read bound address");
+
+        let (drain_started_tx, drain_started_rx) = oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server = tokio::spawn(async move {
+            let s = axum::serve(listener, app).with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+                let _ = drain_started_tx.send(());
+            });
+            shutdown::await_bounded_drain(s, drain_started_rx, Duration::from_millis(50)).await
+        });
+
+        let _request = tokio::spawn(async move {
+            let _ = reqwest::Client::new()
+                .get(format!("http://{addr}/slow"))
+                .send()
+                .await;
+        });
+
+        started.notified().await;
+        shutdown_tx.send(()).unwrap();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("serve returns before test deadline")
+            .expect("serve task join")
+            .expect("bounded drain result");
+        assert_eq!(outcome, shutdown::DrainOutcome::TimedOut);
+
+        finish.notify_one();
     }
 }

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -66,7 +66,8 @@ impl RuntimeState {
 /// good config rather than going down or running open.
 ///
 /// Fields that cannot be hot-applied (`server.bind`,
-/// `server.max_concurrent_requests`, spend-limit route registration/state path,
+/// `server.max_concurrent_requests`, `server.shutdown_timeout_seconds`,
+/// spend-limit route registration/state path,
 /// `[sentry]`, `[otel]`, and enabling or disabling the optional `[server.*]` route
 /// trees) are compared against the live config and a `warn!` is logged when they
 /// change; the new values are accepted into the swapped config but only take
@@ -136,6 +137,13 @@ fn warn_on_restart_only_changes(previous: &Config, next: &Config) {
             previous = previous.server.max_concurrent_requests,
             next = next.server.max_concurrent_requests,
             "server.max_concurrent_requests changed but requires a restart to apply; the concurrency gate is fixed at boot"
+        );
+    }
+    if previous.server.shutdown_timeout_seconds != next.server.shutdown_timeout_seconds {
+        tracing::warn!(
+            previous = previous.server.shutdown_timeout_seconds,
+            next = next.server.shutdown_timeout_seconds,
+            "server.shutdown_timeout_seconds changed but requires a restart to apply; the shutdown coordinator is fixed at boot"
         );
     }
     if previous.server.access_control != next.server.access_control {
@@ -1164,5 +1172,24 @@ mod tests {
             reloaded,
             "file watcher should have hot-reloaded the changed config"
         );
+    }
+
+    #[test]
+    fn shutdown_timeout_change_warns_but_reload_still_succeeds() {
+        let dir = temp_dir("shutdown-timeout");
+        let _guard = TempDirGuard(dir.clone());
+        let path = dir.join("shunt.toml");
+
+        std::fs::write(&path, "[server]\nshutdown_timeout_seconds = 30\n").unwrap();
+        let shared = shared_from(Config::load(Some(&path)).unwrap());
+
+        std::fs::write(&path, "[server]\nshutdown_timeout_seconds = 45\n").unwrap();
+        let logs = capture_logs(|| {
+            reload(&shared, Some(&path)).expect("reload succeeds despite timeout change");
+        });
+
+        assert_eq!(shared.load().config.server.shutdown_timeout_seconds, 45);
+        assert!(logs.contains("server.shutdown_timeout_seconds changed"));
+        assert!(logs.contains("requires a restart"));
     }
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -5,17 +5,26 @@
 //! shutdown and the immediate-exit path terminate them explicitly. Extracted
 //! from `main.rs` to keep that file focused (see `src/AGENTS.md`).
 
-use std::future::Future;
+use std::{
+    future::{Future, IntoFuture},
+    time::Duration,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DrainOutcome {
+    Drained,
+    TimedOut,
+}
 
 /// Waits for SIGTERM or ctrl-c (SIGINT) and logs which one fired. Passed to
 /// `axum::serve(...).with_graceful_shutdown(...)` in `serve` (main.rs) so
 /// `brew services stop shunt` — which launchd stops with SIGTERM — drains
 /// in-flight requests instead of dropping them.
 ///
-/// The drain has no deadline (an open SSE stream holds the process for as long
-/// as its client keeps reading), so before returning this arms a watcher that
-/// turns a second signal into an immediate exit, preserving the operator's
-/// usual "press ctrl-c again" escape hatch. The [`SignalListener`]s are
+/// The caller begins its configured deadline when the notification channel is
+/// sent below. Before returning this also arms a watcher that turns a second
+/// signal into an immediate exit, preserving the operator's usual "press
+/// ctrl-c again" escape hatch. The [`SignalListener`]s are
 /// created once, here, and reused for both waits by moving them into the
 /// watcher: tokio delivers each signal through a process-wide channel with no
 /// queue, so a signal landing between the first wait's receiver being dropped
@@ -24,8 +33,33 @@ use std::future::Future;
 /// listener keeps the subscription continuously live and consumes signals
 /// sequentially, so this closes that gap without double-counting the signal
 /// that ends the first wait.
-pub(crate) async fn shutdown_signal() {
-    shutdown_signal_inner(None).await;
+pub(crate) async fn shutdown_signal(drain_started: tokio::sync::oneshot::Sender<()>) {
+    shutdown_signal_inner(None, Some(drain_started)).await;
+}
+
+/// Awaits a server normally until the first-signal notification, then gives
+/// its graceful drain one absolute budget. Returning `TimedOut` drops the
+/// still-pinned server future before the caller returns from `run`, after which
+/// Tokio runtime teardown cancels remaining connection and background tasks.
+pub(crate) async fn await_bounded_drain<F, E>(
+    server: F,
+    drain_started: tokio::sync::oneshot::Receiver<()>,
+    deadline: Duration,
+) -> Result<DrainOutcome, E>
+where
+    F: IntoFuture<Output = Result<(), E>>,
+{
+    let server = server.into_future();
+    tokio::pin!(server);
+    tokio::select! {
+        result = &mut server => return result.map(|()| DrainOutcome::Drained),
+        _ = drain_started => {}
+    }
+
+    match tokio::time::timeout(deadline, &mut server).await {
+        Ok(result) => result.map(|()| DrainOutcome::Drained),
+        Err(_) => Ok(DrainOutcome::TimedOut),
+    }
 }
 
 /// Does the actual work of [`shutdown_signal`], with an optional readiness
@@ -37,7 +71,10 @@ pub(crate) async fn shutdown_signal() {
 /// `yield_now()`), so it can't raise its signal before a listener exists to
 /// receive it. Named apart from [`shutdown_signal`] to avoid reading as the
 /// unrelated `run` in `main.rs`.
-async fn shutdown_signal_inner(ready: Option<tokio::sync::oneshot::Sender<()>>) {
+async fn shutdown_signal_inner(
+    ready: Option<tokio::sync::oneshot::Sender<()>>,
+    drain_started: Option<tokio::sync::oneshot::Sender<()>>,
+) {
     let mut sigterm = SignalListener::sigterm();
     let mut ctrl_c = SignalListener::ctrl_c();
     if let Some(ready) = ready {
@@ -54,6 +91,9 @@ async fn shutdown_signal_inner(ready: Option<tokio::sync::oneshot::Sender<()>>) 
         async move { select_shutdown_trigger(sigterm.recv(), ctrl_c.recv()).await },
         |signal| force_exit(signal),
     );
+    if let Some(drain_started) = drain_started {
+        let _ = drain_started.send(());
+    }
 }
 
 /// Runs `on_signal` on a detached task once `next_signal` resolves. Split out
@@ -193,6 +233,89 @@ impl SignalListener {
 mod tests {
     use super::*;
 
+    struct PendingUntilDropped(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+    impl Future for PendingUntilDropped {
+        type Output = Result<(), ()>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            std::task::Poll::Pending
+        }
+    }
+
+    impl Drop for PendingUntilDropped {
+        fn drop(&mut self) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_drain_completes_cleanly_after_notification() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (complete_tx, complete_rx) = tokio::sync::oneshot::channel();
+        let server = async move {
+            complete_rx.await.expect("completion sender remains live");
+            Ok::<(), ()>(())
+        };
+        started_tx.send(()).expect("drain receiver remains live");
+        complete_tx.send(()).expect("server receiver remains live");
+
+        assert_eq!(
+            await_bounded_drain(server, started_rx, Duration::from_secs(1)).await,
+            Ok(DrainOutcome::Drained)
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_drain_timeout_drops_pending_work_and_its_lease() {
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        started_tx.send(()).expect("drain receiver remains live");
+
+        assert_eq!(
+            await_bounded_drain(
+                PendingUntilDropped(dropped.clone()),
+                started_rx,
+                Duration::from_millis(10),
+            )
+            .await,
+            Ok(DrainOutcome::TimedOut)
+        );
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "timing out must drop the server future and its owned leases"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_deadline_does_not_start_before_notification() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(await_bounded_drain(
+            std::future::pending::<Result<(), ()>>(),
+            started_rx,
+            Duration::from_millis(10),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !waiter.is_finished(),
+            "deadline must not be an uptime limit"
+        );
+        started_tx.send(()).expect("drain receiver remains live");
+        assert_eq!(
+            waiter.await.expect("bounded drain task joins"),
+            Ok(DrainOutcome::TimedOut)
+        );
+    }
+
     #[tokio::test]
     async fn select_shutdown_trigger_reports_sigterm_when_it_fires_first() {
         let label = select_shutdown_trigger(async {}, std::future::pending()).await;
@@ -281,7 +404,7 @@ mod tests {
         use std::time::Duration;
 
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-        let waiter = tokio::spawn(shutdown_signal_inner(Some(ready_tx)));
+        let waiter = tokio::spawn(shutdown_signal_inner(Some(ready_tx), None));
         // Wait on the readiness channel `shutdown_signal_inner` sends on right after
         // registering both `SignalListener`s, rather than assuming a
         // `yield_now()` scheduler tick reaches that point first — a channel


### PR DESCRIPTION
## Summary
Adds `server.shutdown_timeout_seconds` (default: 30s, valid range 1..=3600) to bound the graceful shutdown drain when stopping shunt.

### Problem
Previously, `axum::serve.with_graceful_shutdown(...)` waited indefinitely for all in-flight connections (such as long-lived or quiet SSE streams) to finish before the process could terminate cleanly. If a client kept reading or a stream hung, the process remained alive indefinitely until a second signal forced an immediate exit (skipping clean drops and telemetry flushes).

### Solution
- Introduced `server.shutdown_timeout_seconds` configuration (default: 30s, valid range: 1..=3600), capturing the drain deadline at startup.
- Coordinated the shutdown signal via `await_bounded_drain`: after the first shutdown signal is received, listener admission stops and in-flight work drains until the configured deadline.
- If in-flight work does not complete before the deadline, the server future is dropped and `serve` returns normally so Tokio runtime cancellation and RAII drops/telemetry flushes still execute.
- A second signal continues to serve as the emergency immediate-exit escape hatch (143/130).
- Config hot-reload warns if `server.shutdown_timeout_seconds` is changed without a restart.
- Complete documentation added across `docs/` and localized site reference (`en`, `ja`, `ko`, `zh-cn`).

### Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin shunt shutdown::`
- `cargo test --bin shunt graceful_shutdown`
- `cargo test --lib config::tests::shutdown_timeout`
- `cargo test --lib reload::tests::shutdown_timeout`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the graceful shutdown drain with a new `server.shutdown_timeout_seconds` config (default 30, valid 1–3600). Previously Shunt waited indefinitely for in-flight connections (like open SSE streams) after the first signal; now the drain stops at the deadline, the server future is dropped, and `run` returns normally so telemetry/cleanup still run. Already-started blocking work gets a fixed 5-second grace after the deadline, then its threads are abandoned. A second signal forces immediate exit during the drain, but not during that final grace — the watcher is cancelled once teardown begins, so a signal in that window is discarded rather than falling through to the default disposition.

**Configuration**

- `shutdown_timeout_seconds` defaults to 30 and accepts 1–3600; values outside that range fail validation.
- Changing it via hot reload logs a warning that a restart is required; the new value only takes effect at next boot.

**Documentation**

- READMEs, site installation pages, and config references in all four languages state the bounded drain and the restart requirement, with `docs/bounded-shutdown.md` covering teardown details.

<sup>Written for commit c19aae5706bb6b8e4a2e18747ac040be1082de21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

