### PR TITLE
fix(review): drop the cubic default flags that produced a false clean review

### DIFF
--- a/.please/config.yml
+++ b/.please/config.yml
@@ -46,9 +46,9 @@ review:
     # scope from the working tree — uncommitted changes when it is dirty, the
     # base branch when it is clean. A configured value overrides that choice
     # for every invocation, and the previous `"--json -b"` did so with a bare
-    # `-b`, which takes a string: it swallowed the following token, cubic
-    # failed internally to produce a diff, and it still exited 0 with an empty
-    # issue list — a false clean review (#514).
+    # `-b`. It takes a string and sat last on the command line, so it got no
+    # value at all: cubic failed internally to produce a diff and still exited
+    # 0 with an empty issue list — a false clean review (#514).
   agy:
     enabled: false
   coderabbit:

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -42,13 +42,22 @@ docs:
 review:
   cubic:
     enabled: true
-    # No default-flags: the reviewer agent already passes `-j` and picks the
-    # scope from the working tree — uncommitted changes when it is dirty, the
-    # base branch when it is clean. A configured value overrides that choice
-    # for every invocation, and the previous `"--json -b"` did so with a bare
-    # `-b`. It takes a string and sat last on the command line, so it got no
-    # value at all: cubic failed internally to produce a diff and still exited
-    # 0 with an empty issue list — a false clean review (#514).
+    # No default-flags: the reviewer agent already passes `-j` and chooses the
+    # scope itself — uncommitted changes when the working tree is dirty, an
+    # attempted base-branch review when it is clean. A configured value
+    # overrides that choice for every invocation, and the previous
+    # `"--json -b"` did so with a bare `-b`. It takes a string and sat last on
+    # the command line, so it got no value at all: cubic failed internally to
+    # produce a diff and still exited 0 with an empty issue list — a false
+    # clean review (#514).
+    #
+    # Removing the key restores the agent's own choice, which repairs the
+    # dirty-tree path. The clean-tree path stays broken for the same reason:
+    # there the agent issues `cubic review -b -j`, `-b` again with no base ref
+    # of its own, so a local review of a clean worktree can still come back
+    # falsely clean. That command is the review plugin's, not this repository's,
+    # and no setting in this file reaches it; #514 carries the upstream
+    # follow-up.
   agy:
     enabled: false
   coderabbit:

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -42,7 +42,13 @@ docs:
 review:
   cubic:
     enabled: true
-    default-flags: "--json -b"
+    # No default-flags: the reviewer agent already passes `-j` and picks the
+    # scope from the working tree — uncommitted changes when it is dirty, the
+    # base branch when it is clean. A configured value overrides that choice
+    # for every invocation, and the previous `"--json -b"` did so with a bare
+    # `-b`, which takes a string: it swallowed the following token, cubic
+    # failed internally to produce a diff, and it still exited 0 with an empty
+    # issue list — a false clean review (#514).
   agy:
     enabled: false
   coderabbit:


### PR DESCRIPTION
Closes #514.

## The defect

`.please/config.yml` pinned `default-flags: "--json -b"` for every local cubic invocation.
`-b, --base` is declared `[string]` in `cubic review --help`. The reviewer agent builds
`cubic review -j <configured words>`, so the configured value put `-b` **last on the command
line, with no value after it**. cubic then fails internally to produce a diff — but still
exits `0` with an empty `issues` array:

```console
$ cubic review --json -b
exit: 0
{ "issues": [] }
```

To every caller that is indistinguishable from a review that ran and genuinely found
nothing. The misconfiguration did not surface as a broken reviewer; it surfaced as a
**clean review**.

## Why remove the key rather than repair it

The reviewer agent already does better without one. Its execution rules:

| Context | Command |
| --- | --- |
| default flags configured | `cubic review -j <configured words>` |
| no flags + uncommitted changes | `cubic review -j` |
| no flags + clean working tree | `cubic review -b -j` |

So it passes `-j` itself — making the configured `--json` redundant — and it selects the
scope from the working tree. A configured value overrides that adaptive choice on **every**
run, including `/review:apply-review` Step 5, which runs before the fix commit and wants
exactly the uncommitted-changes scope. Removing the key restores both behaviors.

## Verification

`setup-env.sh --print`, the only consumer of this key:

```console
# before (origin/main)
export REVIEW_CUBIC_ENABLED='true'
export REVIEW_CUBIC_DEFAULT_FLAGS='--json -b'

# after (this branch)
export REVIEW_CUBIC_ENABLED='true'
```

`enabled: true` is preserved; only the flag export is gone.

## Scope

Only the locally-invoked CLI path was affected. The cubic **GitHub app** reviews pushed
commits normally and was never impacted — it posted real findings throughout #508, #526,
and #528.

## Not fixed here — upstream, `passionfactory/review`

Two related hazards live in the review plugin, not in this repository, so this PR does not
touch them:

1. The agent's own clean-tree fallback is `cubic review -b -j` — the same bare `-b`, which
   here swallows `-j`.
2. The wrapper treats an empty result as a clean pass regardless of cubic's internal status,
   which is what let this misconfiguration stay invisible. #514 raised this as "worth
   checking alongside".

## Docs

No doc surface describes this key. The root READMEs mention cubic only as a listed review
service, and `.please/config.yml` is workspace tooling rather than a shunt config key,
endpoint, CLI, or provider surface. The rationale is recorded as an inline comment at the
removal site instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `cubic` `default-flags` from `.please/config.yml`, which previously forced `--json -b` on every local run. `-b` takes a string and was left without a value, so cubic failed internally to produce a diff but still exited `0` with an empty issues array — a misconfigured reviewer looked like a clean review. Now the agent passes `-j` itself and selects scope from the working tree, so dirty-tree reviews reflect actual changes. Closes #514.

**Scope**
- The fix repairs only the dirty-tree path; the clean-tree fallback `cubic review -b -j` lives in the review plugin upstream, where bare `-b` can still yield a false clean review, and no key in this file reaches it.
- Only the local CLI path is affected; the cubic GitHub app is untouched.

<sup>Written for commit 755af4179d5ef0552dbd5201669b9c289095a809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

