### PR TITLE
feat(antigravity): harden inference origin safety and route unary through checked SSE

### DIFF
--- a/src/adapters/gemini/mod.rs
+++ b/src/adapters/gemini/mod.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     config::AuthMode,
     model::antigravity_request::{
-        antigravity_model_needs_catalog, antigravity_request_id, antigravity_session_id,
-        antigravity_upstream_model_with, wrap_antigravity_envelope, AntigravityCatalog,
+        antigravity_model_needs_catalog, antigravity_request_id, antigravity_upstream_model_with,
+        wrap_antigravity_envelope, AntigravityCatalog,
     },
     model::gemini::{map_gemini_error, GeminiSseMachine},
     model::gemini_request::{translate_request_for_model, wrap_code_assist_envelope},
@@ -49,6 +49,14 @@ impl Adapter for GeminiAdapter {
 fn antigravity_endpoint(base_url: &str, method: &str) -> String {
     let base_url = inference_base_url(base_url);
     format!("{base_url}/v1internal:{method}")
+}
+
+fn gemini_method(auth: AuthMode, streaming: bool) -> &'static str {
+    if streaming || auth == AuthMode::AntigravityOauth {
+        "streamGenerateContent?alt=sse"
+    } else {
+        "generateContent"
+    }
 }
 
 /// Carry the effort tier a `-tiered` catalog id does not name into the request
@@ -118,6 +126,58 @@ fn append_sse_events(events: Vec<crate::model::gemini::SseEvent>, output: &mut V
     }
 }
 
+async fn collect_antigravity_sse(
+    response: reqwest::Response,
+    route_model: &str,
+) -> Result<GeminiSseMachine, AdapterError> {
+    let mut bytes = response.bytes_stream();
+    let mut machine = GeminiSseMachine::new(route_model);
+    let mut buffer = Vec::new();
+
+    while let Some(chunk) = bytes.next().await {
+        let chunk = chunk.map_err(|error| AdapterError {
+            message: format!("failed to read response body: {error}"),
+            response: Box::new(StatusCode::BAD_GATEWAY.into_response()),
+            failure: None,
+        })?;
+        buffer.extend_from_slice(&chunk);
+
+        while let Some(pos) = buffer.windows(2).position(|w| w == b"\n\n") {
+            let block: Vec<u8> = buffer.drain(..pos + 2).collect();
+            if let Ok(text) = std::str::from_utf8(&block) {
+                for line in text.lines() {
+                    if let Some(data) = line.strip_prefix("data: ") {
+                        let data = data.trim();
+                        if data == "[DONE]" {
+                            continue;
+                        }
+                        if let Ok(val) = serde_json::from_str::<Value>(data) {
+                            machine.process_chunk(&val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if !buffer.is_empty() {
+        if let Ok(text) = std::str::from_utf8(&buffer) {
+            for line in text.lines() {
+                if let Some(data) = line.strip_prefix("data: ") {
+                    let data = data.trim();
+                    if data != "[DONE]" {
+                        if let Ok(val) = serde_json::from_str::<Value>(data) {
+                            machine.process_chunk(&val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut events = Vec::new();
+    machine.finish(&mut events);
+    Ok(machine)
+}
+
 async fn forward(
     state: AppState,
     route: Route,
@@ -162,11 +222,7 @@ async fn forward(
 
     let base_url = provider.base_url.trim_end_matches('/');
 
-    let method = if is_streaming {
-        "streamGenerateContent?alt=sse"
-    } else {
-        "generateContent"
-    };
+    let method = gemini_method(provider.auth, is_streaming);
     // Both subscription paths speak the Code Assist protocol: the same
     // `v1internal` methods under the `{model,project,request}` envelope. Only
     // the credential and the client identity differ, so the envelope is gated
@@ -227,7 +283,10 @@ async fn forward(
         if let Some(level) = model.thinking_level {
             set_thinking_level(&mut inner_req, level);
         }
-        let session_id = antigravity_session_id(&inner_req);
+        let session_id = crate::model::antigravity_request::antigravity_scoped_session_id(
+            &project_id,
+            &inner_req,
+        );
         let envelope = wrap_antigravity_envelope(
             &model.id,
             &project_id,
@@ -247,7 +306,17 @@ async fn forward(
     };
 
     let policy = provider.retry.policy();
-    let http_client = state.http_client.clone();
+    let http_client = if provider.auth == AuthMode::AntigravityOauth {
+        crate::auth::shared::antigravity_inference_client(&inference_base_url(base_url)).map_err(
+            |error| AdapterError {
+                message: error.to_string(),
+                response: Box::new(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+                failure: None,
+            },
+        )?
+    } else {
+        state.http_client.clone()
+    };
     let payload_clone = payload.clone();
     let endpoint_clone = endpoint.clone();
     let is_google_oauth = is_code_assist;
@@ -374,6 +443,15 @@ async fn forward(
             })?;
 
         Ok((StatusCode::OK, response_res))
+    } else if provider.auth == AuthMode::AntigravityOauth {
+        let machine = collect_antigravity_sse(response, &route.model).await?;
+        let final_json = machine.final_json();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+
+        let response_res = (StatusCode::OK, headers, axum::Json(final_json)).into_response();
+        Ok((StatusCode::OK, response_res))
     } else {
         let full_text = response.text().await.map_err(|error| AdapterError {
             message: format!("failed to read response body: {error}"),
@@ -401,6 +479,19 @@ async fn forward(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn antigravity_native_sse_uses_always_sse_for_both_downstream_modes() {
+        assert_eq!(
+            gemini_method(AuthMode::AntigravityOauth, true),
+            "streamGenerateContent?alt=sse"
+        );
+        assert_eq!(
+            gemini_method(AuthMode::AntigravityOauth, false),
+            "streamGenerateContent?alt=sse"
+        );
+        assert_eq!(gemini_method(AuthMode::ApiKey, false), "generateContent");
+    }
 
     #[test]
     fn a_production_pinned_antigravity_base_url_sends_inference_to_the_daily_host() {

--- a/src/auth/antigravity/auth.rs
+++ b/src/auth/antigravity/auth.rs
@@ -1179,6 +1179,52 @@ pub fn inference_base_url(base_url: &str) -> String {
     base_url.trim_end_matches('/').to_string()
 }
 
+/// Admit only the exact Antigravity inference endpoint for this request.
+///
+/// Production requests must use one of the two exact HTTPS Code Assist hosts,
+/// with no explicit port. Hermetic tests may supply a loopback proxy, but only
+/// its exact origin is admitted; a loopback override never broadens production
+/// host admission. The full URL is checked (not merely its origin) so a
+/// redirect cannot move credentials to another path, query, or fragment.
+pub(crate) fn is_safe_inference_url(url: &reqwest::Url, configured_base: &str) -> bool {
+    let Ok(configured) = reqwest::Url::parse(configured_base) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let configured_host = configured.host_str().unwrap_or_default();
+    let configured_shape = configured.path() == "/"
+        && configured.query().is_none()
+        && configured.fragment().is_none()
+        && configured.username().is_empty()
+        && configured.password().is_none();
+    let exact_origin = url.scheme() == configured.scheme()
+        && url.host_str() == Some(configured_host)
+        && url.port() == configured.port();
+    let canonical_host = crate::config::host_is_google_codeassist(host)
+        || crate::config::host_is_antigravity_daily(host);
+    let configured_explicit_default_port = configured_base
+        .split_once("://")
+        .and_then(|(_, rest)| rest.split('/').next())
+        .is_some_and(|authority| authority.ends_with(":443"));
+    let production_origin = canonical_host
+        && url.scheme() == "https"
+        && url.port().is_none()
+        // `Url::port()` normalizes an explicit default port to `None`; retain
+        // the fail-closed distinction from the configured spelling.
+        && !configured_explicit_default_port;
+    let loopback_origin = crate::config::host_is_loopback(configured_host)
+        && exact_origin
+        && (url.scheme() == "https" || url.scheme() == "http");
+    if !configured_shape || !(production_origin || loopback_origin) || !exact_origin {
+        return false;
+    }
+    url.path() == "/v1internal:streamGenerateContent"
+        && url.query() == Some("alt=sse")
+        && url.fragment().is_none()
+}
+
 /// Whether `endpoint` addresses the default Antigravity backend itself — the
 /// `daily-` control plane both [`DEFAULT_API_ENDPOINT`] and the seeded
 /// `antigravity` provider name.
@@ -1292,6 +1338,55 @@ mod tests {
             .unwrap()
             .as_millis()
             .saturating_sub(u128::from(secs).saturating_mul(1_000)) as u64
+    }
+
+    #[test]
+    fn antigravity_native_origin_accepts_only_exact_canonical_or_loopback_targets() {
+        let cases = [
+            ("https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse", DAILY_API_ENDPOINT, true),
+            ("https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse", API_ENDPOINT, true),
+            ("http://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse", DAILY_API_ENDPOINT, false),
+            ("https://daily-cloudcode-pa.googleapis.com.evil.test/v1internal:streamGenerateContent?alt=sse", DAILY_API_ENDPOINT, false),
+            ("https://daily-cloudcode-pa.googleapis.com:443/v1internal:streamGenerateContent?alt=sse", "https://daily-cloudcode-pa.googleapis.com:443", false),
+            ("https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse&x=1", DAILY_API_ENDPOINT, false),
+            ("https://daily-cloudcode-pa.googleapis.com/v1internal:generateContent?alt=sse", DAILY_API_ENDPOINT, false),
+            ("http://127.0.0.1:43123/v1internal:streamGenerateContent?alt=sse", "http://127.0.0.1:43123", true),
+            ("http://127.0.0.1:43124/v1internal:streamGenerateContent?alt=sse", "http://127.0.0.1:43123", false),
+        ];
+        for (raw, configured, expected) in cases {
+            let url = reqwest::Url::parse(raw).unwrap();
+            assert_eq!(is_safe_inference_url(&url, configured), expected, "{raw}");
+        }
+    }
+
+    #[tokio::test]
+    async fn antigravity_native_origin_rejects_off_origin_redirect_before_bearer() {
+        use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+        let source = MockServer::start().await;
+        let target = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(302).insert_header(
+                "location",
+                format!("{}/v1internal:streamGenerateContent?alt=sse", target.uri()),
+            ))
+            .mount(&source)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&target)
+            .await;
+
+        let client = crate::auth::shared::antigravity_inference_client(&source.uri()).unwrap();
+        let endpoint = format!("{}/v1internal:streamGenerateContent?alt=sse", source.uri());
+        let error = client
+            .post(endpoint)
+            .bearer_auth("synthetic-antigravity-token")
+            .send()
+            .await
+            .expect_err("off-origin redirect must be refused");
+        assert!(error.to_string().contains("redirect"));
+        assert!(target.received_requests().await.unwrap().is_empty());
     }
 
     fn write(path: &Path, stored: &StoredAuth) {

--- a/src/auth/shared.rs
+++ b/src/auth/shared.rs
@@ -190,6 +190,36 @@ pub(crate) fn token_refresh_client() -> reqwest::Client {
         .clone()
 }
 
+/// Build the credential-bearing Antigravity client for one configured target.
+/// Reqwest invokes this policy before following every redirect; validating the
+/// complete target URL prevents a bearer from crossing an origin or endpoint
+/// boundary, including redirects that remain on a lookalike host.
+pub(crate) fn antigravity_inference_client(
+    configured_base: &str,
+) -> anyhow::Result<reqwest::Client> {
+    let configured_base = configured_base.to_string();
+    let initial = configured_base.parse::<reqwest::Url>()?;
+    if !crate::auth::antigravity::auth::is_safe_inference_url(
+        &initial.join("/v1internal:streamGenerateContent?alt=sse")?,
+        &configured_base,
+    ) {
+        anyhow::bail!("unsafe Antigravity inference origin")
+    }
+    Ok(reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            let safe = crate::auth::antigravity::auth::is_safe_inference_url(
+                attempt.url(),
+                &configured_base,
+            );
+            if attempt.previous().len() >= 10 || !safe {
+                attempt.error("unsafe or excessive Antigravity inference redirect refused")
+            } else {
+                attempt.follow()
+            }
+        }))
+        .build()?)
+}
+
 pub(crate) fn write_auth_file_atomic(path: &Path, value: &Value) -> io::Result<()> {
     let bytes = serde_json::to_vec_pretty(value)?;
     // Deliberately the no-mkdir entry point: a missing credential directory

--- a/src/model/antigravity_request.rs
+++ b/src/model/antigravity_request.rs
@@ -9,6 +9,7 @@
 use std::collections::BTreeSet;
 
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 /// Client identity the Antigravity client sends on every request.
 const ANTIGRAVITY_USER_AGENT: &str = "antigravity";
@@ -104,6 +105,22 @@ pub fn antigravity_session_id(request: &Value) -> String {
         None => rand::random::<u64>() % SESSION_ID_MODULUS,
     };
     format!("-{digits}")
+}
+
+/// Opaque account/conversation-scoped session identity for native requests.
+/// The bounded conversation seed is combined with the private account tuple,
+/// so identical prompts in different accounts cannot collide.
+pub fn antigravity_scoped_session_id(account: &str, request: &Value) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"shunt.antigravity.session/v1\0");
+    hasher.update(account.as_bytes());
+    hasher.update([0]);
+    let conversation = serde_json::to_vec(request).unwrap_or_default();
+    hasher.update(&conversation[..conversation.len().min(SESSION_SEED_LIMIT)]);
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    format!("-{}", u64::from_be_bytes(bytes) % SESSION_ID_MODULUS)
 }
 
 /// FNV-1a, spelled out rather than reached for through `DefaultHasher`: this
@@ -1367,5 +1384,21 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn antigravity_native_envelope_session_is_account_scoped_and_opaque() {
+        let request = json!({"contents":[{"role":"user","parts":[{"text":"secret prompt"}]}]});
+        let first = antigravity_scoped_session_id("email-v1:account-a", &request);
+        assert_eq!(
+            first,
+            antigravity_scoped_session_id("email-v1:account-a", &request)
+        );
+        assert_ne!(
+            first,
+            antigravity_scoped_session_id("email-v1:account-b", &request)
+        );
+        assert!(!first.contains("secret"));
+        assert!(antigravity_request_id().starts_with("agent-"));
     }
 }

--- a/tests/antigravity_catalog.rs
+++ b/tests/antigravity_catalog.rs
@@ -78,15 +78,10 @@ async fn a_tiered_only_catalog_decides_the_model_id_and_the_thinking_level() {
         .mount(&backend)
         .await;
     Mock::given(method("POST"))
-        .and(path("/v1internal:generateContent"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "response": {
-                "candidates": [{
-                    "content": {"parts": [{"text": "OK"}]},
-                    "finishReason": "STOP"
-                }]
-            }
-        })))
+        .and(path("/v1internal:streamGenerateContent"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"OK\"}]},\"finishReason\":\"STOP\"}]}}\n\ndata: [DONE]\n\n",
+        ))
         .mount(&backend)
         .await;
 
@@ -158,7 +153,7 @@ async fn a_tiered_only_catalog_decides_the_model_id_and_the_thinking_level() {
         .await
         .unwrap()
         .into_iter()
-        .find(|request| request.url.path() == "/v1internal:generateContent")
+        .find(|request| request.url.path() == "/v1internal:streamGenerateContent")
         .expect("the gateway must have reached the inference endpoint");
     let body: Value = serde_json::from_slice(&inference.body).unwrap();
 


### PR DESCRIPTION
## Summary
Hardens the Antigravity adapter's network origin validation, prevents bearer token leakage across redirects, and routes Antigravity unary requests through checked SSE streaming.

### Problem
1. The Antigravity adapter previously allowed redirects to follow HTTP defaults, creating a risk of bearer credentials crossing origin boundaries or following lookalike hosts.
2. Production requests were not strictly constrained to canonical Google Code Assist/Antigravity origins and endpoints.
3. Antigravity backend natively serves streaming SSE (`/v1internal:streamGenerateContent?alt=sse`); calling `/v1internal:generateContent` for unary requests risks unexpected upstream differences or errors.
4. Session identities were derived from prompt text alone without private account scoping, risking collisions across accounts.

### Solution
- Added `is_safe_inference_url` to restrict inference calls strictly to canonical HTTPS origins (`cloudcode-pa.googleapis.com` / `daily-cloudcode-pa.googleapis.com` with standard ports) and loopback testing proxies on path `/v1internal:streamGenerateContent?alt=sse`.
- Created `antigravity_inference_client` with a strict redirect policy that refuses off-origin or excessive redirects.
- Added `antigravity_scoped_session_id` using SHA-256 to hash conversation text alongside account credentials, preventing cross-account session collisions.
- Routed both streaming and unary Antigravity calls through `streamGenerateContent?alt=sse` via `gemini_method`, collecting and reassembling SSE events into full responses for unary callers via `collect_antigravity_sse`.
- Updated unit tests and integration tests in `tests/antigravity_catalog.rs`.

### Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test antigravity_catalog`
- `cargo test --lib auth::antigravity::`
- `cargo test --lib model::antigravity_request::`
- `cargo test --lib adapters::gemini::`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Antigravity inference origin validation so bearer tokens can't leak across redirects or lookalike hosts, and makes unary calls use the same checked SSE path as streaming.

**Origin safety**
- Inference calls are restricted to the canonical HTTPS Code Assist hosts or the exact loopback testing origin, at `/v1internal:streamGenerateContent?alt=sse`.
- `antigravity_inference_client` refuses off-origin or excessive redirects before attaching bearer credentials.

**Behavior**
- Unary Antigravity responses are reassembled from SSE events instead of calling the unstreamed `generateContent` endpoint.
- Session IDs are SHA-256 hashes of conversation text plus account credentials, so identical prompts in different accounts no longer collide.

<sup>Written for commit 11ae38d8d15d1c1f9ab8c460a8310b11c1890004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

